### PR TITLE
enhance tfp-automation to allow testing against rancher2 RCs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,10 @@ SHELL ["/bin/bash", "-c"]
 RUN go mod download && \
     go install gotest.tools/gotestsum@latest
 
-ARG TERRAFORM_VERSION=1.6.5
+ARG TERRAFORM_VERSION
 ARG EXTERNAL_ENCODED_VPN
 ARG VPN_ENCODED_LOGIN
+ARG RANCHER2_PROVIDER_VERSION
 
 RUN wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && apt-get update && apt-get install unzip &&  unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip && rm terraform_${TERRAFORM_VERSION}_linux_amd64.zip && chmod u+x terraform && mv terraform /usr/bin/terraform
 
@@ -28,3 +29,8 @@ RUN if [[ -z '$EXTERNAL_ENCODED_VPN' ]] ; then \
     else \
       apt-get update && apt-get -y install sudo openvpn net-tools ; \
     fi;
+
+RUN if [[ "$RANCHER2_PROVIDER_VERSION" == *"-rc"* ]]; then \
+      chmod +x ./scripts/setup-provider.sh && ./scripts/setup-provider.sh rancher2 v${RANCHER2_PROVIDER_VERSION} ; \
+    fi;
+

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,6 +13,14 @@ node {
   if ("${env.TIMEOUT}" != "null" && "${env.TIMEOUT}" != "") {
         timeout = "${env.TIMEOUT}" 
   }
+  def terraformVersion = "${env.TERRAFORM_VERSION}"
+  if ("${env.TERRAFORM_VERSION}" != "null" && "${env.TERRAFORM_VERSION}" != "") {
+        terraformVersion = "${env.TERRAFORM_VERSION}" 
+  }
+  def rancher2ProviderVersion = "${env.RANCHER2_PROVIDER_VERSION}"
+  if ("${env.RANCHER2_PROVIDER_VERSION}" != "null" && "${env.RANCHER2_PROVIDER_VERSION}" != "") {
+        rancher2ProviderVersion = "${env.RANCHER2_PROVIDER_VERSION}" 
+  }
   stage('Checkout') {
           deleteDir()
           checkout([
@@ -25,12 +33,12 @@ node {
     stage('Build Docker image') {
             writeFile file: 'config.yml', text: env.CONFIG
             env.CATTLE_TEST_CONFIG='/home/jenkins/workspace/rancher_qa/tfp-automation/config.yml'
-            sh 'docker build --build-arg CONFIG_FILE=config.yml -f Dockerfile -t tfp-automation . '
+            sh "docker build --build-arg CONFIG_FILE=config.yml --build-arg TERRAFORM_VERSION=${terraformVersion} --build-arg RANCHER2_PROVIDER_VERSION=${rancher2ProviderVersion} -f Dockerfile -t tfp-automation . "
     }
     
     stage('Run Module Test') {
             def dockerImage = docker.image('tfp-automation')
-            dockerImage.inside() {
+            dockerImage.inside("-u root") {
                 sh "go test -v -timeout ${timeout} ${params.TEST_CASE} ${testsDir}"
             }
     }

--- a/Jenkinsfile_vpn
+++ b/Jenkinsfile_vpn
@@ -13,6 +13,14 @@ node {
   if ("${env.TIMEOUT}" != "null" && "${env.TIMEOUT}" != "") {
         timeout = "${env.TIMEOUT}" 
   }
+  def terraformVersion = "${env.TERRAFORM_VERSION}"
+  if ("${env.TERRAFORM_VERSION}" != "null" && "${env.TERRAFORM_VERSION}" != "") {
+        terraformVersion = "${env.TERRAFORM_VERSION}" 
+  }
+  def rancher2ProviderVersion = "${env.RANCHER2_PROVIDER_VERSION}"
+  if ("${env.RANCHER2_PROVIDER_VERSION}" != "null" && "${env.RANCHER2_PROVIDER_VERSION}" != "") {
+        rancher2ProviderVersion = "${env.RANCHER2_PROVIDER_VERSION}" 
+  }
   withCredentials([ string(credentialsId: 'EXTERNAL_ENCODED_VPN', variable: 'EXTERNAL_ENCODED_VPN'),
                       string(credentialsId: 'VPN_ENCODED_LOGIN', variable: 'VPN_ENCODED_LOGIN')]) {
   stage('Checkout') {
@@ -30,7 +38,7 @@ node {
             sh "echo ${env.EXTERNAL_ENCODED_VPN} | base64 -d > external.ovpn"
             sh "echo ${env.VPN_ENCODED_LOGIN} | base64 -d > passfile"
             sh "sed -i 's/auth-user-pass/auth-user-pass passfile/g' external.ovpn"
-            sh "docker build --build-arg CONFIG_FILE=config.yml --build-arg EXTERNAL_ENCODED_VPN=external.ovpn --build-arg VPN_ENCODED_LOGIN=passfile -f Dockerfile -t tfp-automation . "   
+            sh "docker build --build-arg CONFIG_FILE=config.yml --build-arg TERRAFORM_VERSION=${terraformVersion} --build-arg RANCHER2_PROVIDER_VERSION=${rancher2ProviderVersion} --build-arg EXTERNAL_ENCODED_VPN=external.ovpn --build-arg VPN_ENCODED_LOGIN=passfile -f Dockerfile -t tfp-automation . "   
     }
     def runArgs = ""
     if (env.EXTERNAL_ENCODED_VPN) {

--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@
 
 ### <p align="center"> Configurations </p>
 
+###### The Rancher2 provider version is determined via the `RANCHER2_PROVIDER_VERSION` environment variable.
+
+##### When testing locally, it is required to set the `RANCHER2_PROVIDER_VERSION`, as type `string`, and formatted without a leading `v`.
+
+##### Example: `export RANCHER2_PROVIDER_VERSION="3.2.0"` or `export RANCHER2_PROVIDER_VERSION="4.0.0-rc6"`
+
 ##### These tests require an accurately configured `cattle-config.yaml` to successfully run.
 
 ##### Each `cattle-config.yaml` must include the following configurations:
@@ -127,12 +133,6 @@ The `terraform` configurations in the `cattle-config.yaml` are module specific. 
       <th>Description</th>
       <th>Type</th>
       <th>Example</th>
-    </tr>
-    <tr>
-      <td>providerVersion</td>
-      <td>rancher2 provider version</td>
-      <td>string</td>
-      <td>'3.2.0'</td>
     </tr>
     <tr>
       <td>module</td>

--- a/config/config.go
+++ b/config/config.go
@@ -143,7 +143,6 @@ type TerraformConfig struct {
 	Module                              string                      `json:"module,omitempty" yaml:"module,omitempty"`
 	NetworkPlugin                       string                      `json:"networkPlugin,omitempty" yaml:"networkPlugin,omitempty"`
 	NodeTemplateName                    string                      `json:"nodeTemplateName,omitempty" yaml:"nodeTemplateName,omitempty"`
-	ProviderVersion                     string                      `json:"providerVersion,omitempty" yaml:"providerVersion,omitempty"`
 }
 
 type Scaling struct {

--- a/framework/set/provisioning/setProvidersTF.go
+++ b/framework/set/provisioning/setProvidersTF.go
@@ -1,6 +1,9 @@
 package provisioning
 
 import (
+	"os"
+	"strings"
+
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/tfp-automation/config"
@@ -9,6 +12,13 @@ import (
 
 // setProvidersTF is a helper function that will set the general Terraform configurations in the main.tf file.
 func setProvidersTF(rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig) (*hclwrite.File, *hclwrite.Body) {
+	providerVersion := os.Getenv("RANCHER2_PROVIDER_VERSION")
+	
+	source := "rancher/rancher2"
+	if strings.Contains(providerVersion, "-rc") {
+		source = "terraform.local/local/rancher2"
+	}
+	
 	newFile := hclwrite.NewEmptyFile()
 	rootBody := newFile.Body()
 
@@ -19,8 +29,8 @@ func setProvidersTF(rancherConfig *rancher.Config, terraformConfig *config.Terra
 	reqProvsBlockBody := reqProvsBlock.Body()
 
 	reqProvsBlockBody.SetAttributeValue("rancher2", cty.ObjectVal(map[string]cty.Value{
-		"source":  cty.StringVal("rancher/rancher2"),
-		"version": cty.StringVal(terraformConfig.ProviderVersion),
+		"source":  cty.StringVal(source),
+		"version": cty.StringVal(providerVersion),
 	}))
 
 	rootBody.AppendNewline()

--- a/scripts/setup-provider.sh
+++ b/scripts/setup-provider.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# QA has a new process to test Terraform using RCs. We will not publish RCs
+# onto the Terraform registry because Hashicorp could potentially block our
+# testing by being slow to publish.
+
+# Instead, we will test using a downloaded binary from the RC. This script
+# sets up the correct binary using a defined <provider> <version> to test
+# updates locally.
+
+# ./setup-provider.sh <provider> <version>
+
+# Example
+# ./setup-provider.sh rancher2 v3.0.0-rc1
+
+set -e 
+
+# Validate user input
+
+if [ $# -ne 2 ]; then
+  echo "Usage: $0 <provider> <version>"
+  exit 1
+fi
+
+# Set global vars
+
+PROVIDER=$1
+VERSION=$2
+VERSION_TAG=$(echo $2 | cut -c 2-)
+
+# Download binary
+DIR=~/.terraform.d/plugins/terraform.local/local/${PROVIDER}/${VERSION_TAG}/linux_amd64
+(umask u=rwx,g=rwx,o=rwx && mkdir -p $DIR)
+curl -sfL https://github.com/rancher/terraform-provider-${PROVIDER}/releases/download/${VERSION}/terraform-provider-${PROVIDER}_${VERSION_TAG}_linux_amd64.zip | gunzip -c - > ${DIR}/terraform-provider-${PROVIDER}
+
+# Mod binary
+chmod +x ${DIR}/terraform-provider-${PROVIDER}
+
+echo -e "Terraform provider ${PROVIDER} ${VERSION} is ready to test!
+Please update the required_providers block in your Terraform config file
+
+terraform {
+  required_providers {
+    rancher2 = {
+      source = "terraform.local/local/${PROVIDER}"
+      version = "${VERSION_TAG}"
+    }
+  }
+}"

--- a/tests/extensions/provisioning/buildModule.go
+++ b/tests/extensions/provisioning/buildModule.go
@@ -2,6 +2,7 @@ package provisioning
 
 import (
 	"os"
+	"testing"
 
 	ranchFrame "github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/tfp-automation/config"
@@ -15,7 +16,7 @@ const (
 )
 
 // BuildModule is a function that builds the Terraform module.
-func BuildModule() error {
+func BuildModule(t *testing.T) error {
 	clusterConfig := new(config.TerratestConfig)
 	ranchFrame.LoadConfig(terratest, clusterConfig)
 
@@ -32,7 +33,7 @@ func BuildModule() error {
 		return err
 	}
 
-	logrus.Infof(string(module))
+	t.Log(string(module))
 
 	return nil
 }

--- a/tests/resources/build_module_test.go
+++ b/tests/resources/build_module_test.go
@@ -16,7 +16,7 @@ type BuildModuleTestSuite struct {
 func (r *BuildModuleTestSuite) TestBuildModule() {
 	defer cleanup.CleanupConfigTF()
 
-	err := provisioning.BuildModule()
+	err := provisioning.BuildModule(r.T())
 	require.NoError(r.T(), err)
 }
 


### PR DESCRIPTION
This PR:
- enhances tfp-automation repo to be able to test via Rancher2 RCs
- fixes poor formatting w/ `BuildModule` test output, caused by logrus
- pulls `providerVersion` out of Terraform config, which is replaced with `RANCHER2_PROVIDER_VERSION` env variable
- enhances repo to allow configurable terraform version -- utilizing `TERRAFORM_VERSION` env variable
- updates `readme.md`, pertaining to `providerVersion` field being pulled out, and new env variable `RANCHER2_PROVIDER_VERSION`