### PR TITLE
Implement Qase with tfp-automation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM golang:1.21
 RUN mkdir -p /.cache && chmod -R 777 /.cache
 RUN mkdir -p $GOPATH/pkg/mod && chmod -R 777 $GOPATH/pkg/mod
 RUN chown -R root:root $GOPATH/pkg/mod && chmod -R g+rwx $GOPATH/pkg/mod
+RUN groupadd -g 1000 jenkins && useradd -u 1000 -g jenkins -m jenkins
 
 WORKDIR /usr/app/src
 
@@ -19,7 +20,10 @@ ARG EXTERNAL_ENCODED_VPN
 ARG VPN_ENCODED_LOGIN
 ARG RANCHER2_PROVIDER_VERSION
 
-RUN wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && apt-get update && apt-get install unzip &&  unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip && rm terraform_${TERRAFORM_VERSION}_linux_amd64.zip && chmod u+x terraform && mv terraform /usr/bin/terraform
+RUN wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && apt-get update && apt-get install unzip && \
+    unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \ 
+    rm terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
+    chmod a+x terraform && mv terraform /usr/local/bin/terraform
 
 ARG CONFIG_FILE
 COPY $CONFIG_FILE /config.yml
@@ -33,3 +37,5 @@ RUN if [[ -z '$EXTERNAL_ENCODED_VPN' ]] ; then \
 RUN if [[ "$RANCHER2_PROVIDER_VERSION" == *"-rc"* ]]; then \
       chmod +x ./scripts/setup-provider.sh && ./scripts/setup-provider.sh rancher2 v${RANCHER2_PROVIDER_VERSION} ; \
     fi;
+
+USER jenkins

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,14 @@
 #!groovy
 node {
+  def rootPath = "/home/jenkins/workspace/rancher_qa/tfp-automation/"
   def testsDir = "./tests/${env.TEST_PACKAGE}"
+  def job_name = "${JOB_NAME}"
+  if (job_name.contains('/')) { 
+    job_names = job_name.split('/')
+    job_name = job_names[job_names.size() - 1] 
+  }
+  def testResultsOut = "results.xml"
+  def testResultsJSON = "results.json"
   def branch = "${env.BRANCH}"
   if ("${env.BRANCH}" != "null" && "${env.BRANCH}" != "") {
         branch = "${env.BRANCH}"
@@ -21,6 +29,7 @@ node {
   if ("${env.RANCHER2_PROVIDER_VERSION}" != "null" && "${env.RANCHER2_PROVIDER_VERSION}" != "") {
         rancher2ProviderVersion = "${env.RANCHER2_PROVIDER_VERSION}" 
   }
+  withCredentials([ string(credentialsId: 'QASE_AUTOMATION_TOKEN', variable: 'QASE_AUTOMATION_TOKEN')]) {
   stage('Checkout') {
           deleteDir()
           checkout([
@@ -32,14 +41,37 @@ node {
         }
     stage('Build Docker image') {
             writeFile file: 'config.yml', text: env.CONFIG
-            env.CATTLE_TEST_CONFIG='/home/jenkins/workspace/rancher_qa/tfp-automation/config.yml'
+            env.CATTLE_TEST_CONFIG=rootPath+'config.yml'
             sh "docker build --build-arg CONFIG_FILE=config.yml --build-arg TERRAFORM_VERSION=${terraformVersion} --build-arg RANCHER2_PROVIDER_VERSION=${rancher2ProviderVersion} -f Dockerfile -t tfp-automation . "
     }
     
     stage('Run Module Test') {
+            def testResultsDir = rootPath+"results"
+            sh "mkdir -p ${testResultsDir}"
             def dockerImage = docker.image('tfp-automation')
-            dockerImage.inside("-u root") {
-                sh "go test -v -timeout ${timeout} ${params.TEST_CASE} ${testsDir}"
+            if (rancher2ProviderVersion.contains("rc")) {
+               try {
+                 dockerImage.inside("-u root -v ${testResultsDir}:/results") {
+                   sh "gotestsum --format standard-verbose --packages=${testsDir} --junitfile results/${testResultsOut} --jsonfile results/${testResultsJSON} -- -timeout=${timeout} -v ${params.TEST_CASE}"
+                   sh "${rootPath}pipeline/scripts/build_qase_reporter.sh"
+                   sh "${rootPath}reporter"
+                  } 
+                 } catch(err) {
+                  echo 'Test run had failures. Collecting results...'
+                 }
+               }
+            else {
+                 try {
+                   dockerImage.inside("-u jenkins -v ${testResultsDir}:/results") {
+                     sh "gotestsum --format standard-verbose --packages=${testsDir} --junitfile results/${testResultsOut} --jsonfile results/${testResultsJSON} -- -timeout=${timeout} -v ${params.TEST_CASE}"
+                     sh "${rootPath}pipeline/scripts/build_qase_reporter.sh"
+                     sh "${rootPath}reporter"
+                   }
+                  } catch(err) {
+                    echo 'Test run had failures. Collecting results...'
+                  }
             }
+            step([$class: 'JUnitResultArchiver', testResults: "**/results/${testResultsOut}"])
+      }
     }
-}
+  }

--- a/Jenkinsfile_vpn
+++ b/Jenkinsfile_vpn
@@ -1,6 +1,14 @@
 #!groovy
 node {
+  def rootPath = "/home/jenkins/workspace/rancher_qa/tfp-automation-vsphere/"
   def testsDir = "./tests/${env.TEST_PACKAGE}"
+  def job_name = "${JOB_NAME}"
+  if (job_name.contains('/')) { 
+    job_names = job_name.split('/')
+    job_name = job_names[job_names.size() - 1] 
+  }
+  def testResultsOut = "results.xml"
+  def testResultsJSON = "results.json"
   def branch = "${env.BRANCH}"
   if ("${env.BRANCH}" != "null" && "${env.BRANCH}" != "") {
         branch = "${env.BRANCH}"
@@ -22,6 +30,7 @@ node {
         rancher2ProviderVersion = "${env.RANCHER2_PROVIDER_VERSION}" 
   }
   withCredentials([ string(credentialsId: 'EXTERNAL_ENCODED_VPN', variable: 'EXTERNAL_ENCODED_VPN'),
+                      string(credentialsId: 'QASE_AUTOMATION_TOKEN', variable: 'QASE_AUTOMATION_TOKEN'),
                       string(credentialsId: 'VPN_ENCODED_LOGIN', variable: 'VPN_ENCODED_LOGIN')]) {
   stage('Checkout') {
           deleteDir()
@@ -46,9 +55,16 @@ node {
     }
     stage('Run Module Test') {
             def dockerImage = docker.image('tfp-automation')
-            dockerImage.inside("-u root --privileged") {
-              sh "${runArgs} go test -v -timeout ${timeout} ${params.TEST_CASE} ${testsDir}"
+            try {
+              dockerImage.inside("-u root --privileged") {
+                sh "${runArgs} gotestsum --format standard-verbose --packages=${testsDir} --junitfile results/${testResultsOut} --jsonfile results/${testResultsJSON} -- -timeout=${timeout} -v ${params.TEST_CASE}"
+                sh "${rootPath}pipeline/scripts/build_qase_reporter.sh"
+                sh "${rootPath}reporter"
+              } 
+            } catch(err) {
+              echo 'Test run had failures. Collecting results...'
             }
+            step([$class: 'JUnitResultArchiver', testResults: "**/results/${testResultsOut}"])
     }
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21
 replace (
 	github.com/rancher/rancher/pkg/apis => github.com/rancher/rancher/pkg/apis v0.0.0-20230525094739-ff2e09449efc
 	github.com/rancher/rancher/pkg/client => github.com/rancher/rancher/pkg/client v0.0.0-20230525094739-ff2e09449efc
+	go.qase.io/client => github.com/rancher/qase-go/client v0.0.0-20231114201952-65195ec001fa
 	k8s.io/api => k8s.io/api v0.27.4
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.27.4
 	k8s.io/apimachinery => k8s.io/apimachinery v0.27.4
@@ -27,6 +28,8 @@ require (
 	github.com/rancher/shepherd v0.0.0-20240212210618-6f6f377a7e21
 	github.com/sirupsen/logrus v1.9.3
 )
+
+require github.com/antihax/optional v1.0.0
 
 require (
 	cloud.google.com/go v0.110.6 // indirect
@@ -174,6 +177,7 @@ require (
 	go.etcd.io/etcd/client/pkg/v3 v3.5.9 // indirect
 	go.etcd.io/etcd/client/v2 v2.305.7 // indirect
 	go.etcd.io/etcd/client/v3 v3.5.9 // indirect
+	go.qase.io/client v0.0.0-20231114201952-65195ec001fa
 	go.starlark.net v0.0.0-20230525235612-a134d8f9ddca // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.25.0 // indirect
@@ -185,7 +189,7 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20230803162519-f966b187b2e5 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230807174057-1744710a1577 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/apiextensions-apiserver v0.28.3 // indirect
 	k8s.io/cli-runtime v0.27.9 // indirect
 	k8s.io/client-go v12.0.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -243,6 +243,7 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:CgnQgUtFrFz9mxFNtED3jI5tLDjKlOM+oUF/sTk6ps0=
+github.com/antihax/optional v1.0.0 h1:xK2lYat7ZLaVVcIuj82J8kIro4V6kDe0AUDFboUCwcg=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20220418222510-f25a4f6275ed/go.mod h1:F7bn7fEU90QkQ3tnmaTx3LTKLEDqnwWODIYppRQ5hnY=
 github.com/antlr/antlr4/runtime/Go/antlr v1.4.10/go.mod h1:F7bn7fEU90QkQ3tnmaTx3LTKLEDqnwWODIYppRQ5hnY=
@@ -1107,6 +1108,8 @@ github.com/rancher/lasso v0.0.0-20230830164424-d684fdeb6f29 h1:+kige/h8/LnzWgPjB
 github.com/rancher/lasso v0.0.0-20230830164424-d684fdeb6f29/go.mod h1:kgk9kJVMj9FIrrXU0iyM6u/9Je4bEjPImqswkTVaKsQ=
 github.com/rancher/norman v0.0.0-20230831160711-5de27f66385d h1:Ft/iTH91TlE2oBGmpkdO4I8o8cvUmCnytdwu52a/tN4=
 github.com/rancher/norman v0.0.0-20230831160711-5de27f66385d/go.mod h1:Sm2Xqai+aecgmJ86ygyEe+TdPMLkauEpykSstBAu4Ko=
+github.com/rancher/qase-go/client v0.0.0-20231114201952-65195ec001fa h1:/qeYlQVfyvsO5yY0dZmm7mRTAsDm54jACiRDx3LAwsA=
+github.com/rancher/qase-go/client v0.0.0-20231114201952-65195ec001fa/go.mod h1:NP3xboG+t2p+XMnrcrJ/L384Ki0Cp3Pww/X+vm5Jcy0=
 github.com/rancher/rancher/pkg/apis v0.0.0-20230525094739-ff2e09449efc h1:NuDuqLYh97OXhaZprux8XXFO4z3ZYiNewfQHRJstggc=
 github.com/rancher/rancher/pkg/apis v0.0.0-20230525094739-ff2e09449efc/go.mod h1:4KAasaWJ3wmljgFGP4z08SVP4Snr1CWeY7McL4JFn+o=
 github.com/rancher/rke v1.5.0 h1:M/YryKnBs7IwzMGA2kh1EiypVQkme6o9KSg0hlllQa4=
@@ -1504,6 +1507,7 @@ golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20210628180205-a41e5a781914/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210805134026-6f1e6394065a/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
+golang.org/x/oauth2 v0.0.0-20211005180243-6b3c2da341f1/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
 golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=

--- a/pipeline/qase/defaults.go
+++ b/pipeline/qase/defaults.go
@@ -1,0 +1,8 @@
+package qase
+
+const (
+	RancherManagerProjectID = "RM"
+	QaseTokenEnvVar         = "QASE_AUTOMATION_TOKEN"
+	TestRunEnvVar           = "QASE_TEST_RUN_ID"
+	TestRunNAMEEnvVar       = "TEST_RUN_NAME"
+)

--- a/pipeline/qase/reporter/main.go
+++ b/pipeline/qase/reporter/main.go
@@ -1,0 +1,230 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/antihax/optional"
+	qasedefaults "github.com/rancher/tfp-automation/pipeline/qase"
+	"github.com/rancher/tfp-automation/pipeline/qase/testcase"
+	"github.com/sirupsen/logrus"
+	qase "go.qase.io/client"
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	automationSuiteID    = int32(14)
+	failStatus           = "fail"
+	passStatus           = "pass"
+	skipStatus           = "skip"
+	automationTestNameID = 15
+	testSourceID         = 14
+	testSource           = "GoValidation"
+	multiSubTestPattern  = `(\w+/\w+/\w+){1,}`
+	subtestPattern       = `(\w+/\w+){1,1}`
+	testResultsJSON      = "results/results.json"
+)
+
+var (
+	multiSubTestReg = regexp.MustCompile(multiSubTestPattern)
+	subTestReg      = regexp.MustCompile(subtestPattern)
+	qaseToken       = os.Getenv(qasedefaults.QaseTokenEnvVar)
+	runIDEnvVar     = os.Getenv(qasedefaults.TestRunEnvVar)
+)
+
+func main() {
+	if runIDEnvVar != "" {
+		cfg := qase.NewConfiguration()
+		cfg.AddDefaultHeader("Token", qaseToken)
+		client := qase.NewAPIClient(cfg)
+
+		runID, err := strconv.ParseInt(runIDEnvVar, 10, 64)
+		if err != nil {
+			logrus.Fatalf("error reporting converting string to int64: %v", err)
+		}
+
+		err = reportTestQases(client, runID)
+		if err != nil {
+			logrus.Error("error reporting: ", err)
+		}
+	}
+}
+
+func getAllAutomationTestCases(client *qase.APIClient) (map[string]qase.TestCase, error) {
+	testCases := []qase.TestCase{}
+	testCaseNameMap := map[string]qase.TestCase{}
+	var numOfTestsCases int32 = 1
+	offSetCount := 0
+	for numOfTestsCases > 0 {
+		offset := optional.NewInt32(int32(offSetCount))
+		localVarOptionals := &qase.CasesApiGetCasesOpts{
+			Offset: offset,
+		}
+		tempResult, _, err := client.CasesApi.GetCases(context.TODO(), qasedefaults.RancherManagerProjectID, localVarOptionals)
+		if err != nil {
+			return nil, err
+		}
+
+		testCases = append(testCases, tempResult.Result.Entities...)
+		numOfTestsCases = tempResult.Result.Count
+		offSetCount += 10
+	}
+
+	for _, testCase := range testCases {
+		automationTestNameCustomField := getAutomationTestName(testCase.CustomFields)
+		if automationTestNameCustomField != "" {
+			testCaseNameMap[automationTestNameCustomField] = testCase
+		} else {
+			testCaseNameMap[testCase.Title] = testCase
+		}
+
+	}
+
+	return testCaseNameMap, nil
+}
+
+func readTestCase() ([]testcase.GoTestOutput, error) {
+	file, err := os.Open(testResultsJSON)
+	if err != nil {
+		return nil, err
+	}
+
+	fscanner := bufio.NewScanner(file)
+	testCases := []testcase.GoTestOutput{}
+	for fscanner.Scan() {
+		var testCase testcase.GoTestOutput
+		err = yaml.Unmarshal(fscanner.Bytes(), &testCase)
+		if err != nil {
+			return nil, err
+		}
+		testCases = append(testCases, testCase)
+	}
+
+	return testCases, nil
+}
+
+func parseCorrectTestCases(testCases []testcase.GoTestOutput) map[string]*testcase.GoTestCase {
+	finalTestCases := map[string]*testcase.GoTestCase{}
+	var deletedTest string
+	for _, testCase := range testCases {
+		if testCase.Action == "run" && strings.Contains(testCase.Test, "/") {
+			newTestCase := &testcase.GoTestCase{Name: testCase.Test}
+			finalTestCases[testCase.Test] = newTestCase
+		} else if testCase.Action == "output" && strings.Contains(testCase.Test, "/") {
+			goTestCase := finalTestCases[testCase.Test]
+			goTestCase.StackTrace += testCase.Output
+		} else if testCase.Action == skipStatus {
+			delete(finalTestCases, testCase.Test)
+		} else if (testCase.Action == failStatus || testCase.Action == passStatus) && strings.Contains(testCase.Test, "/") {
+			goTestCase := finalTestCases[testCase.Test]
+
+			if goTestCase != nil {
+				substring := subTestReg.FindString(goTestCase.Name)
+				goTestCase.StackTrace += testCase.Output
+				goTestCase.Status = testCase.Action
+				goTestCase.Elapsed = testCase.Elapsed
+
+				if multiSubTestReg.MatchString(goTestCase.Name) && substring != deletedTest {
+					deletedTest = subTestReg.FindString(goTestCase.Name)
+					delete(finalTestCases, deletedTest)
+				}
+
+			}
+		}
+	}
+
+	return finalTestCases
+}
+
+func reportTestQases(client *qase.APIClient, testRunID int64) error {
+	tempTestCases, err := readTestCase()
+	if err != nil {
+		return nil
+	}
+
+	goTestCases := parseCorrectTestCases(tempTestCases)
+
+	qaseTestCases, err := getAllAutomationTestCases(client)
+	if err != nil {
+		return err
+	}
+
+	for _, goTestCase := range goTestCases {
+		if testQase, ok := qaseTestCases[goTestCase.Name]; ok {
+			// update test status
+			err = updateTestInRun(client, *goTestCase, testQase.Id, testRunID)
+			if err != nil {
+				return err
+			}
+		} else {
+			// write test case
+			caseID, err := writeTestCaseToQase(client, *goTestCase)
+			if err != nil {
+				return err
+			}
+			err = updateTestInRun(client, *goTestCase, caseID.Result.Id, testRunID)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func writeTestCaseToQase(client *qase.APIClient, testCase testcase.GoTestCase) (*qase.IdResponse, error) {
+	testQaseBody := qase.TestCaseCreate{
+		Title:      testCase.Name,
+		SuiteId:    int64(automationSuiteID),
+		IsFlaky:    int32(0),
+		Automation: int32(2),
+		CustomField: map[string]string{
+			fmt.Sprintf("%d", testSourceID): testSource,
+		},
+	}
+	caseID, _, err := client.CasesApi.CreateCase(context.TODO(), testQaseBody, qasedefaults.RancherManagerProjectID)
+	if err != nil {
+		return nil, err
+	}
+	return &caseID, err
+}
+
+func updateTestInRun(client *qase.APIClient, testCase testcase.GoTestCase, qaseTestCaseID, testRunID int64) error {
+	status := fmt.Sprintf("%sed", testCase.Status)
+	var elapsedTime float64
+	if testCase.Elapsed != "" {
+		var err error
+		elapsedTime, err = strconv.ParseFloat(testCase.Elapsed, 64)
+		if err != nil {
+			return err
+		}
+	}
+
+	resultBody := qase.ResultCreate{
+		CaseId:  qaseTestCaseID,
+		Status:  status,
+		Comment: testCase.StackTrace,
+		Time:    int64(elapsedTime),
+	}
+
+	_, _, err := client.ResultsApi.CreateResult(context.TODO(), resultBody, qasedefaults.RancherManagerProjectID, testRunID)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func getAutomationTestName(customFields []qase.CustomFieldValue) string {
+	for _, field := range customFields {
+		if field.Id == automationTestNameID {
+			return field.Value
+		}
+	}
+	return ""
+}

--- a/pipeline/qase/testcase/testcase.go
+++ b/pipeline/qase/testcase/testcase.go
@@ -1,0 +1,19 @@
+package testcase
+
+// GoTestOutput is the JSON output from gotestsum, this what is used to parse go test results.
+type GoTestOutput struct {
+	Time    string `json:"Time" yaml:"Time"`
+	Action  string `json:"Action" yaml:"Action"`
+	Package string `json:"Package" yaml:"Package"`
+	Test    string `json:"Test" yaml:"Test"`
+	Output  string `json:"Output" yaml:"Output"`
+	Elapsed string `json:"Elapsed" yaml:"Elapsed"`
+}
+
+// GoTestCase is the struct used for sending the appropriate API call to Qase
+type GoTestCase struct {
+	Name       string
+	Status     string
+	StackTrace string
+	Elapsed    string
+}

--- a/pipeline/qase/testrun/main.go
+++ b/pipeline/qase/testrun/main.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	qasedefaults "github.com/rancher/tfp-automation/pipeline/qase"
+	"github.com/sirupsen/logrus"
+	qase "go.qase.io/client"
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	runSourceID    = 16
+	recurringRunID = 1
+)
+
+var (
+	testRunName = os.Getenv(qasedefaults.TestRunNAMEEnvVar)
+	qaseToken   = os.Getenv(qasedefaults.QaseTokenEnvVar)
+)
+
+type RecurringTestRun struct {
+	ID int64 `json:"id" yaml:"id"`
+}
+
+func main() {
+	// commandline flags
+	startRun := flag.Bool("startRun", false, "commandline flag that determines when to start a run, and conversely when to end it.")
+	flag.Parse()
+
+	cfg := qase.NewConfiguration()
+	cfg.AddDefaultHeader("Token", qaseToken)
+	client := qase.NewAPIClient(cfg)
+
+	if *startRun {
+		// create test run
+		resp, err := createTestRun(client, testRunName)
+		if err != nil {
+			logrus.Error("error creating test run: ", err)
+		}
+
+		newRunID := resp.Result.Id
+		recurringTestRun := RecurringTestRun{}
+		recurringTestRun.ID = newRunID
+		err = writeToConfigFile(recurringTestRun)
+		if err != nil {
+			logrus.Error("error writiing test run config: ", err)
+		}
+	} else {
+
+		testRunConfig, err := readConfigFile()
+		if err != nil {
+			logrus.Fatalf("error reporting converting string to int32: %v", err)
+		}
+		// complete test run
+		_, _, err = client.RunsApi.CompleteRun(context.TODO(), qasedefaults.RancherManagerProjectID, int32(testRunConfig.ID))
+		if err != nil {
+			log.Fatalf("error completing test run: %v", err)
+		}
+	}
+
+}
+
+func createTestRun(client *qase.APIClient, testRunName string) (*qase.IdResponse, error) {
+	runCreateBody := qase.RunCreate{
+		Title: testRunName,
+		CustomField: map[string]string{
+			fmt.Sprintf("%d", runSourceID): fmt.Sprintf("%d", recurringRunID),
+		},
+	}
+
+	idResponse, _, err := client.RunsApi.CreateRun(context.TODO(), runCreateBody, qasedefaults.RancherManagerProjectID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &idResponse, nil
+}
+
+func writeToConfigFile(config RecurringTestRun) error {
+	yamlConfig, err := yaml.Marshal(config)
+
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile("testrunconfig.yaml", yamlConfig, 0644)
+}
+
+func readConfigFile() (*RecurringTestRun, error) {
+	configString, err := os.ReadFile("testrunconfig.yaml")
+	if err != nil {
+		return nil, err
+	}
+
+	var testRunConfig RecurringTestRun
+	err = yaml.Unmarshal(configString, &testRunConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return &testRunConfig, nil
+}

--- a/pipeline/scripts/build_qase_reporter.sh
+++ b/pipeline/scripts/build_qase_reporter.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+cd $(dirname $0)/../../
+if [[ -z "${QASE_TEST_RUN_ID}" ]]; then
+  echo "no test run ID is provided"
+else
+  echo "building qase reporter bin"
+  env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -buildvcs=false -o reporter ./pipeline/qase/reporter
+fi


### PR DESCRIPTION
### PR Description

Issue: https://github.com/rancher/qa-tasks/issues/1219

We are using Qase for internal tracking of automation in rancher/rancher tests that we run. We should ensure that we have this happening for the `tfp-automation` tests as well.

As there are underlying architecture differences from rancher/rancher and rancher/tfp-automation, there is duplicate code being copied over in this PR. Specifically, the `pipeline` folder is what is being copied over.