### PR TITLE
Enhance upgrade test to use default K8s version if none selected

### DIFF
--- a/tests/extensions/provisioning/kubernetesUpgrade.go
+++ b/tests/extensions/provisioning/kubernetesUpgrade.go
@@ -1,17 +1,43 @@
 package provisioning
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/clusters/kubernetesversions"
 	"github.com/rancher/tfp-automation/config"
 	set "github.com/rancher/tfp-automation/framework/set/provisioning"
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	RKE1 = "-rancher"
+	RKE2 = "rke2"
+	K3S  = "k3s"
+)
+
 // KubernetesUpgrade is a function that will run terraform apply and uprade the Kubernetes version of the provisioned cluster.
-func KubernetesUpgrade(t *testing.T, clusterName string, terraformOptions *terraform.Options, clusterConfig *config.TerratestConfig) {
-	clusterConfig.KubernetesVersion = clusterConfig.UpgradedKubernetesVersion
+func KubernetesUpgrade(t *testing.T, client *rancher.Client, clusterName string, terraformOptions *terraform.Options, clusterConfig *config.TerratestConfig) {
+	if clusterConfig.UpgradedKubernetesVersion == "" {
+		if strings.Contains(clusterConfig.KubernetesVersion, RKE1) {
+			defaultVersion, err := kubernetesversions.Default(client, clusters.RKE1ClusterType.String(), nil)
+			clusterConfig.KubernetesVersion = defaultVersion[0]
+			require.NoError(t, err)
+		} else if strings.Contains(clusterConfig.KubernetesVersion, RKE2) {
+			defaultVersion, err := kubernetesversions.Default(client, clusters.RKE2ClusterType.String(), nil)
+			clusterConfig.KubernetesVersion = defaultVersion[0]
+			require.NoError(t, err)
+		} else if strings.Contains(clusterConfig.KubernetesVersion, K3S) {
+			defaultVersion, err := kubernetesversions.Default(client, clusters.K3SClusterType.String(), nil)
+			clusterConfig.KubernetesVersion = defaultVersion[0]
+			require.NoError(t, err)
+		}
+	} else {
+		clusterConfig.KubernetesVersion = clusterConfig.UpgradedKubernetesVersion
+	}
 
 	err := set.SetConfigTF(clusterConfig, clusterName)
 	require.NoError(t, err)

--- a/tests/upgrading/README.md
+++ b/tests/upgrading/README.md
@@ -32,7 +32,7 @@ Similar to the `provisioning` tests, the node scaling tests have static test cas
 ```yaml
 terratest:
   kubernetesVersion: "v1.26.11+k3s2"
-  upgradedKubernetesVersion: "v1.27.8+k3s2"
+  upgradedKubernetesVersion: "" # If left blank or is omitted completely, the latest version in Rancher will be used
   psact: "" # Optional, can be left out or can have values `rancher-privileged` or `rancher-restricted`
   ```
 

--- a/tests/upgrading/kubernetes_upgrade_test.go
+++ b/tests/upgrading/kubernetes_upgrade_test.go
@@ -97,7 +97,7 @@ func (k *KubernetesUpgradeTestSuite) TestKubernetesUpgrade() {
 			provisioning.Provision(k.T(), clusterName, k.terraformConfig, &clusterConfig, k.terraformOptions)
 			provisioning.VerifyCluster(k.T(), tt.client, clusterName, k.terraformConfig, k.terraformOptions, &clusterConfig)
 
-			provisioning.KubernetesUpgrade(k.T(), clusterName, k.terraformOptions, &clusterConfig)
+			provisioning.KubernetesUpgrade(k.T(), tt.client, clusterName, k.terraformOptions, &clusterConfig)
 			provisioning.VerifyCluster(k.T(), tt.client, clusterName, k.terraformConfig, k.terraformOptions, &clusterConfig)
 			provisioning.VerifyUpgradedKubernetesVersion(k.T(), tt.client, k.terraformConfig, clusterName, k.clusterConfig.UpgradedKubernetesVersion)
 
@@ -121,7 +121,7 @@ func (k *KubernetesUpgradeTestSuite) TestKubernetesUpgradeDynamicInput() {
 			provisioning.Provision(k.T(), clusterName, k.terraformConfig, k.clusterConfig, k.terraformOptions)
 			provisioning.VerifyCluster(k.T(), k.client, clusterName, k.terraformConfig, k.terraformOptions, k.clusterConfig)
 
-			provisioning.KubernetesUpgrade(k.T(), clusterName, k.terraformOptions, k.clusterConfig)
+			provisioning.KubernetesUpgrade(k.T(), tt.client, clusterName, k.terraformOptions, k.clusterConfig)
 			provisioning.VerifyCluster(k.T(), k.client, clusterName, k.terraformConfig, k.terraformOptions, k.clusterConfig)
 			provisioning.VerifyUpgradedKubernetesVersion(k.T(), k.client, k.terraformConfig, clusterName, k.clusterConfig.UpgradedKubernetesVersion)
 


### PR DESCRIPTION
### PR Description
Currently, the `tfp-automation` framework allows for upgrading downstream clusters. This is done through the `upgradedKubernetesVersion` in the `terratest` config block. You will need to set the version in order for the test to work.

This PR enhances the test so that if that parameter is blank or non-existent, then the latest K8s version available be used to upgrade the downstream cluster. We have this functionality in the Go framework, so it should be here as well.