### PR TITLE
Remove -run in the Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ node {
     stage('Run Module Test') {
             def dockerImage = docker.image('tfp-automation')
             dockerImage.inside() {
-                sh "go test -v -timeout ${timeout} -run ${params.TEST_CASE} ${testsDir}"
+                sh "go test -v -timeout ${timeout} ${params.TEST_CASE} ${testsDir}"
             }
     }
 }


### PR DESCRIPTION
### PR Description
In the Jenkins job, there's some confusion with how `run` is defined in the test case description. On further inspection, we're incorrectly specifying `run` in the Jenkinsfile. This small PR removes that to be on 1:1 with the Jenkinsfile in the Go framework.