### PR TITLE
Remove recurring restores from snapshot test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -2050,24 +2050,6 @@ Note: In this test suite, Terraform explicitly cleans up resources after each te
       <td>string</td>
       <td>view section on snapshotInput in example yaml below</td>
     </tr>
-    <tr>
-      <td>controlPlaneUnavailableValue</td>
-      <td>specify the control plane unavailable value used when upgrading RKE1 clusters</td>
-      <td>string</td>
-      <td>view section on snapshotInput in example yaml below</td>
-    </tr>
-    <tr>
-      <td>workerUnavailableValue</td>
-      <td>specify the worker unavailable value used when upgrading RKE1 clusters</td>
-      <td>string</td>
-      <td>view section on snapshotInput in example yaml below</td>
-    </tr>
-    <tr>
-      <td>recurringRestores</td>
-      <td>specify the number of times a snapshot is going to restore</td>
-      <td>string</td>
-      <td>view section on snapshotInput in example yaml below</td>
-    </tr>
   </tbody>
 </table>
 
@@ -2079,9 +2061,6 @@ terratest:
     upgradeKubernetesVersion: ""
     controlPlaneConcurrencyValue: "15%"
     workerConcurrencyValue: "20%"
-    controlPlaneUnavailableValue: "1"
-    workerUnavailableValue: "10%"
-    recurringRestores: 1
 ```
 Note: In this test suite, Terraform explicitly cleans up resources after each test case is performed. This is because Terraform will experience caching issues, causing tests to fail.
 

--- a/config/config.go
+++ b/config/config.go
@@ -159,10 +159,7 @@ type Snapshots struct {
 	UpgradeKubernetesVersion     string `json:"upgradeKubernetesVersion,omitempty" yaml:"upgradeKubernetesVersion,omitempty"`
 	SnapshotRestore              string `json:"snapshotRestore,omitempty" yaml:"snapshotRestore,omitempty"`
 	ControlPlaneConcurrencyValue string `json:"controlPlaneConcurrencyValue,omitempty" yaml:"controlPlaneConcurrencyValue,omitempty"`
-	ControlPlaneUnavailableValue string `json:"controlPlaneUnavailableValue,omitempty" yaml:"controlPlaneUnavailableValue,omitempty"`
 	WorkerConcurrencyValue       string `json:"workerConcurrencyValue,omitempty" yaml:"workerConcurrencyValue,omitempty"`
-	WorkerUnavailableValue       string `json:"workerUnavailableValue,omitempty" yaml:"workerUnavailableValue,omitempty"`
-	RecurringRestores            int    `json:"recurringRestores,omitempty" yaml:"recurringRestores,omitempty"`
 }
 
 type TerratestConfig struct {

--- a/tests/snapshot/README.md
+++ b/tests/snapshot/README.md
@@ -54,9 +54,6 @@ terratest:
     snapshotRestore: "all" # Options include none, kubernetesVersion, all. Option 'none' means that only the etcd will be restored.
     controlPlaneConcurrencyValue: "15%"
     workerConcurrencyValue: "20%"
-    controlPlaneUnavailableValue: "3"
-    workerUnavailableValue: "15%"
-    recurringRestores: 1 # By default, this is set to 1 if this field is not included in the config.
   ```
 
 See the below examples on how to run the tests:

--- a/tests/snapshot/snapshot_restore_k8s_upgrade_test.go
+++ b/tests/snapshot/snapshot_restore_k8s_upgrade_test.go
@@ -81,7 +81,6 @@ func (s *SnapshotRestoreK8sUpgradeTestSuite) TestSnapshotRestoreK8sUpgrade() {
 		SnapshotInput: config.Snapshots{
 			UpgradeKubernetesVersion: "",
 			SnapshotRestore:          "kubernetesVersion",
-			RecurringRestores:        1,
 		},
 	}
 
@@ -89,7 +88,6 @@ func (s *SnapshotRestoreK8sUpgradeTestSuite) TestSnapshotRestoreK8sUpgrade() {
 		SnapshotInput: config.Snapshots{
 			UpgradeKubernetesVersion: "",
 			SnapshotRestore:          "all",
-			RecurringRestores:        1,
 		},
 	}
 
@@ -112,7 +110,6 @@ func (s *SnapshotRestoreK8sUpgradeTestSuite) TestSnapshotRestoreK8sUpgrade() {
 		clusterConfig.Nodepools = tt.nodeRoles
 		clusterConfig.SnapshotInput.UpgradeKubernetesVersion = tt.etcdSnapshot.SnapshotInput.UpgradeKubernetesVersion
 		clusterConfig.SnapshotInput.SnapshotRestore = tt.etcdSnapshot.SnapshotInput.SnapshotRestore
-		clusterConfig.SnapshotInput.RecurringRestores = tt.etcdSnapshot.SnapshotInput.RecurringRestores
 
 		clusterName := namegen.AppendRandomString(provisioning.TFP)
 

--- a/tests/snapshot/snapshot_restore_test.go
+++ b/tests/snapshot/snapshot_restore_test.go
@@ -81,7 +81,6 @@ func (s *SnapshotRestoreTestSuite) TestSnapshotRestoreETCDOnly() {
 		SnapshotInput: config.Snapshots{
 			UpgradeKubernetesVersion: "",
 			SnapshotRestore:          "none",
-			RecurringRestores:        1,
 		},
 	}
 
@@ -101,7 +100,6 @@ func (s *SnapshotRestoreTestSuite) TestSnapshotRestoreETCDOnly() {
 		clusterConfig.Nodepools = tt.nodeRoles
 		clusterConfig.SnapshotInput.UpgradeKubernetesVersion = tt.etcdSnapshot.SnapshotInput.UpgradeKubernetesVersion
 		clusterConfig.SnapshotInput.SnapshotRestore = tt.etcdSnapshot.SnapshotInput.SnapshotRestore
-		clusterConfig.SnapshotInput.RecurringRestores = tt.etcdSnapshot.SnapshotInput.RecurringRestores
 
 		clusterName := namegen.AppendRandomString(provisioning.TFP)
 

--- a/tests/snapshot/snapshot_restore_upgrade_strategy_test.go
+++ b/tests/snapshot/snapshot_restore_upgrade_strategy_test.go
@@ -82,10 +82,7 @@ func (s *SnapshotRestoreUpgradeStrategyTestSuite) TestSnapshotRestoreUpgradeStra
 			UpgradeKubernetesVersion:     "",
 			SnapshotRestore:              "kubernetesVersion",
 			ControlPlaneConcurrencyValue: "15%",
-			ControlPlaneUnavailableValue: "3",
 			WorkerConcurrencyValue:       "20%",
-			WorkerUnavailableValue:       "15%",
-			RecurringRestores:            1,
 		},
 	}
 
@@ -94,10 +91,7 @@ func (s *SnapshotRestoreUpgradeStrategyTestSuite) TestSnapshotRestoreUpgradeStra
 			UpgradeKubernetesVersion:     "",
 			SnapshotRestore:              "all",
 			ControlPlaneConcurrencyValue: "15%",
-			ControlPlaneUnavailableValue: "3",
 			WorkerConcurrencyValue:       "20%",
-			WorkerUnavailableValue:       "15%",
-			RecurringRestores:            1,
 		},
 	}
 
@@ -121,10 +115,7 @@ func (s *SnapshotRestoreUpgradeStrategyTestSuite) TestSnapshotRestoreUpgradeStra
 		clusterConfig.SnapshotInput.UpgradeKubernetesVersion = tt.etcdSnapshot.SnapshotInput.UpgradeKubernetesVersion
 		clusterConfig.SnapshotInput.SnapshotRestore = tt.etcdSnapshot.SnapshotInput.SnapshotRestore
 		clusterConfig.SnapshotInput.ControlPlaneConcurrencyValue = tt.etcdSnapshot.SnapshotInput.ControlPlaneConcurrencyValue
-		clusterConfig.SnapshotInput.ControlPlaneUnavailableValue = tt.etcdSnapshot.SnapshotInput.ControlPlaneUnavailableValue
 		clusterConfig.SnapshotInput.WorkerConcurrencyValue = tt.etcdSnapshot.SnapshotInput.WorkerConcurrencyValue
-		clusterConfig.SnapshotInput.WorkerUnavailableValue = tt.etcdSnapshot.SnapshotInput.WorkerUnavailableValue
-		clusterConfig.SnapshotInput.RecurringRestores = tt.etcdSnapshot.SnapshotInput.RecurringRestores
 
 		clusterName := namegen.AppendRandomString(provisioning.TFP)
 


### PR DESCRIPTION
### PR Description
In providing a `tfp-automation` counterpart PR for QA task https://github.com/rancher/qa-tasks/issues/1143, it was noted that recurring restores go against the best practices of the `tfp-automation` repo. Specifically, restoring multiple times will not work as the `main.tf` does not change.

As such, Terraform will not proceed forward. As that is the case, we are already covering the functionality of recurring restores, so there is no need to duplicate effort here.