### PR TITLE
Restructure `snapshot` package to match `rancher/rancher` snapshot package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20
+FROM golang:1.21
 
 RUN mkdir -p /.cache && chmod -R 777 /.cache
 RUN mkdir -p $GOPATH/pkg/mod && chmod -R 777 $GOPATH/pkg/mod
@@ -33,4 +33,3 @@ RUN if [[ -z '$EXTERNAL_ENCODED_VPN' ]] ; then \
 RUN if [[ "$RANCHER2_PROVIDER_VERSION" == *"-rc"* ]]; then \
       chmod +x ./scripts/setup-provider.sh && ./scripts/setup-provider.sh rancher2 v${RANCHER2_PROVIDER_VERSION} ; \
     fi;
-

--- a/README.md
+++ b/README.md
@@ -1893,6 +1893,10 @@ Note: In this test suite, Terraform explicitly cleans up resources after each te
 ```yaml
 # this example is valid for RKE1 scale
 terratest:
+  kubernetesVersion: v1.27.8-rancher2-1
+  nodeCount: 3
+  scaledUpNodeCount: 8
+  scaledDownNodeCount: 6
   nodepools:
     - quantity: 1
       etcd: true
@@ -1906,36 +1910,33 @@ terratest:
       etcd: false
       controlplane: false
       worker: true
-  scaledUpNodepools:
-    - quantity: 3
-      etcd: true
-      controlplane: false
-      worker: false
-    - quantity: 2
-      etcd: false
-      controlplane: true
-      worker: false
-    - quantity: 3
-      etcd: false
-      controlplane: false
-      worker: true
-  scaledDownNodepools:
-    - quantity: 3
-      etcd: true
-      controlplane: false
-      worker: false
-    - quantity: 2
-      etcd: false
-      controlplane: true
-      worker: false
-    - quantity: 1
-      etcd: false
-      controlplane: false
-      worker: true
-  kubernetesVersion: v1.27.8-rancher2-1
-  nodeCount: 3
-  scaledUpNodeCount: 8
-  scaledDownNodeCount: 6
+  scalingInput:
+    scaledUpNodepools:
+      - quantity: 3
+        etcd: true
+        controlplane: false
+        worker: false
+      - quantity: 2
+        etcd: false
+        controlplane: true
+        worker: false
+      - quantity: 3
+        etcd: false
+        controlplane: false
+        worker: true
+    scaledDownNodepools:
+      - quantity: 3
+        etcd: true
+        controlplane: false
+        worker: false
+      - quantity: 2
+        etcd: false
+        controlplane: true
+        worker: false
+      - quantity: 1
+        etcd: false
+        controlplane: false
+        worker: true
 ```
 Note: In this test suite, Terraform explicitly cleans up resources after each test case is performed. This is because Terraform will experience caching issues, causing tests to fail.
 

--- a/framework/set/provisioning/setProvidersTF.go
+++ b/framework/set/provisioning/setProvidersTF.go
@@ -13,12 +13,12 @@ import (
 // setProvidersTF is a helper function that will set the general Terraform configurations in the main.tf file.
 func setProvidersTF(rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig) (*hclwrite.File, *hclwrite.Body) {
 	providerVersion := os.Getenv("RANCHER2_PROVIDER_VERSION")
-	
+
 	source := "rancher/rancher2"
 	if strings.Contains(providerVersion, "-rc") {
 		source = "terraform.local/local/rancher2"
 	}
-	
+
 	newFile := hclwrite.NewEmptyFile()
 	rootBody := newFile.Body()
 

--- a/framework/set/provisioning/setRKE1Config.go
+++ b/framework/set/provisioning/setRKE1Config.go
@@ -73,31 +73,33 @@ func SetRKE1(clusterName, k8sVersion, psact string, nodePools []config.Nodepool,
 	servicesBlock := rkeConfigBlockBody.AppendNewBlock("services", nil)
 	servicesBlockBody := servicesBlock.Body()
 
-	etcdBlock := servicesBlockBody.AppendNewBlock("etcd", nil)
-	etcdBlockBody := etcdBlock.Body()
+	if terraformConfig.ETCDRKE1 != nil {
+		etcdBlock := servicesBlockBody.AppendNewBlock("etcd", nil)
+		etcdBlockBody := etcdBlock.Body()
 
-	backupConfigBlock := etcdBlockBody.AppendNewBlock("backup_config", nil)
-	backupConfigBlockBody := backupConfigBlock.Body()
+		backupConfigBlock := etcdBlockBody.AppendNewBlock("backup_config", nil)
+		backupConfigBlockBody := backupConfigBlock.Body()
 
-	backupConfigBlockBody.SetAttributeValue("enabled", cty.BoolVal(true))
-	backupConfigBlockBody.SetAttributeValue("interval_hours", cty.NumberIntVal(terraformConfig.ETCDRKE1.BackupConfig.IntervalHours))
-	backupConfigBlockBody.SetAttributeValue("safe_timestamp", cty.BoolVal(terraformConfig.ETCDRKE1.BackupConfig.SafeTimestamp))
-	backupConfigBlockBody.SetAttributeValue("timeout", cty.NumberIntVal(terraformConfig.ETCDRKE1.BackupConfig.Timeout))
+		backupConfigBlockBody.SetAttributeValue("enabled", cty.BoolVal(true))
+		backupConfigBlockBody.SetAttributeValue("interval_hours", cty.NumberIntVal(terraformConfig.ETCDRKE1.BackupConfig.IntervalHours))
+		backupConfigBlockBody.SetAttributeValue("safe_timestamp", cty.BoolVal(terraformConfig.ETCDRKE1.BackupConfig.SafeTimestamp))
+		backupConfigBlockBody.SetAttributeValue("timeout", cty.NumberIntVal(terraformConfig.ETCDRKE1.BackupConfig.Timeout))
 
-	if terraformConfig.Module == ec2RKE1 && terraformConfig.ETCDRKE1.BackupConfig.S3BackupConfig != nil {
-		s3ConfigBlock := backupConfigBlockBody.AppendNewBlock("s3_backup_config", nil)
-		s3ConfigBlockBody := s3ConfigBlock.Body()
+		if terraformConfig.Module == ec2RKE1 && terraformConfig.ETCDRKE1.BackupConfig.S3BackupConfig != nil {
+			s3ConfigBlock := backupConfigBlockBody.AppendNewBlock("s3_backup_config", nil)
+			s3ConfigBlockBody := s3ConfigBlock.Body()
 
-		s3ConfigBlockBody.SetAttributeValue("access_key", cty.StringVal(terraformConfig.ETCDRKE1.BackupConfig.S3BackupConfig.AccessKey))
-		s3ConfigBlockBody.SetAttributeValue("bucket_name", cty.StringVal(terraformConfig.ETCDRKE1.BackupConfig.S3BackupConfig.BucketName))
-		s3ConfigBlockBody.SetAttributeValue("endpoint", cty.StringVal(terraformConfig.ETCDRKE1.BackupConfig.S3BackupConfig.Endpoint))
-		s3ConfigBlockBody.SetAttributeValue("folder", cty.StringVal(terraformConfig.ETCDRKE1.BackupConfig.S3BackupConfig.Folder))
-		s3ConfigBlockBody.SetAttributeValue("region", cty.StringVal(terraformConfig.ETCDRKE1.BackupConfig.S3BackupConfig.Region))
-		s3ConfigBlockBody.SetAttributeValue("secret_key", cty.StringVal(terraformConfig.ETCDRKE1.BackupConfig.S3BackupConfig.SecretKey))
+			s3ConfigBlockBody.SetAttributeValue("access_key", cty.StringVal(terraformConfig.ETCDRKE1.BackupConfig.S3BackupConfig.AccessKey))
+			s3ConfigBlockBody.SetAttributeValue("bucket_name", cty.StringVal(terraformConfig.ETCDRKE1.BackupConfig.S3BackupConfig.BucketName))
+			s3ConfigBlockBody.SetAttributeValue("endpoint", cty.StringVal(terraformConfig.ETCDRKE1.BackupConfig.S3BackupConfig.Endpoint))
+			s3ConfigBlockBody.SetAttributeValue("folder", cty.StringVal(terraformConfig.ETCDRKE1.BackupConfig.S3BackupConfig.Folder))
+			s3ConfigBlockBody.SetAttributeValue("region", cty.StringVal(terraformConfig.ETCDRKE1.BackupConfig.S3BackupConfig.Region))
+			s3ConfigBlockBody.SetAttributeValue("secret_key", cty.StringVal(terraformConfig.ETCDRKE1.BackupConfig.S3BackupConfig.SecretKey))
+		}
+
+		etcdBlockBody.SetAttributeValue("retention", cty.StringVal(terraformConfig.ETCDRKE1.Retention))
+		etcdBlockBody.SetAttributeValue("snapshot", cty.BoolVal(false))
 	}
-
-	etcdBlockBody.SetAttributeValue("retention", cty.StringVal("72h"))
-	etcdBlockBody.SetAttributeValue("snapshot", cty.BoolVal(false))
 
 	rootBody.AppendNewline()
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/tfp-automation
 
-go 1.20
+go 1.21
 
 replace (
 	github.com/rancher/rancher/pkg/apis => github.com/rancher/rancher/pkg/apis v0.0.0-20230525094739-ff2e09449efc
@@ -24,7 +24,7 @@ require (
 	github.com/gruntwork-io/terratest v0.42.0
 	github.com/rancher/norman v0.0.0-20230831160711-5de27f66385d
 	github.com/rancher/rancher/pkg/apis v0.0.0
-	github.com/rancher/shepherd v0.0.0-20231221153749-b41f540bc67e
+	github.com/rancher/shepherd v0.0.0-20240212210618-6f6f377a7e21
 	github.com/sirupsen/logrus v1.9.3
 )
 
@@ -187,7 +187,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/apiextensions-apiserver v0.28.3 // indirect
-	k8s.io/cli-runtime v0.27.6 // indirect
+	k8s.io/cli-runtime v0.27.9 // indirect
 	k8s.io/client-go v12.0.0+incompatible // indirect
 	k8s.io/component-base v0.28.3 // indirect
 	k8s.io/klog/v2 v2.100.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -266,6 +266,7 @@ github.com/aws/aws-sdk-go v1.44.322/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
+github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -372,6 +373,7 @@ github.com/containerd/continuity v0.0.0-20201208142359-180525291bb7/go.mod h1:kR
 github.com/containerd/continuity v0.0.0-20210208174643-50096c924a4e/go.mod h1:EXlVlkqNba9rJe3j7w3Xa924itAMLgZH4UD/Q4PExuQ=
 github.com/containerd/continuity v0.1.0/go.mod h1:ICJu0PwR54nI0yPEnJ6jcS+J7CZAUXrLh8lPo2knzsM=
 github.com/containerd/continuity v0.3.0 h1:nisirsYROK15TAMVukJOUyGJjz4BNQJBVsNvAXZJ/eg=
+github.com/containerd/continuity v0.3.0/go.mod h1:wJEAIwKOm/pBZuBd0JmeTvnLquTB1Ag8espWhkykbPM=
 github.com/containerd/fifo v0.0.0-20180307165137-3d5202aec260/go.mod h1:ODA38xgv3Kuk8dQz2ZQXpnv/UZZUHUCL7pnLehbXgQI=
 github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448/go.mod h1:ODA38xgv3Kuk8dQz2ZQXpnv/UZZUHUCL7pnLehbXgQI=
 github.com/containerd/fifo v0.0.0-20200410184934-f15a3290365b/go.mod h1:jPQ2IAeZRCYxpS/Cm1495vGFww6ecHmMk1YJH2Q5ln0=
@@ -516,6 +518,7 @@ github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSw
 github.com/flowstack/go-jsonschema v0.1.1/go.mod h1:yL7fNggx1o8rm9RlgXv7hTBWxdBM0rVwpMwimd3F3N0=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=
+github.com/frankban/quicktest v1.14.4/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
@@ -556,6 +559,7 @@ github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre
 github.com/go-logr/zapr v0.4.0/go.mod h1:tabnROwaDl0UNxkVeFRbY8bwB37GwRv0P8lg6aAiEnk=
 github.com/go-logr/zapr v1.2.3/go.mod h1:eIauM6P8qSvTw5o2ez6UEAfGjQKrxQTl5EoK+Qa2oG4=
 github.com/go-logr/zapr v1.2.4 h1:QHVo+6stLbfJmYGkQ7uGHUCu5hnAFAj6mDe6Ea0SeOo=
+github.com/go-logr/zapr v1.2.4/go.mod h1:FyHWQIzQORZ0QVE1BtVHv3cKtNLuXsbNLtpuhNapBOA=
 github.com/go-openapi/jsonpointer v0.19.2/go.mod h1:3akKfEdA7DF1sugOqz1dVQHBcuDBPKZGEoHC/NkiQRg=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonpointer v0.19.5/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
@@ -576,6 +580,7 @@ github.com/go-openapi/swag v0.22.3/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
+github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
 github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-test/deep v1.0.7 h1:/VSMRlnY/JSyqxQUzQLKVMAskpY/NZKFA5j2P+0pP2M=
 github.com/go-test/deep v1.0.7/go.mod h1:QV8Hv/iy04NyLBxAdO9njL0iVPN1S4d/A3NVv1V36o8=
@@ -670,6 +675,7 @@ github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIG
 github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/martian/v3 v3.2.1/go.mod h1:oBOf6HBosgwRXnUGWUB05QECsc6uvmMiJ3+6W4l/CUk=
 github.com/google/martian/v3 v3.3.2 h1:IqNFLAmvJOgVlpdEBiQbDc2EwKW77amAycfTuWKdfvw=
+github.com/google/martian/v3 v3.3.2/go.mod h1:oBOf6HBosgwRXnUGWUB05QECsc6uvmMiJ3+6W4l/CUk=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
@@ -716,6 +722,7 @@ github.com/googleapis/gnostic v0.5.5/go.mod h1:7+EbHbldMins07ALC74bsA81Ovc97Dwqy
 github.com/googleapis/go-type-adapters v1.0.0/go.mod h1:zHW75FOG2aur7gAO2B+MLby+cLsWGBF62rFAi7WjWO4=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gopherjs/gopherjs v0.0.0-20191106031601-ce3c9ade29de h1:F7WD09S8QB4LrkEpka0dFPLSotH11HRpCsLIbIcJ7sU=
+github.com/gopherjs/gopherjs v0.0.0-20191106031601-ce3c9ade29de/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/handlers v0.0.0-20150720190736-60c7bfde3e33/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/mux v1.7.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
@@ -839,6 +846,7 @@ github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
@@ -964,6 +972,7 @@ github.com/onsi/ginkgo/v2 v2.8.1/go.mod h1:N1/NbDngAFcSLdyZ+/aYTYGSlq9qMCS/cNKGJ
 github.com/onsi/ginkgo/v2 v2.9.0/go.mod h1:4xkjoL/tZv4SMWeww56BU5kAt19mVB47gTWxmrTcxyk=
 github.com/onsi/ginkgo/v2 v2.9.1/go.mod h1:FEcmzVcCHl+4o9bQZVab+4dC9+j+91t2FHSzmGAPfuo=
 github.com/onsi/ginkgo/v2 v2.11.0 h1:WgqUCUt/lT6yXoQ8Wef0fsNn5cAuMK7+KT9UFRz2tcU=
+github.com/onsi/ginkgo/v2 v2.11.0/go.mod h1:ZhrRA5XmEE3x3rhlzamx/JJvujdZoJ2uvgI7kR0iZvM=
 github.com/onsi/gomega v0.0.0-20151007035656-2152b45fa28a/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -985,6 +994,7 @@ github.com/onsi/gomega v1.27.1/go.mod h1:aHX5xOykVYzWOV4WqQy0sy8BQptgukenXpCXfad
 github.com/onsi/gomega v1.27.3/go.mod h1:5vG284IBtfDAmDyrK+eGyZmUgUlmi+Wngqo557cZ6Gw=
 github.com/onsi/gomega v1.27.4/go.mod h1:riYq/GJKh8hhoM01HN6Vmuy93AarCXCBGpvFDK3q3fQ=
 github.com/onsi/gomega v1.27.10 h1:naR28SdDFlqrG6kScpT8VWpu1xWY5nJRCF3XaYyBjhI=
+github.com/onsi/gomega v1.27.10/go.mod h1:RsS8tutOdbdgzbPtzzATp12yT7kM5I5aElG3evPbQ0M=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
@@ -1101,8 +1111,8 @@ github.com/rancher/rancher/pkg/apis v0.0.0-20230525094739-ff2e09449efc h1:NuDuqL
 github.com/rancher/rancher/pkg/apis v0.0.0-20230525094739-ff2e09449efc/go.mod h1:4KAasaWJ3wmljgFGP4z08SVP4Snr1CWeY7McL4JFn+o=
 github.com/rancher/rke v1.5.0 h1:M/YryKnBs7IwzMGA2kh1EiypVQkme6o9KSg0hlllQa4=
 github.com/rancher/rke v1.5.0/go.mod h1:wZaVWzW46OTuGvyxgRHXGUyJ/QP0zOkKESO9hBOwTaY=
-github.com/rancher/shepherd v0.0.0-20231221153749-b41f540bc67e h1:FVgqnqMQD0MTBVZgb5WUU2RXgMYUet2N98Y+lY4uE7Q=
-github.com/rancher/shepherd v0.0.0-20231221153749-b41f540bc67e/go.mod h1:P1cHvo3eKgYm4tNnFDAL0jE6lTvk3YhS6yL4B8o84As=
+github.com/rancher/shepherd v0.0.0-20240212210618-6f6f377a7e21 h1:GCa3Yv6im4aAxchaPWFlsqN3jxeZGgCgNulkvRhhS7I=
+github.com/rancher/shepherd v0.0.0-20240212210618-6f6f377a7e21/go.mod h1:pggo0NvlbxaplK5cwiTSp7AixbGrGWbz6CC710biulI=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007 h1:ru+mqGnxMmKeU0Q3XIDxkARvInDIqT1hH2amTcsjxI4=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007/go.mod h1:Ja346o44aTPWADc/5Jm93+KgctT6KtftuOosgz0F2AM=
 github.com/rancher/wrangler v0.6.1/go.mod h1:L4HtjPeX8iqLgsxfJgz+JjKMcX2q3qbRXSeTlC/CSd4=
@@ -1145,6 +1155,7 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v1.0.1 h1:voD4ITNjPL5jjBfgR/r8fPIIBrliWrWHeiJApdr3r4w=
+github.com/smartystreets/assertions v1.0.1/go.mod h1:kHHU4qYBaI3q23Pp3VPrmWhuIUrLW/7eUrw0BU5VaoM=
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
@@ -1760,6 +1771,7 @@ golang.org/x/tools v0.4.0/go.mod h1:UE5sM2OK9E/d67R0ANs2xJizIymRP5gJU295PvKXxjQ=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/tools v0.7.0/go.mod h1:4pg6aUX35JBAogB10C9AtvVL+qowtN4pT3CGSQex14s=
 golang.org/x/tools v0.12.0 h1:YW6HUoUmYBpwSgyaGaZq1fHjrBjX1rlpZ54T6mu2kss=
+golang.org/x/tools v0.12.0/go.mod h1:Sc0INKfu04TlqNoRA1hgpFZbhYXHPr4V5DzpSBTPqQM=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -2027,6 +2039,7 @@ gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/ini.v1 v1.62.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
+gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
@@ -2069,8 +2082,8 @@ k8s.io/apimachinery v0.27.4/go.mod h1:XNfZ6xklnMCOGGFNqXG7bUrQCoR04dh/E7FprV6pb+
 k8s.io/apiserver v0.27.4 h1:ncZ0MBR9yQ/Gf34rtu1EK+HqT8In1YpfAUINu/Akvho=
 k8s.io/apiserver v0.27.4/go.mod h1:GDEFRfFZ4/l+pAvwYRnoSfz0K4j3TWiN4WsG2KnRteE=
 k8s.io/cli-runtime v0.22.2/go.mod h1:tkm2YeORFpbgQHEK/igqttvPTRIHFRz5kATlw53zlMI=
-k8s.io/cli-runtime v0.27.6 h1:ik1+20C0AvxYcqEzwebH2PHOlqBTKUHZnOuPtG2CCl8=
-k8s.io/cli-runtime v0.27.6/go.mod h1:+qSBK08EJL1fFvsfVNlETzsgGtxIhascIGZSuaQXQro=
+k8s.io/cli-runtime v0.27.9 h1:cUbqqP7UwDvPTcFS82bJXr4z9DqZ5alKp4mR4b2GGGY=
+k8s.io/cli-runtime v0.27.9/go.mod h1:8MTuOilOztxvWqOU8P9SrimdDaWX6JXszNNH71OYMWI=
 k8s.io/code-generator v0.18.0/go.mod h1:+UHX5rSbxmR8kzS+FAv7um6dtYrZokQvjHpDSYRVkTc=
 k8s.io/code-generator v0.19.7/go.mod h1:lwEq3YnLYb/7uVXLorOJfxg+cUu2oihFhHZ0n9NIla0=
 k8s.io/code-generator v0.22.2/go.mod h1:eV77Y09IopzeXOJzndrDyCI88UBok2h6WxAlBwpxa+o=

--- a/tests/nodescaling/README.md
+++ b/tests/nodescaling/README.md
@@ -51,32 +51,33 @@ terratest:
       controlplane: false
       worker: true
       quantity: 1
-  scaledUpNodepools:
-    - etcd: true
-      controlplane: false
-      worker: false
-      quantity: 3
-    - etcd: false
-      controlplane: true
-      worker: false
-      quantity: 2
-    - etcd: false
-      controlplane: false
-      worker: true
-      quantity: 3
-  scaledDownNodepools:
-    - etcd: true
-      controlplane: false
-      worker: false
-      quantity: 3
-    - etcd: false
-      controlplane: true
-      worker: false
-      quantity: 2
-    - etcd: false
-      controlplane: false
-      worker: true
-      quantity: 1
+  scalingInput:
+    scaledUpNodepools:
+      - etcd: true
+        controlplane: false
+        worker: false
+        quantity: 3
+      - etcd: false
+        controlplane: true
+        worker: false
+        quantity: 2
+      - etcd: false
+        controlplane: false
+        worker: true
+        quantity: 3
+    scaledDownNodepools:
+      - etcd: true
+        controlplane: false
+        worker: false
+        quantity: 3
+      - etcd: false
+        controlplane: true
+        worker: false
+        quantity: 2
+      - etcd: false
+        controlplane: false
+        worker: true
+        quantity: 1
   ```
 
 See the below examples on how to run the tests:

--- a/tests/nodescaling/scale_test.go
+++ b/tests/nodescaling/scale_test.go
@@ -1,4 +1,4 @@
-package tests
+package nodescaling
 
 import (
 	"testing"

--- a/tests/snapshot/README.md
+++ b/tests/snapshot/README.md
@@ -4,12 +4,13 @@ In the snapshot tests, the following workflow is followed:
 
 1. Provision a downstream cluster
 2. Perform post-cluster provisioning checks
-3. Check if the downstream cluster is RKE1, RKE2 or K3S
-4. Perform etcd snapshot
-5. Perform post etcd snapshot checks
-6. Perform etcd restore
-7. Perform post etcd restore checks
+3. Perform etcd snapshot
+4. Perform post etcd snapshot checks
+5. Perform etcd restore
+6. Perform post etcd restore checks
 7. Cleanup resources (Terraform explicitly needs to call its cleanup method so that each test doesn't experience caching issues)
+
+NOTE: Only RKE2/K3s clusters are supported in this package - RKE1 clusters are NOT supported. For reference, see this [ticket](https://github.com/rancher/terraform-provider-rancher2/issues/1292). 
 
 Please see below for more details for your config. Please note that the config can be in either JSON or YAML (all examples are illustrated in YAML).
 
@@ -48,13 +49,14 @@ Similar to the `provisioning` tests, the snapshot tests have static test cases a
 ```yaml
 terratest:
   kubernetesVersion: "v1.26.11+k3s2"
-  upgradeKubernetesVersion: "" # If left blank, the default version in Rancher will be used.
-  snapshotRestore: "all" # Options include none, kubernetesVersion, all. Option 'none' means that only the etcd will be restored.
-  controlPlaneConcurrencyValue: "15%"
-  workerConcurrencyValue: "20%"
-  controlPlaneUnavailableValue: "1"
-  workerUnavailableValue: "10%"
-  recurringRestores: 1 # By default, this is set to 1 if this field is not included in the config.
+  snapshotInput:
+    upgradeKubernetesVersion: "" # If left blank, the default version in Rancher will be used.
+    snapshotRestore: "all" # Options include none, kubernetesVersion, all. Option 'none' means that only the etcd will be restored.
+    controlPlaneConcurrencyValue: "15%"
+    workerConcurrencyValue: "20%"
+    controlPlaneUnavailableValue: "3"
+    workerUnavailableValue: "15%"
+    recurringRestores: 1 # By default, this is set to 1 if this field is not included in the config.
   ```
 
 See the below examples on how to run the tests:

--- a/tests/snapshot/snapshot_restore_k8s_upgrade_test.go
+++ b/tests/snapshot/snapshot_restore_k8s_upgrade_test.go
@@ -79,7 +79,7 @@ func (s *SnapshotRestoreK8sUpgradeTestSuite) TestSnapshotRestoreK8sUpgrade() {
 
 	snapshotRestoreK8sVersion := config.TerratestConfig{
 		SnapshotInput: config.Snapshots{
-			UpgradeKubernetesVersion: s.clusterConfig.UpgradedKubernetesVersion,
+			UpgradeKubernetesVersion: "",
 			SnapshotRestore:          "kubernetesVersion",
 			RecurringRestores:        1,
 		},
@@ -87,7 +87,7 @@ func (s *SnapshotRestoreK8sUpgradeTestSuite) TestSnapshotRestoreK8sUpgrade() {
 
 	snapshotRestoreAll := config.TerratestConfig{
 		SnapshotInput: config.Snapshots{
-			UpgradeKubernetesVersion: s.clusterConfig.UpgradedKubernetesVersion,
+			UpgradeKubernetesVersion: "",
 			SnapshotRestore:          "all",
 			RecurringRestores:        1,
 		},
@@ -101,10 +101,10 @@ func (s *SnapshotRestoreK8sUpgradeTestSuite) TestSnapshotRestoreK8sUpgrade() {
 	}{
 		{"Restore Kubernetes version and etcd: 1 node all roles", nodeRolesAll, snapshotRestoreK8sVersion, s.client},
 		{"Restore cluster config, Kubernetes version and etcd: 1 node all roles", nodeRolesAll, snapshotRestoreAll, s.client},
-		{"Restore Kubernetes version and etcd: 2 nodes - etcd/cp roles per 1 node", nodeRolesShared, snapshotRestoreK8sVersion, s.client},
-		{"Restore cluster config, Kubernetes version and etcd: 2 nodes - etcd/cp roles per 1 node", nodeRolesShared, snapshotRestoreAll, s.client},
-		{"Restore Kubernetes version and etcd: 3 nodes - 1 role per node", nodeRolesDedicated, snapshotRestoreK8sVersion, s.client},
-		{"Restore cluster config, Kubernetes version and etcd: 3 nodes - 1 role per node", nodeRolesDedicated, snapshotRestoreAll, s.client},
+		{"Restore Kubernetes version and etcd: 2 nodes shared roles", nodeRolesShared, snapshotRestoreK8sVersion, s.client},
+		{"Restore cluster config, Kubernetes version and etcd: 2 nodes shared roles", nodeRolesShared, snapshotRestoreAll, s.client},
+		{"Restore Kubernetes version and etcd: 3 nodes dedicated roles", nodeRolesDedicated, snapshotRestoreK8sVersion, s.client},
+		{"Restore cluster config, Kubernetes version and etcd: 3 nodes dedicated roles", nodeRolesDedicated, snapshotRestoreAll, s.client},
 	}
 
 	for _, tt := range tests {
@@ -128,6 +128,10 @@ func (s *SnapshotRestoreK8sUpgradeTestSuite) TestSnapshotRestoreK8sUpgrade() {
 }
 
 func (s *SnapshotRestoreK8sUpgradeTestSuite) TestSnapshotRestoreK8sUpgradeDynamicInput() {
+	if s.clusterConfig.SnapshotInput == (config.Snapshots{}) {
+		s.T().Skip()
+	}
+
 	tests := []struct {
 		name   string
 		client *rancher.Client

--- a/tests/snapshot/snapshot_restore_test.go
+++ b/tests/snapshot/snapshot_restore_test.go
@@ -92,8 +92,8 @@ func (s *SnapshotRestoreTestSuite) TestSnapshotRestoreETCDOnly() {
 		client       *rancher.Client
 	}{
 		{"Restore etcd only: 1 node all roles", nodeRolesAll, snapshotRestoreNone, s.client},
-		{"Restore etcd only: 2 nodes - etcd/cp roles per 1 node", nodeRolesShared, snapshotRestoreNone, s.client},
-		{"Restore etcd only: 3 nodes - 1 role per node", nodeRolesDedicated, snapshotRestoreNone, s.client},
+		{"Restore etcd only: 2 nodes shared roles", nodeRolesShared, snapshotRestoreNone, s.client},
+		{"Restore etcd only: 3 nodes dedicated roles", nodeRolesDedicated, snapshotRestoreNone, s.client},
 	}
 
 	for _, tt := range tests {
@@ -117,6 +117,10 @@ func (s *SnapshotRestoreTestSuite) TestSnapshotRestoreETCDOnly() {
 }
 
 func (s *SnapshotRestoreTestSuite) TestSnapshotRestoreETCDOnlyDynamicInput() {
+	if s.clusterConfig.SnapshotInput == (config.Snapshots{}) {
+		s.T().Skip()
+	}
+
 	tests := []struct {
 		name   string
 		client *rancher.Client

--- a/tests/snapshot/snapshot_restore_upgrade_strategy_test.go
+++ b/tests/snapshot/snapshot_restore_upgrade_strategy_test.go
@@ -79,24 +79,24 @@ func (s *SnapshotRestoreUpgradeStrategyTestSuite) TestSnapshotRestoreUpgradeStra
 
 	snapshotRestoreK8sVersion := config.TerratestConfig{
 		SnapshotInput: config.Snapshots{
-			UpgradeKubernetesVersion:     s.clusterConfig.UpgradedKubernetesVersion,
+			UpgradeKubernetesVersion:     "",
 			SnapshotRestore:              "kubernetesVersion",
 			ControlPlaneConcurrencyValue: "15%",
-			ControlPlaneUnavailableValue: "1",
+			ControlPlaneUnavailableValue: "3",
 			WorkerConcurrencyValue:       "20%",
-			WorkerUnavailableValue:       "10%",
+			WorkerUnavailableValue:       "15%",
 			RecurringRestores:            1,
 		},
 	}
 
 	snapshotRestoreAll := config.TerratestConfig{
 		SnapshotInput: config.Snapshots{
-			UpgradeKubernetesVersion:     s.clusterConfig.UpgradedKubernetesVersion,
+			UpgradeKubernetesVersion:     "",
 			SnapshotRestore:              "all",
 			ControlPlaneConcurrencyValue: "15%",
-			ControlPlaneUnavailableValue: "1",
+			ControlPlaneUnavailableValue: "3",
 			WorkerConcurrencyValue:       "20%",
-			WorkerUnavailableValue:       "10%",
+			WorkerUnavailableValue:       "15%",
 			RecurringRestores:            1,
 		},
 	}
@@ -109,10 +109,10 @@ func (s *SnapshotRestoreUpgradeStrategyTestSuite) TestSnapshotRestoreUpgradeStra
 	}{
 		{"Restore Kubernetes version and etcd: 1 node all roles", nodeRolesAll, snapshotRestoreK8sVersion, s.client},
 		{"Restore cluster config, Kubernetes version and etcd: 1 node all roles", nodeRolesAll, snapshotRestoreAll, s.client},
-		{"Restore Kubernetes version and etcd: 2 nodes - etcd/cp roles per 1 node", nodeRolesShared, snapshotRestoreK8sVersion, s.client},
-		{"Restore cluster config, Kubernetes version and etcd: 2 nodes - etcd/cp roles per 1 node", nodeRolesShared, snapshotRestoreAll, s.client},
-		{"Restore Kubernetes version and etcd: 3 nodes - 1 role per node", nodeRolesDedicated, snapshotRestoreK8sVersion, s.client},
-		{"Restore cluster config, Kubernetes version and etcd: 3 nodes - 1 role per node", nodeRolesDedicated, snapshotRestoreAll, s.client},
+		{"Restore Kubernetes version and etcd: 2 nodes shared roles", nodeRolesShared, snapshotRestoreK8sVersion, s.client},
+		{"Restore cluster config, Kubernetes version and etcd: 2 nodes shared roles", nodeRolesShared, snapshotRestoreAll, s.client},
+		{"Restore Kubernetes version and etcd: 3 nodes dedicated roles", nodeRolesDedicated, snapshotRestoreK8sVersion, s.client},
+		{"Restore cluster config, Kubernetes version and etcd: 3 nodes dedicated roles", nodeRolesDedicated, snapshotRestoreAll, s.client},
 	}
 
 	for _, tt := range tests {
@@ -140,6 +140,10 @@ func (s *SnapshotRestoreUpgradeStrategyTestSuite) TestSnapshotRestoreUpgradeStra
 }
 
 func (s *SnapshotRestoreUpgradeStrategyTestSuite) TestSnapshotRestoreUpgradeStrategyDynamicInput() {
+	if s.clusterConfig.SnapshotInput == (config.Snapshots{}) {
+		s.T().Skip()
+	}
+
 	tests := []struct {
 		name   string
 		client *rancher.Client


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> NA
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
As part of ongoing additional etcd snapshot coverage, there are constant changes going on. As such, we will need to make sure that the `tfp-automation` framework accommodates where it makes sense to do so.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
- Restructures `snapshot` package based upon latest `rancher/rancher` snapshot package changes.
- Removes RKE1 clusters from the `snapshot` package.
- Gives needed stability in flakiness found during release testing in the snapshot tests.
- Makes specifying etcd blocks optional when provisioning RKE1/RKE2/K3S clusters
     - Unrelated to the snapshot tests, but good to have this in and small change.
 
### Automated Testing
Jenkins jobs will be provided offline to the reviewers.