### PR TITLE
Update cluster pool names to avoid name conflicts

### DIFF
--- a/framework/set/provisioning/setRKE1Config.go
+++ b/framework/set/provisioning/setRKE1Config.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/rancher/shepherd/clients/rancher"
 	ranchFrame "github.com/rancher/shepherd/pkg/config"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
 	"github.com/rancher/tfp-automation/config"
 	azure "github.com/rancher/tfp-automation/framework/set/provisioning/providers/azure"
 	ec2 "github.com/rancher/tfp-automation/framework/set/provisioning/providers/ec2"
@@ -53,7 +54,7 @@ func SetRKE1(clusterName, k8sVersion, psact string, nodePools []config.Nodepool,
 
 	if strings.Contains(psact, rancherBaseline) {
 		newFile, rootBody = SetBaselinePSACT(newFile, rootBody)
-		
+
 		rootBody.AppendNewline()
 	}
 
@@ -66,9 +67,9 @@ func SetRKE1(clusterName, k8sVersion, psact string, nodePools []config.Nodepool,
 
 	if psact == "rancher-baseline" {
 		dependsOnTemp = hclwrite.Tokens{
-			{Type: hclsyntax.TokenIdent, Bytes: []byte("[rancher2_node_template.rancher2_node_template," + 
-			"rancher2_pod_security_admission_configuration_template.rancher2_pod_security_admission_configuration_template]")},
-		}	
+			{Type: hclsyntax.TokenIdent, Bytes: []byte("[rancher2_node_template.rancher2_node_template," +
+				"rancher2_pod_security_admission_configuration_template.rancher2_pod_security_admission_configuration_template]")},
+		}
 	}
 
 	clusterBlockBody.SetAttributeRaw("depends_on", dependsOnTemp)
@@ -143,8 +144,8 @@ func SetRKE1(clusterName, k8sVersion, psact string, nodePools []config.Nodepool,
 		}
 
 		nodePoolBlockBody.SetAttributeRaw("cluster_id", clusterID)
-		nodePoolBlockBody.SetAttributeValue("name", cty.StringVal("pool"+poolNum))
-		nodePoolBlockBody.SetAttributeValue("hostname_prefix", cty.StringVal(terraformConfig.HostnamePrefix+"-pool"+poolNum+"-"))
+		nodePoolBlockBody.SetAttributeValue("name", cty.StringVal(namegen.AppendRandomString("tfp-rke1")))
+		nodePoolBlockBody.SetAttributeValue("hostname_prefix", cty.StringVal(terraformConfig.HostnamePrefix+namegen.AppendRandomString("tfp")))
 
 		nodeTempID := hclwrite.Tokens{
 			{Type: hclsyntax.TokenIdent, Bytes: []byte("rancher2_node_template.rancher2_node_template.id")},

--- a/framework/set/provisioning/setRKE2K3sConfig.go
+++ b/framework/set/provisioning/setRKE2K3sConfig.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/rancher/shepherd/clients/rancher"
 	ranchFrame "github.com/rancher/shepherd/pkg/config"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
 	"github.com/rancher/tfp-automation/config"
 	azure "github.com/rancher/tfp-automation/framework/set/provisioning/providers/azure"
 	ec2 "github.com/rancher/tfp-automation/framework/set/provisioning/providers/ec2"
@@ -47,19 +48,19 @@ func SetRKE2K3s(clusterName, k8sVersion, psact string, nodePools []config.Nodepo
 
 	if strings.Contains(psact, rancherBaseline) {
 		newFile, rootBody = SetBaselinePSACT(newFile, rootBody)
-		
+
 		rootBody.AppendNewline()
 	}
 
 	machineConfigBlock := rootBody.AppendNewBlock("resource", []string{"rancher2_machine_config_v2", "rancher2_machine_config_v2"})
 	machineConfigBlockBody := machineConfigBlock.Body()
-	
+
 	if psact == "rancher-baseline" {
 		dependsOnTemp := hclwrite.Tokens{
-			{Type: hclsyntax.TokenIdent, Bytes: []byte("[rancher2_pod_security_admission_configuration_template." + 
-			"rancher2_pod_security_admission_configuration_template]")},
+			{Type: hclsyntax.TokenIdent, Bytes: []byte("[rancher2_pod_security_admission_configuration_template." +
+				"rancher2_pod_security_admission_configuration_template]")},
 		}
-	
+
 		machineConfigBlockBody.SetAttributeRaw("depends_on", dependsOnTemp)
 	}
 
@@ -101,7 +102,7 @@ func SetRKE2K3s(clusterName, k8sVersion, psact string, nodePools []config.Nodepo
 		machinePoolsBlock := rkeConfigBlockBody.AppendNewBlock("machine_pools", nil)
 		machinePoolsBlockBody := machinePoolsBlock.Body()
 
-		machinePoolsBlockBody.SetAttributeValue("name", cty.StringVal("tfp-pool"+poolNum))
+		machinePoolsBlockBody.SetAttributeValue("name", cty.StringVal(namegen.AppendRandomString("tfp-v2prov")))
 
 		cloudCredSecretName := hclwrite.Tokens{
 			{Type: hclsyntax.TokenIdent, Bytes: []byte("rancher2_cloud_credential.rancher2_cloud_credential.id")},


### PR DESCRIPTION
### PR Description
When using a node provider like Linode, you are not permitted to have duplicate naming with your instances. As a result, the cluster never provisions as the node never comes up.

For node providers like AWS, they allow duplicate names. This PR avoids naming conflicts to not hit this problem.