### PR TITLE
Enhance dynamic naming for cluster machine pools

### DIFF
--- a/framework/set/provisioning/setConfigTF.go
+++ b/framework/set/provisioning/setConfigTF.go
@@ -33,10 +33,10 @@ const (
 )
 
 // SetConfigTF is a function that will set the main.tf file based on the module type.
-func SetConfigTF(clusterConfig *config.TerratestConfig, clusterName string) error {
+func SetConfigTF(clusterConfig *config.TerratestConfig, clusterName, poolName string) error {
 	rancherConfig := new(rancher.Config)
 	framework.LoadConfig("rancher", rancherConfig)
-	
+
 	terraformConfig := new(config.TerraformConfig)
 	framework.LoadConfig("terraform", terraformConfig)
 
@@ -64,10 +64,10 @@ func SetConfigTF(clusterConfig *config.TerratestConfig, clusterName string) erro
 		err = SetGKE(clusterName, clusterConfig.KubernetesVersion, clusterConfig.Nodepools, file)
 		return err
 	case strings.Contains(module, rke1):
-		err = SetRKE1(clusterName, clusterConfig.KubernetesVersion, clusterConfig.PSACT, clusterConfig.Nodepools, clusterConfig.SnapshotInput, file)
+		err = SetRKE1(clusterName, poolName, clusterConfig.KubernetesVersion, clusterConfig.PSACT, clusterConfig.Nodepools, clusterConfig.SnapshotInput, file)
 		return err
 	case strings.Contains(module, rke2) || strings.Contains(module, k3s):
-		err = SetRKE2K3s(clusterName, clusterConfig.KubernetesVersion, clusterConfig.PSACT, clusterConfig.Nodepools, clusterConfig.SnapshotInput, file)
+		err = SetRKE2K3s(clusterName, poolName, clusterConfig.KubernetesVersion, clusterConfig.PSACT, clusterConfig.Nodepools, clusterConfig.SnapshotInput, file)
 		return err
 	default:
 		logrus.Errorf("Unsupported module: %v", module)

--- a/framework/set/provisioning/setRKE1Config.go
+++ b/framework/set/provisioning/setRKE1Config.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/rancher/shepherd/clients/rancher"
 	ranchFrame "github.com/rancher/shepherd/pkg/config"
-	namegen "github.com/rancher/shepherd/pkg/namegenerator"
 	"github.com/rancher/tfp-automation/config"
 	azure "github.com/rancher/tfp-automation/framework/set/provisioning/providers/azure"
 	ec2 "github.com/rancher/tfp-automation/framework/set/provisioning/providers/ec2"
@@ -20,7 +19,7 @@ import (
 )
 
 // SetRKE1 is a function that will set the RKE1 configurations in the main.tf file.
-func SetRKE1(clusterName, k8sVersion, psact string, nodePools []config.Nodepool, snapshots config.Snapshots, file *os.File) error {
+func SetRKE1(clusterName, poolName, k8sVersion, psact string, nodePools []config.Nodepool, snapshots config.Snapshots, file *os.File) error {
 	rancherConfig := new(rancher.Config)
 	ranchFrame.LoadConfig("rancher", rancherConfig)
 
@@ -122,6 +121,7 @@ func SetRKE1(clusterName, k8sVersion, psact string, nodePools []config.Nodepool,
 	rootBody.AppendNewline()
 
 	clusterSyncNodePoolIDs := ""
+
 	for count, pool := range nodePools {
 		poolNum := strconv.Itoa(count)
 
@@ -144,8 +144,8 @@ func SetRKE1(clusterName, k8sVersion, psact string, nodePools []config.Nodepool,
 		}
 
 		nodePoolBlockBody.SetAttributeRaw("cluster_id", clusterID)
-		nodePoolBlockBody.SetAttributeValue("name", cty.StringVal(namegen.AppendRandomString("tfp-rke1")))
-		nodePoolBlockBody.SetAttributeValue("hostname_prefix", cty.StringVal(terraformConfig.HostnamePrefix+namegen.AppendRandomString("tfp")))
+		nodePoolBlockBody.SetAttributeValue("name", cty.StringVal(poolName+poolNum))
+		nodePoolBlockBody.SetAttributeValue("hostname_prefix", cty.StringVal(terraformConfig.HostnamePrefix+"-"+poolName))
 
 		nodeTempID := hclwrite.Tokens{
 			{Type: hclsyntax.TokenIdent, Bytes: []byte("rancher2_node_template.rancher2_node_template.id")},

--- a/framework/set/provisioning/setRKE2K3sConfig.go
+++ b/framework/set/provisioning/setRKE2K3sConfig.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/rancher/shepherd/clients/rancher"
 	ranchFrame "github.com/rancher/shepherd/pkg/config"
-	namegen "github.com/rancher/shepherd/pkg/namegenerator"
 	"github.com/rancher/tfp-automation/config"
 	azure "github.com/rancher/tfp-automation/framework/set/provisioning/providers/azure"
 	ec2 "github.com/rancher/tfp-automation/framework/set/provisioning/providers/ec2"
@@ -20,7 +19,7 @@ import (
 )
 
 // SetRKE2K3s is a function that will set the RKE2/K3S configurations in the main.tf file.
-func SetRKE2K3s(clusterName, k8sVersion, psact string, nodePools []config.Nodepool, snapshots config.Snapshots, file *os.File) error {
+func SetRKE2K3s(clusterName, poolName, k8sVersion, psact string, nodePools []config.Nodepool, snapshots config.Snapshots, file *os.File) error {
 	rancherConfig := new(rancher.Config)
 	ranchFrame.LoadConfig("rancher", rancherConfig)
 
@@ -102,7 +101,7 @@ func SetRKE2K3s(clusterName, k8sVersion, psact string, nodePools []config.Nodepo
 		machinePoolsBlock := rkeConfigBlockBody.AppendNewBlock("machine_pools", nil)
 		machinePoolsBlockBody := machinePoolsBlock.Body()
 
-		machinePoolsBlockBody.SetAttributeValue("name", cty.StringVal(namegen.AppendRandomString("tfp-v2prov")))
+		machinePoolsBlockBody.SetAttributeValue("name", cty.StringVal(poolName+poolNum))
 
 		cloudCredSecretName := hclwrite.Tokens{
 			{Type: hclsyntax.TokenIdent, Bytes: []byte("rancher2_cloud_credential.rancher2_cloud_credential.id")},

--- a/framework/setup.go
+++ b/framework/setup.go
@@ -22,7 +22,7 @@ func Setup(t *testing.T) *terraform.Options {
 
 	keyPath := set.SetKeyPath()
 
-	err := set.SetConfigTF(clusterConfig, "")
+	err := set.SetConfigTF(clusterConfig, "", "")
 	require.NoError(t, err)
 
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{

--- a/tests/extensions/provisioning/buildModule.go
+++ b/tests/extensions/provisioning/buildModule.go
@@ -22,7 +22,7 @@ func BuildModule(t *testing.T) error {
 
 	keyPath := set.SetKeyPath()
 
-	err := set.SetConfigTF(clusterConfig, "")
+	err := set.SetConfigTF(clusterConfig, "", "")
 	if err != nil {
 		return err
 	}

--- a/tests/extensions/provisioning/kubernetesUpgrade.go
+++ b/tests/extensions/provisioning/kubernetesUpgrade.go
@@ -12,11 +12,11 @@ import (
 
 // KubernetesUpgrade is a function that will run terraform apply and uprade the
 // Kubernetes version of the provisioned cluster.
-func KubernetesUpgrade(t *testing.T, client *rancher.Client, clusterName string, terraformOptions *terraform.Options,
+func KubernetesUpgrade(t *testing.T, client *rancher.Client, clusterName, poolName string, terraformOptions *terraform.Options,
 	terraformConfig *config.TerraformConfig, clusterConfig *config.TerratestConfig) {
 	DefaultUpgradedK8sVersion(t, client, clusterConfig, terraformConfig)
 
-	err := set.SetConfigTF(clusterConfig, clusterName)
+	err := set.SetConfigTF(clusterConfig, clusterName, poolName)
 	require.NoError(t, err)
 
 	terraform.Apply(t, terraformOptions)

--- a/tests/extensions/provisioning/provision.go
+++ b/tests/extensions/provisioning/provision.go
@@ -15,8 +15,8 @@ const (
 )
 
 // Provision is a function that will run terraform init and apply Terraform resources to provision a cluster.
-func Provision(t *testing.T, client *rancher.Client, clusterName string, clusterConfig *config.TerratestConfig, terraformOptions *terraform.Options) {
-	err := set.SetConfigTF(clusterConfig, clusterName)
+func Provision(t *testing.T, client *rancher.Client, clusterName, poolName string, clusterConfig *config.TerratestConfig, terraformOptions *terraform.Options) {
+	err := set.SetConfigTF(clusterConfig, clusterName, poolName)
 	require.NoError(t, err)
 
 	isSupported := SupportedModules(terraformOptions)

--- a/tests/extensions/provisioning/scale.go
+++ b/tests/extensions/provisioning/scale.go
@@ -11,8 +11,8 @@ import (
 
 // Scale is a function that will run terraform apply and scale the provisioned
 // cluster, according to user's desired amount.
-func Scale(t *testing.T, clusterName string, terraformOptions *terraform.Options, clusterConfig *config.TerratestConfig) {
-	err := set.SetConfigTF(clusterConfig, clusterName)
+func Scale(t *testing.T, clusterName, poolName string, terraformOptions *terraform.Options, clusterConfig *config.TerratestConfig) {
+	err := set.SetConfigTF(clusterConfig, clusterName, poolName)
 	require.NoError(t, err)
 
 	terraform.Apply(t, terraformOptions)

--- a/tests/nodescaling/scale_test.go
+++ b/tests/nodescaling/scale_test.go
@@ -119,20 +119,21 @@ func (s *ScaleTestSuite) TestTfpScale() {
 			s.clusterConfig.KubernetesVersion
 
 		clusterName := namegen.AppendRandomString(provisioning.TFP)
+		poolName := namegen.AppendRandomString(provisioning.TFP)
 
 		s.Run((tt.name), func() {
-			provisioning.Provision(s.T(), tt.client, clusterName, &clusterConfig, s.terraformOptions)
+			provisioning.Provision(s.T(), tt.client, clusterName, poolName, &clusterConfig, s.terraformOptions)
 			provisioning.VerifyCluster(s.T(), tt.client, clusterName, s.terraformConfig, s.terraformOptions, &clusterConfig)
 
 			clusterConfig.Nodepools = clusterConfig.ScalingInput.ScaledUpNodepools
 
-			provisioning.Scale(s.T(), clusterName, s.terraformOptions, &clusterConfig)
+			provisioning.Scale(s.T(), clusterName, poolName, s.terraformOptions, &clusterConfig)
 			provisioning.VerifyCluster(s.T(), tt.client, clusterName, s.terraformConfig, s.terraformOptions, &clusterConfig)
 			provisioning.VerifyNodeCount(s.T(), tt.client, clusterName, scaledUpCount)
 
 			clusterConfig.Nodepools = clusterConfig.ScalingInput.ScaledDownNodepools
 
-			provisioning.Scale(s.T(), clusterName, s.terraformOptions, &clusterConfig)
+			provisioning.Scale(s.T(), clusterName, poolName, s.terraformOptions, &clusterConfig)
 			provisioning.VerifyCluster(s.T(), tt.client, clusterName, s.terraformConfig, s.terraformOptions, &clusterConfig)
 			provisioning.VerifyNodeCount(s.T(), tt.client, clusterName, scaledDownCount)
 
@@ -153,22 +154,23 @@ func (s *ScaleTestSuite) TestTfpScaleDynamicInput() {
 		tt.name = tt.name + " Module: " + s.terraformConfig.Module + " Kubernetes version: " + s.clusterConfig.KubernetesVersion
 
 		clusterName := namegen.AppendRandomString(provisioning.TFP)
+		poolName := namegen.AppendRandomString(provisioning.TFP)
 
 		s.Run((tt.name), func() {
 			defer cleanup.Cleanup(s.T(), s.terraformOptions)
 
-			provisioning.Provision(s.T(), tt.client, clusterName, s.clusterConfig, s.terraformOptions)
+			provisioning.Provision(s.T(), tt.client, clusterName, poolName, s.clusterConfig, s.terraformOptions)
 			provisioning.VerifyCluster(s.T(), s.client, clusterName, s.terraformConfig, s.terraformOptions, s.clusterConfig)
 
 			s.clusterConfig.Nodepools = s.clusterConfig.ScalingInput.ScaledUpNodepools
 
-			provisioning.Scale(s.T(), clusterName, s.terraformOptions, s.clusterConfig)
+			provisioning.Scale(s.T(), clusterName, poolName, s.terraformOptions, s.clusterConfig)
 			provisioning.VerifyCluster(s.T(), s.client, clusterName, s.terraformConfig, s.terraformOptions, s.clusterConfig)
 			provisioning.VerifyNodeCount(s.T(), s.client, clusterName, s.clusterConfig.ScalingInput.ScaledUpNodeCount)
 
 			s.clusterConfig.Nodepools = s.clusterConfig.ScalingInput.ScaledDownNodepools
 
-			provisioning.Scale(s.T(), clusterName, s.terraformOptions, s.clusterConfig)
+			provisioning.Scale(s.T(), clusterName, poolName, s.terraformOptions, s.clusterConfig)
 			provisioning.VerifyCluster(s.T(), s.client, clusterName, s.terraformConfig, s.terraformOptions, s.clusterConfig)
 			provisioning.VerifyNodeCount(s.T(), s.client, clusterName, s.clusterConfig.ScalingInput.ScaledDownNodeCount)
 		})

--- a/tests/provisioning/provision_test.go
+++ b/tests/provisioning/provision_test.go
@@ -97,11 +97,12 @@ func (p *ProvisionTestSuite) TestTfpProvision() {
 			p.clusterConfig.KubernetesVersion
 
 		clusterName := namegen.AppendRandomString(provisioning.TFP)
+		poolName := namegen.AppendRandomString(provisioning.TFP)
 
 		p.Run((tt.name), func() {
 			defer cleanup.Cleanup(p.T(), p.terraformOptions)
 
-			provisioning.Provision(p.T(), tt.client, clusterName, &clusterConfig, p.terraformOptions)
+			provisioning.Provision(p.T(), tt.client, clusterName, poolName, &clusterConfig, p.terraformOptions)
 			provisioning.VerifyCluster(p.T(), tt.client, clusterName, p.terraformConfig, p.terraformOptions, &clusterConfig)
 		})
 	}
@@ -119,11 +120,12 @@ func (p *ProvisionTestSuite) TestTfpProvisionDynamicInput() {
 		tt.name = tt.name + " Module: " + p.terraformConfig.Module + " Kubernetes version: " + p.clusterConfig.KubernetesVersion
 
 		clusterName := namegen.AppendRandomString(provisioning.TFP)
+		poolName := namegen.AppendRandomString(provisioning.TFP)
 
 		p.Run((tt.name), func() {
 			defer cleanup.Cleanup(p.T(), p.terraformOptions)
 
-			provisioning.Provision(p.T(), tt.client, clusterName, p.clusterConfig, p.terraformOptions)
+			provisioning.Provision(p.T(), tt.client, clusterName, poolName, p.clusterConfig, p.terraformOptions)
 			provisioning.VerifyCluster(p.T(), p.client, clusterName, p.terraformConfig, p.terraformOptions, p.clusterConfig)
 		})
 	}

--- a/tests/psact/psact_test.go
+++ b/tests/psact/psact_test.go
@@ -111,11 +111,12 @@ func (p *PSACTTestSuite) TestTfpPSACT() {
 		tt.name = tt.name + " Module: " + p.terraformConfig.Module + " Kubernetes version: " + p.clusterConfig.KubernetesVersion
 
 		clusterName := namegen.AppendRandomString(provisioning.TFP)
+		poolName := namegen.AppendRandomString(provisioning.TFP)
 
 		p.Run((tt.name), func() {
 			defer cleanup.Cleanup(p.T(), p.terraformOptions)
 
-			provisioning.Provision(p.T(), tt.client, clusterName, &clusterConfig, p.terraformOptions)
+			provisioning.Provision(p.T(), tt.client, clusterName, poolName, &clusterConfig, p.terraformOptions)
 			provisioning.VerifyCluster(p.T(), tt.client, clusterName, p.terraformConfig, p.terraformOptions, &clusterConfig)
 		})
 	}

--- a/tests/snapshot/snapshot_restore_k8s_upgrade_test.go
+++ b/tests/snapshot/snapshot_restore_k8s_upgrade_test.go
@@ -116,14 +116,15 @@ func (s *SnapshotRestoreK8sUpgradeTestSuite) TestTfpSnapshotRestoreK8sUpgrade() 
 		tt.name = tt.name + " Module: " + s.terraformConfig.Module + " Kubernetes version: " + s.clusterConfig.KubernetesVersion
 
 		clusterName := namegen.AppendRandomString(provisioning.TFP)
+		poolName := namegen.AppendRandomString(provisioning.TFP)
 
 		s.Run(tt.name, func() {
 			defer cleanup.Cleanup(s.T(), s.terraformOptions)
 
-			provisioning.Provision(s.T(), tt.client, clusterName, &clusterConfig, s.terraformOptions)
+			provisioning.Provision(s.T(), tt.client, clusterName, poolName, &clusterConfig, s.terraformOptions)
 			provisioning.VerifyCluster(s.T(), tt.client, clusterName, s.terraformConfig, s.terraformOptions, &clusterConfig)
 
-			snapshotRestore(s.T(), s.client, clusterName, &clusterConfig, s.terraformOptions)
+			snapshotRestore(s.T(), s.client, clusterName, poolName, &clusterConfig, s.terraformOptions)
 		})
 	}
 }
@@ -144,14 +145,15 @@ func (s *SnapshotRestoreK8sUpgradeTestSuite) TestTfpSnapshotRestoreK8sUpgradeDyn
 		tt.name = tt.name + " Module: " + s.terraformConfig.Module + " Kubernetes version: " + s.clusterConfig.KubernetesVersion
 
 		clusterName := namegen.AppendRandomString(provisioning.TFP)
+		poolName := namegen.AppendRandomString(provisioning.TFP)
 
 		s.Run((tt.name), func() {
 			defer cleanup.Cleanup(s.T(), s.terraformOptions)
 
-			provisioning.Provision(s.T(), tt.client, clusterName, s.clusterConfig, s.terraformOptions)
+			provisioning.Provision(s.T(), tt.client, clusterName, poolName, s.clusterConfig, s.terraformOptions)
 			provisioning.VerifyCluster(s.T(), s.client, clusterName, s.terraformConfig, s.terraformOptions, s.clusterConfig)
 
-			snapshotRestore(s.T(), s.client, clusterName, s.clusterConfig, s.terraformOptions)
+			snapshotRestore(s.T(), s.client, clusterName, poolName, s.clusterConfig, s.terraformOptions)
 		})
 	}
 }

--- a/tests/snapshot/snapshot_restore_test.go
+++ b/tests/snapshot/snapshot_restore_test.go
@@ -106,14 +106,15 @@ func (s *SnapshotRestoreTestSuite) TestTfpSnapshotRestoreETCDOnly() {
 		tt.name = tt.name + " Module: " + s.terraformConfig.Module + " Kubernetes version: " + s.clusterConfig.KubernetesVersion
 
 		clusterName := namegen.AppendRandomString(provisioning.TFP)
+		poolName := namegen.AppendRandomString(provisioning.TFP)
 
 		s.Run(tt.name, func() {
 			defer cleanup.Cleanup(s.T(), s.terraformOptions)
 
-			provisioning.Provision(s.T(), tt.client, clusterName, &clusterConfig, s.terraformOptions)
+			provisioning.Provision(s.T(), tt.client, clusterName, poolName, &clusterConfig, s.terraformOptions)
 			provisioning.VerifyCluster(s.T(), tt.client, clusterName, s.terraformConfig, s.terraformOptions, &clusterConfig)
 
-			snapshotRestore(s.T(), s.client, clusterName, &clusterConfig, s.terraformOptions)
+			snapshotRestore(s.T(), s.client, clusterName, poolName, &clusterConfig, s.terraformOptions)
 		})
 	}
 }
@@ -134,14 +135,15 @@ func (s *SnapshotRestoreTestSuite) TestTfpSnapshotRestoreETCDOnlyDynamicInput() 
 		tt.name = tt.name + " Module: " + s.terraformConfig.Module + " Kubernetes version: " + s.clusterConfig.KubernetesVersion
 
 		clusterName := namegen.AppendRandomString(provisioning.TFP)
+		poolName := namegen.AppendRandomString(provisioning.TFP)
 
 		s.Run((tt.name), func() {
 			defer cleanup.Cleanup(s.T(), s.terraformOptions)
 
-			provisioning.Provision(s.T(), tt.client, clusterName, s.clusterConfig, s.terraformOptions)
+			provisioning.Provision(s.T(), tt.client, clusterName, poolName, s.clusterConfig, s.terraformOptions)
 			provisioning.VerifyCluster(s.T(), s.client, clusterName, s.terraformConfig, s.terraformOptions, s.clusterConfig)
 
-			snapshotRestore(s.T(), s.client, clusterName, s.clusterConfig, s.terraformOptions)
+			snapshotRestore(s.T(), s.client, clusterName, poolName, s.clusterConfig, s.terraformOptions)
 		})
 	}
 }

--- a/tests/snapshot/snapshot_restore_upgrade_strategy_test.go
+++ b/tests/snapshot/snapshot_restore_upgrade_strategy_test.go
@@ -122,14 +122,15 @@ func (s *SnapshotRestoreUpgradeStrategyTestSuite) TestTfpSnapshotRestoreUpgradeS
 		tt.name = tt.name + " Module: " + s.terraformConfig.Module + " Kubernetes version: " + s.clusterConfig.KubernetesVersion
 
 		clusterName := namegen.AppendRandomString(provisioning.TFP)
+		poolName := namegen.AppendRandomString(provisioning.TFP)
 
 		s.Run(tt.name, func() {
 			defer cleanup.Cleanup(s.T(), s.terraformOptions)
 
-			provisioning.Provision(s.T(), tt.client, clusterName, &clusterConfig, s.terraformOptions)
+			provisioning.Provision(s.T(), tt.client, clusterName, poolName, &clusterConfig, s.terraformOptions)
 			provisioning.VerifyCluster(s.T(), tt.client, clusterName, s.terraformConfig, s.terraformOptions, &clusterConfig)
 
-			snapshotRestore(s.T(), s.client, clusterName, &clusterConfig, s.terraformOptions)
+			snapshotRestore(s.T(), s.client, clusterName, poolName, &clusterConfig, s.terraformOptions)
 		})
 	}
 }
@@ -150,14 +151,15 @@ func (s *SnapshotRestoreUpgradeStrategyTestSuite) TestTfpSnapshotRestoreUpgradeS
 		tt.name = tt.name + " Module: " + s.terraformConfig.Module + " Kubernetes version: " + s.clusterConfig.KubernetesVersion
 
 		clusterName := namegen.AppendRandomString(provisioning.TFP)
+		poolName := namegen.AppendRandomString(provisioning.TFP)
 
 		s.Run((tt.name), func() {
 			defer cleanup.Cleanup(s.T(), s.terraformOptions)
 
-			provisioning.Provision(s.T(), tt.client, clusterName, s.clusterConfig, s.terraformOptions)
+			provisioning.Provision(s.T(), tt.client, clusterName, poolName, s.clusterConfig, s.terraformOptions)
 			provisioning.VerifyCluster(s.T(), s.client, clusterName, s.terraformConfig, s.terraformOptions, s.clusterConfig)
 
-			snapshotRestore(s.T(), s.client, clusterName, s.clusterConfig, s.terraformOptions)
+			snapshotRestore(s.T(), s.client, clusterName, poolName, s.clusterConfig, s.terraformOptions)
 		})
 	}
 }

--- a/tests/upgrading/kubernetes_upgrade_test.go
+++ b/tests/upgrading/kubernetes_upgrade_test.go
@@ -94,14 +94,15 @@ func (k *KubernetesUpgradeTestSuite) TestTfpKubernetesUpgrade() {
 		tt.name = tt.name + " Module: " + k.terraformConfig.Module + " Kubernetes version: " + k.clusterConfig.KubernetesVersion
 
 		clusterName := namegen.AppendRandomString(provisioning.TFP)
+		poolName := namegen.AppendRandomString(provisioning.TFP)
 
 		k.Run((tt.name), func() {
 			defer cleanup.Cleanup(k.T(), k.terraformOptions)
 
-			provisioning.Provision(k.T(), tt.client, clusterName, &clusterConfig, k.terraformOptions)
+			provisioning.Provision(k.T(), tt.client, clusterName, poolName, &clusterConfig, k.terraformOptions)
 			provisioning.VerifyCluster(k.T(), tt.client, clusterName, k.terraformConfig, k.terraformOptions, &clusterConfig)
 
-			provisioning.KubernetesUpgrade(k.T(), tt.client, clusterName, k.terraformOptions, k.terraformConfig, &clusterConfig)
+			provisioning.KubernetesUpgrade(k.T(), tt.client, clusterName, poolName, k.terraformOptions, k.terraformConfig, &clusterConfig)
 			provisioning.VerifyCluster(k.T(), tt.client, clusterName, k.terraformConfig, k.terraformOptions, &clusterConfig)
 			provisioning.VerifyUpgradedKubernetesVersion(k.T(), tt.client, k.terraformConfig, clusterName,
 				k.clusterConfig.UpgradedKubernetesVersion)
@@ -121,14 +122,15 @@ func (k *KubernetesUpgradeTestSuite) TestTfpKubernetesUpgradeDynamicInput() {
 		tt.name = tt.name + " Module: " + k.terraformConfig.Module + " Kubernetes version: " + k.clusterConfig.KubernetesVersion
 
 		clusterName := namegen.AppendRandomString(provisioning.TFP)
+		poolName := namegen.AppendRandomString(provisioning.TFP)
 
 		k.Run((tt.name), func() {
 			defer cleanup.Cleanup(k.T(), k.terraformOptions)
 
-			provisioning.Provision(k.T(), tt.client, clusterName, k.clusterConfig, k.terraformOptions)
+			provisioning.Provision(k.T(), tt.client, clusterName, poolName, k.clusterConfig, k.terraformOptions)
 			provisioning.VerifyCluster(k.T(), k.client, clusterName, k.terraformConfig, k.terraformOptions, k.clusterConfig)
 
-			provisioning.KubernetesUpgrade(k.T(), tt.client, clusterName, k.terraformOptions, k.terraformConfig, k.clusterConfig)
+			provisioning.KubernetesUpgrade(k.T(), tt.client, clusterName, poolName, k.terraformOptions, k.terraformConfig, k.clusterConfig)
 			provisioning.VerifyCluster(k.T(), k.client, clusterName, k.terraformConfig, k.terraformOptions, k.clusterConfig)
 			provisioning.VerifyUpgradedKubernetesVersion(k.T(), k.client, k.terraformConfig, clusterName,
 				k.clusterConfig.UpgradedKubernetesVersion)


### PR DESCRIPTION
### PR Description
When running non-provisioning tests such as nodescaling, the `main.tf` was resetting the node pool/machine pool name. This was causing failures in tests. As a result, we were unable to properly get passing tests.

This enhances this and fixes the failures we were seeing.