### PR TITLE
Refactor hosted clusters tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,19 +147,19 @@ The `terraform` configurations in the `cattle-config.yaml` are module specific. 
       <td>tf-aks</td>
     </tr>
     <tr>
-      <td>azureClientID</td>
+      <td>clientID</td>
       <td>provide azure client id</td>
       <td>string</td>
       <td>XXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX</td>
     </tr>
     <tr>
-      <td>azureClientSecret</td>
+      <td>clientSecret</td>
       <td>provide azure client secret</td>
       <td>string</td>
       <td>XXXXXXXXXXXXXXXXXXXXXXXXXX</td>
     </tr>
     <tr>
-      <td>azureSubscriptionID</td>
+      <td>subscriptionID</td>
       <td>provide azure subscription id</td>
       <td>string</td>
       <td>XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX</td>
@@ -217,22 +217,20 @@ The `terraform` configurations in the `cattle-config.yaml` are module specific. 
 
 ```yaml
 terraform:
-  providerVersion: '3.2.0'
   module: aks
   cloudCredentialName: tf-aks
   azureConfig:
-    azureClientID: XXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-    azureClientSecret: XXXXXXXXXXXXXXXXXXXXXXXXXX
-    azureSubscriptionID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-    resourceGroup: my-resource-group
+    clientID: ""
+    clientSecret: ""
+    subscriptionID: ""
+    resourceGroup: ""
     resourceLocation: eastus
-    hostnamePrefix: tf-prefix
-    networkPlugin: kubenet
     availabilityZones:
       - '1'
       - '2'
       - '3'
     osDiskSizeGB: 128
+    tenantId: ""
     vmSize: Standard_DS2_v2
 ```
 
@@ -250,12 +248,6 @@ terraform:
       <th>Description</th>
       <th>Type</th>
       <th>Example</th>
-    </tr>
-    <tr>
-      <td>providerVersion</td>
-      <td>rancher2 provider version</td>
-      <td>string</td>
-      <td>'3.2.0'</td>
     </tr>
     <tr>
       <td>module</td>
@@ -340,24 +332,21 @@ terraform:
 
 ```yaml
 terraform:
-  providerVersion: '3.2.0'
   module: eks
   cloudCredentialName: tf-eks
   hostnamePrefix: tfp
   awsConfig:
-    awsAccessKey: XXXXXXXXXXXXXXXXXXXX
-    awsSecretKey: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+    awsAccessKey: ""
+    awsSecretKey: ""
     awsInstanceType: t3.medium
     region: us-east-2
     awsSubnets:
-      - subnet-xxxxxxxx
-      - subnet-yyyyyyyy
-      - subnet-zzzzzzzz
+      - ""
+      - ""
     awsSecurityGroups:
-      - sg-xxxxxxxxxxxxxxxxx
+      - ""
     publicAccess: true
     privateAccess: true
-    nodeRole: arn:aws:iam::############:role/my-custom-NodeInstanceRole-############
 ```
 
 ---
@@ -378,43 +367,37 @@ terraform:
       <th>Example</th>
     </tr>
     <tr>
-      <td>providerVersion</td>
-      <td>rancher2 provider version</td>
-      <td>string</td>
-      <td>'3.2.0'</td>
-    </tr>
-    <tr>
       <td>module</td>
       <td>specify terraform module here</td>
       <td>string</td>
-      <td>eks</td>
+      <td>gke</td>
     </tr>
     <tr>
       <td>cloudCredentialName</td>
       <td>provide the name of unique cloud credentials to be created during testing</td>
       <td>string</td>
-      <td>tf-eks</td>
+      <td>tf-gke</td>
     </tr>
     <tr>
       <td>region</td>
       <td>provide region for resources to be created in</td>
       <td>string</td>
-      <td>us-central1-a</td>
+      <td>us-central1-c</td>
     </tr>
     <tr>
-      <td>gkeProjectID</td>
+      <td>projectID</td>
       <td>provide gke project ID</td>
       <td>string</td>
       <td>my-project-id-here</td>
     </tr>
     <tr>
-      <td>gkeNetwork</td>
+      <td>network</td>
       <td>specify network here</td>
       <td>string</td>
       <td>default</td>
     </tr>
     <tr>
-      <td>gkeSubnetwork</td>
+      <td>subnetwork</td>
       <td>specify subnetwork here</td>
       <td>string</td>
       <td>default</td>
@@ -432,15 +415,27 @@ terraform:
 
 ```yaml
 terraform:
-  providerVersion: '3.2.0'
   module: gke
   cloudCredentialName: tf-creds-gke
   hostnamePrefix: tfp
-  google:
-    region: us-central1-a
-    gkeProjectID: my-project-id-here
-    gkeNetwork: default
-    gkeSubnetwork: default
+  googleConfig:
+    authEncodedJson: |-
+      {
+        "type": "service_account",
+        "project_id": "",
+        "private_key_id": "",
+        "private_key": "",
+        "client_email": "",
+        "client_id": "",
+        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+        "token_uri": "https://oauth2.googleapis.com/token",
+        "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+        "client_x509_cert_url": ""
+      }
+    region: us-central1-c
+    projectID: ""
+    network: default
+    subnetwork: default
 ```
 
 ---
@@ -457,12 +452,6 @@ terraform:
       <th>Description</th>
       <th>Type</th>
       <th>Example</th>
-    </tr>
-    <tr>
-      <td>providerVersion</td>
-      <td>rancher2 provider version</td>
-      <td>string</td>
-      <td>'3.2.0'</td>
     </tr>
     <tr>
       <td>module</td>
@@ -603,7 +592,6 @@ terraform:
 
 ```yaml
 terraform:
-  providerVersion: '3.2.0'
   module: azure_rke1
   networkPlugin: canal
   nodeTemplateName: tf-rke1-template
@@ -645,12 +633,6 @@ terraform:
       <th>Description</th>
       <th>Type</th>
       <th>Example</th>
-    </tr>
-    <tr>
-      <td>providerVersion</td>
-      <td>rancher2 provider version</td>
-      <td>string</td>
-      <td>'3.2.0'</td>
     </tr>
     <tr>
       <td>module</td>
@@ -743,7 +725,6 @@ terraform:
 
 ```yaml
 terraform:
-  providerVersion: '3.2.0'
   module: ec2_rke1
   networkPlugin: canal
   nodeTemplateName: tf-rke1-template
@@ -776,12 +757,6 @@ terraform:
       <th>Description</th>
       <th>Type</th>
       <th>Example</th>
-    </tr>
-    <tr>
-      <td>providerVersion</td>
-      <td>rancher2 provider version</td>
-      <td>string</td>
-      <td>'3.2.0'</td>
     </tr>
     <tr>
       <td>module</td>
@@ -831,7 +806,6 @@ terraform:
 ##### Example:
 ```yaml
 terraform:
-  providerVersion: '3.2.0'
   module: linode_rke1
   networkPlugin: canal
   nodeTemplateName: tf-rke1-template
@@ -856,12 +830,6 @@ terraform:
       <th>Description</th>
       <th>Type</th>
       <th>Example</th>
-    </tr>
-    <tr>
-      <td>providerVersion</td>
-      <td>rancher2 provider version</td>
-      <td>string</td>
-      <td>'3.2.0'</td>
     </tr>
     <tr>
       <td>module</td>
@@ -1014,7 +982,6 @@ terraform:
 
 ```yaml
 terraform:
-  providerVersion: '3.2.0'
   module: vsphere_rke1
   networkPlugin: canal
   nodeTemplateName: tf-rke1-template
@@ -1059,12 +1026,6 @@ terraform:
       <th>Description</th>
       <th>Type</th>
       <th>Example</th>
-    </tr>
-    <tr>
-      <td>providerVersion</td>
-      <td>rancher2 provider version</td>
-      <td>string</td>
-      <td>'3.2.0'</td>
     </tr>
     <tr>
       <td>module</td>
@@ -1211,7 +1172,6 @@ terraform:
 
 ```yaml
 terraform:
-  providerVersion: '3.2.0'
   module: azure_k3s
   networkPlugin: canal
   nodeTemplateName: tf-rke1-template
@@ -1255,12 +1215,6 @@ terraform:
       <th>Description</th>
       <th>Type</th>
       <th>Example</th>
-    </tr>
-    <tr>
-      <td>providerVersion</td>
-      <td>rancher2 provider version</td>
-      <td>string</td>
-      <td>'3.2.0'</td>
     </tr>
     <tr>
       <td>module</td>
@@ -1346,7 +1300,6 @@ terraform:
 ##### Example:
 ```yaml
 terraform:
-  providerVersion: '3.2.0'
   module: ec2_rke2
   cloudCredentialName: tf-creds-rke2
   machineConfigName: tf-rke2
@@ -1379,12 +1332,6 @@ terraform:
       <th>Description</th>
       <th>Type</th>
       <th>Example</th>
-    </tr>
-    <tr>
-      <td>providerVersion</td>
-      <td>rancher2 provider version</td>
-      <td>string</td>
-      <td>'3.2.0'</td>
     </tr>
     <tr>
       <td>module</td>
@@ -1446,7 +1393,6 @@ terraform:
 ##### Example:
 ```yaml
 terraform:
-  providerVersion: '3.2.0'
   module: linode_k3s
   cloudCredentialName: tf-linode-creds
   machineConfigName: tf-k3s
@@ -1473,12 +1419,6 @@ terraform:
       <th>Description</th>
       <th>Type</th>
       <th>Example</th>
-    </tr>
-    <tr>
-      <td>providerVersion</td>
-      <td>rancher2 provider version</td>
-      <td>string</td>
-      <td>'3.2.0'</td>
     </tr>
     <tr>
       <td>module</td>
@@ -1631,7 +1571,6 @@ terraform:
 
 ```yaml
 terraform:
-  providerVersion: '3.2.0'
   module: vsphere_k3s
   networkPlugin: canal
   nodeTemplateName: tf-rke1-template
@@ -1802,29 +1741,29 @@ terratest:
       etcd: false
       controlplane: false
       worker: true
-  kubernetesVersion: v1.27.8-rancher2-1
+  kubernetesVersion: ""
   nodeCount: 3
 
 
   # Below are the expected formats for all module kubernetes versions
   
   # AKS without leading v
-  # e.g. '1.24.6'
+  # e.g. '1.28.5'
   
   # EKS without leading v or any tail ending
-  # e.g. '1.23' or '1.24'
+  # e.g. '1.28'
   
   # GKE without leading v but with tail ending included
-  # e.g. 1.23.12-gke.100
+  # e.g. 1.28.7-gke.1026000
   
   # RKE1 with leading v and -rancher1-1 tail
-  # e.g. v1.24.9-rancher1-1
+  # e.g. v1.28.7-rancher1-1
 
   # RKE2 with leading v and +rke2r# tail
-  # e.g. v1.24.9+rke2r1
+  # e.g. v1.28.7+rke2r1
 
   # K3S with leading v and +k3s# tail
-  # e.g. v1.24.9+k3s1
+  # e.g. v1.28.7+k3s1
 ```
 
 Note: In this test suite, Terraform explicitly cleans up resources after each test case is performed. This is because Terraform will experience caching issues, causing tests to fail.
@@ -1893,7 +1832,7 @@ Note: In this test suite, Terraform explicitly cleans up resources after each te
 ```yaml
 # this example is valid for RKE1 scale
 terratest:
-  kubernetesVersion: v1.27.8-rancher2-1
+  kubernetesVersion: ""
   nodeCount: 3
   scaledUpNodeCount: 8
   scaledDownNodeCount: 6
@@ -2000,8 +1939,8 @@ terratest:
       controlplane: false
       worker: true
   nodeCount: 3
-  kubernetesVersion: v1.26.11+k3s2
-  upgradedKubernetesVersion: v1.27.8+k3s2
+  kubernetesVersion: ""
+  upgradedKubernetesVersion: ""
 ```
 Note: In this test suite, Terraform explicitly cleans up resources after each test case is performed. This is because Terraform will experience caching issues, causing tests to fail.
 

--- a/config/nodeproviders/google_config.go
+++ b/config/nodeproviders/google_config.go
@@ -1,8 +1,9 @@
 package nodeproviders
 
 type GoogleConfig struct {
-	GKENetwork    string `json:"gkeNetwork,omitempty" yaml:"gkeNetwork,omitempty"`
-	GKEProjectID  string `json:"gkeProjectID,omitempty" yaml:"gkeProjectID,omitempty"`
-	GKESubnetwork string `json:"gkeSubnetwork,omitempty" yaml:"gkeSubnetwork,omitempty"`
-	Region        string `json:"region,omitempty" yaml:"region,omitempty"`
+	AuthEncodedJSON string `json:"authEncodedJson" yaml:"authEncodedJson"`
+	Network         string `json:"network,omitempty" yaml:"network,omitempty"`
+	ProjectID       string `json:"projectID,omitempty" yaml:"projectID,omitempty"`
+	Subnetwork      string `json:"subnetwork,omitempty" yaml:"subnetwork,omitempty"`
+	Region          string `json:"region,omitempty" yaml:"region,omitempty"`
 }

--- a/framework/set/provisioning/setAKS.go
+++ b/framework/set/provisioning/setAKS.go
@@ -37,6 +37,7 @@ func SetAKS(clusterName, k8sVersion string, nodePools []config.Nodepool, file *o
 	azCredConfigBlockBody.SetAttributeValue("client_id", cty.StringVal(terraformConfig.AzureConfig.ClientID))
 	azCredConfigBlockBody.SetAttributeValue("client_secret", cty.StringVal(terraformConfig.AzureConfig.ClientSecret))
 	azCredConfigBlockBody.SetAttributeValue("subscription_id", cty.StringVal(terraformConfig.AzureConfig.SubscriptionID))
+	azCredConfigBlockBody.SetAttributeValue("tenant_id", cty.StringVal(terraformConfig.AzureConfig.TenantID))
 
 	rootBody.AppendNewline()
 

--- a/framework/set/provisioning/setGKE.go
+++ b/framework/set/provisioning/setGKE.go
@@ -21,9 +21,6 @@ func SetGKE(clusterName, k8sVersion string, nodePools []config.Nodepool, file *o
 	terraformConfig := new(config.TerraformConfig)
 	framework.LoadConfig("terraform", terraformConfig)
 
-	googleAuthEncodedJSONConfig := new(config.GoogleAuthEncodedJSON)
-	framework.LoadConfig("googleAuthEncodedJSON", googleAuthEncodedJSONConfig)
-
 	newFile, rootBody := SetProvidersTF(rancherConfig, terraformConfig)
 
 	rootBody.AppendNewline()
@@ -34,12 +31,7 @@ func SetGKE(clusterName, k8sVersion string, nodePools []config.Nodepool, file *o
 	cloudCredBlockBody.SetAttributeValue("name", cty.StringVal(terraformConfig.CloudCredentialName))
 
 	googleCredConfigBlock := cloudCredBlockBody.AppendNewBlock("google_credential_config", nil)
-
-	authEncodedJSON := hclwrite.Tokens{
-		{Type: hclsyntax.TokenIdent, Bytes: []byte(`jsonencode({"type" = "` + googleAuthEncodedJSONConfig.Type + `", "project_id" = "` + googleAuthEncodedJSONConfig.ProjectID + `", "private_key_id" = "` + googleAuthEncodedJSONConfig.PrivateKeyID + `", "private_key" = "` + googleAuthEncodedJSONConfig.PrivateKey + `", "client_email" = "` + googleAuthEncodedJSONConfig.ClientEmail + `", "client_id" = "` + googleAuthEncodedJSONConfig.ClientID + `", "auth_uri" = "` + googleAuthEncodedJSONConfig.AuthURI + `", "token_uri" = "` + googleAuthEncodedJSONConfig.TokenURI + `", "auth_provider_x509_cert_url" = "` + googleAuthEncodedJSONConfig.AuthProviderX509CertURL + `", "client_x509_cert_url" = "` + googleAuthEncodedJSONConfig.ClientX509CertURL + `"})`)},
-	}
-
-	googleCredConfigBlock.Body().SetAttributeRaw("auth_encoded_json", authEncodedJSON)
+	googleCredConfigBlock.Body().SetAttributeValue("auth_encoded_json", cty.StringVal(terraformConfig.GoogleConfig.AuthEncodedJSON))
 
 	rootBody.AppendNewline()
 
@@ -59,10 +51,10 @@ func SetGKE(clusterName, k8sVersion string, nodePools []config.Nodepool, file *o
 
 	gkeConfigBlockBody.SetAttributeRaw("google_credential_secret", cloudCredSecret)
 	gkeConfigBlockBody.SetAttributeValue("region", cty.StringVal(terraformConfig.GoogleConfig.Region))
-	gkeConfigBlockBody.SetAttributeValue("project_id", cty.StringVal(terraformConfig.GoogleConfig.GKEProjectID))
+	gkeConfigBlockBody.SetAttributeValue("project_id", cty.StringVal(terraformConfig.GoogleConfig.ProjectID))
 	gkeConfigBlockBody.SetAttributeValue("kubernetes_version", cty.StringVal(k8sVersion))
-	gkeConfigBlockBody.SetAttributeValue("network", cty.StringVal(terraformConfig.GoogleConfig.GKENetwork))
-	gkeConfigBlockBody.SetAttributeValue("subnetwork", cty.StringVal(terraformConfig.GoogleConfig.GKESubnetwork))
+	gkeConfigBlockBody.SetAttributeValue("network", cty.StringVal(terraformConfig.GoogleConfig.Network))
+	gkeConfigBlockBody.SetAttributeValue("subnetwork", cty.StringVal(terraformConfig.GoogleConfig.Subnetwork))
 
 	for count, pool := range nodePools {
 		poolNum := strconv.Itoa(count)

--- a/framework/wait/state/activeCluster.go
+++ b/framework/wait/state/activeCluster.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/defaults"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
@@ -19,7 +20,7 @@ const (
 // IsActiveCluster is a function that will wait for the cluster to be in an active state.
 func IsActiveCluster(client *rancher.Client, clusterID string) error {
 	isWaiting := true
-	err := wait.Poll(10*time.Second, 10*time.Minute, func() (done bool, err error) {
+	err := wait.Poll(10*time.Second, defaults.ThirtyMinuteTimeout, func() (done bool, err error) {
 		cluster, err := client.Management.Cluster.ByID(clusterID)
 		if err != nil {
 			return false, err

--- a/framework/wait/state/activeNodes.go
+++ b/framework/wait/state/activeNodes.go
@@ -5,13 +5,14 @@ import (
 
 	"github.com/rancher/norman/types"
 	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/defaults"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 // AreNodesActive is a function that will wait for all nodes in the cluster to be in an active state.
 func AreNodesActive(client *rancher.Client, clusterID string) error {
-	err := wait.Poll(10*time.Second, 10*time.Minute, func() (bool, error) {
+	err := wait.Poll(10*time.Second, defaults.ThirtyMinuteTimeout, func() (bool, error) {
 		nodes, err := client.Management.Node.ListAll(&types.ListOpts{
 			Filters: map[string]interface{}{
 				"clusterId": clusterID,

--- a/tests/nodescaling/README.md
+++ b/tests/nodescaling/README.md
@@ -31,9 +31,11 @@ To see what goes into the `terraform` block in addition to the `rancher`, please
 ## Scaling Node Pools
 Similar to the `provisioning` tests, the node scaling tests have static test cases as well as dynamicInput tests you can specify. In order to run the dynamicInput tests, you will need to define the `terratest` block in your config file. See an example below:
 
+### RKE1/RKE2/K3S
+
 ```yaml
 terratest:
-  kubernetesVersion: "v1.28.6+k3s2"
+  kubernetesVersion: ""
   nodeCount: 3
   scaledUpNodeCount: 8
   scaledDownNodeCount: 6
@@ -80,9 +82,78 @@ terratest:
         quantity: 1
   ```
 
+### AKS
+
+```yaml
+terratest:
+  kubernetesVersion: ""
+  nodeCount: 3
+  scaledUpNodeCount: 8
+  scaledDownNodeCount: 6
+  nodepools:
+    - quantity: 3
+  scalingInput:
+    scaledUpNodepools:
+      - quantity: 8
+    scaledDownNodepools:
+      - quantity: 6
+```
+
+### EKS
+
+```yaml
+terratest:
+  kubernetesVersion: ""
+  nodeCount: 3
+  scaledUpNodeCount: 8
+  scaledDownNodeCount: 6
+  nodepools:
+    - instanceType: "t3.medium"
+      desiredSize: 3
+      maxSize: 10
+      minSize: 3
+  scalingInput:
+    scaledUpNodepools:
+      - instanceType: "t3.medium"
+        desiredSize: 8
+        maxSize: 10
+        minSize: 3
+    scaledDownNodepools:
+      - instanceType: "t3.medium"
+        desiredSize: 6
+        maxSize: 10
+        minSize: 3
+```
+
+### GKE
+
+```yaml
+terratest:
+  kubernetesVersion: ""
+  nodeCount: 3
+  scaledUpNodeCount: 8
+  scaledDownNodeCount: 6
+  nodepools:
+    - quantity: 3
+      maxPodsContraint: 110
+  scalingInput:
+    scaledUpNodepools:
+      - quantity: 8
+        maxPodsContraint: 110
+    scaledDownNodepools:
+      - quantity: 6
+        maxPodsContraint: 110
+```
+
 See the below examples on how to run the tests:
+
+### RKE1/RKE2/K3S
 
 `gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/nodescaling --junitfile results.xml -- -timeout=60m -v -run "TestTfpScaleTestSuite/TestTfpScale$"` \
 `gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/nodescaling --junitfile results.xml -- -timeout=60m -v -run "TestTfpScaleTestSuite/TestTfpScaleDynamicInput$"`
+
+### Hosted
+
+`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/nodescaling --junitfile results.xml -- -timeout=60m -v -run "TestTfpScaleHostedTestSuite/TestTfpScaleHosted$"`
 
 If the specified test passes immediately without warning, try adding the -count=1 flag to get around this issue. This will avoid previous results from interfering with the new test run.

--- a/tests/provisioning/README.md
+++ b/tests/provisioning/README.md
@@ -29,13 +29,19 @@ The provisioning tests have static test cases as well as dynamicInput tests you 
 
 ```yaml
 terratest:
-  kubernetesVersion: "v1.28.6+k3s2"
+  kubernetesVersion: ""
   psact: "" # Optional, can be left out or can have values `rancher-privileged` or `rancher-restricted`
   ```
 
 See the below examples on how to run the tests:
 
+### RKE1/RKE2/K3S
+
 `gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/provisioning --junitfile results.xml -- -timeout=60m -v -run "TestTfpProvisionTestSuite/TestTfpProvision$"` \
 `gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/provisioning --junitfile results.xml -- -timeout=60m -v -run "TestTfpProvisionTestSuite/TestTfpProvisionDynamicInput$"`
+
+### Hosted
+
+`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/provisioning --junitfile results.xml -- -timeout=60m -v -run "TestTfpProvisionHostedTestSuite/TestTfpProvisionHosted$"`
 
 If the specified test passes immediately without warning, try adding the -count=1 flag to get around this issue. This will avoid previous results from interfering with the new test run.

--- a/tests/provisioning/provision_hosted_test.go
+++ b/tests/provisioning/provision_hosted_test.go
@@ -1,0 +1,102 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/extensions/users"
+	password "github.com/rancher/shepherd/extensions/users/passwordgenerator"
+	ranchFrame "github.com/rancher/shepherd/pkg/config"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/framework"
+	cleanup "github.com/rancher/tfp-automation/framework/cleanup"
+	"github.com/rancher/tfp-automation/tests/extensions/provisioning"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type ProvisionHostedTestSuite struct {
+	suite.Suite
+	client             *rancher.Client
+	standardUserClient *rancher.Client
+	session            *session.Session
+	terraformConfig    *config.TerraformConfig
+	clusterConfig      *config.TerratestConfig
+	terraformOptions   *terraform.Options
+}
+
+func (p *ProvisionHostedTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	p.session = testSession
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(p.T(), err)
+
+	p.client = client
+
+	enabled := true
+	var testuser = namegen.AppendRandomString("testuser-")
+	var testpassword = password.GenerateUserPassword("testpass-")
+	user := &management.User{
+		Username: testuser,
+		Password: testpassword,
+		Name:     testuser,
+		Enabled:  &enabled,
+	}
+
+	newUser, err := users.CreateUserWithRole(client, user, "user")
+	require.NoError(p.T(), err)
+
+	newUser.Password = user.Password
+
+	standardUserClient, err := client.AsUser(newUser)
+	require.NoError(p.T(), err)
+
+	p.standardUserClient = standardUserClient
+
+	terraformConfig := new(config.TerraformConfig)
+	ranchFrame.LoadConfig(config.TerraformConfigurationFileKey, terraformConfig)
+
+	p.terraformConfig = terraformConfig
+
+	clusterConfig := new(config.TerratestConfig)
+	ranchFrame.LoadConfig(config.TerratestConfigurationFileKey, clusterConfig)
+
+	p.clusterConfig = clusterConfig
+
+	terraformOptions := framework.Setup(p.T())
+	p.terraformOptions = terraformOptions
+
+	provisioning.DefaultK8sVersion(p.T(), p.client, p.clusterConfig, p.terraformConfig)
+}
+
+func (p *ProvisionHostedTestSuite) TestTfpProvisionHosted() {
+	tests := []struct {
+		name   string
+		client *rancher.Client
+	}{
+		{config.StandardClientName.String(), p.standardUserClient},
+	}
+
+	for _, tt := range tests {
+		tt.name = tt.name + " Module: " + p.terraformConfig.Module + " Kubernetes version: " + p.clusterConfig.KubernetesVersion
+
+		clusterName := namegen.AppendRandomString(provisioning.TFP)
+		poolName := namegen.AppendRandomString(provisioning.TFP)
+
+		p.Run((tt.name), func() {
+			defer cleanup.Cleanup(p.T(), p.terraformOptions)
+
+			provisioning.Provision(p.T(), tt.client, clusterName, poolName, p.clusterConfig, p.terraformOptions)
+			provisioning.VerifyCluster(p.T(), p.client, clusterName, p.terraformConfig, p.terraformOptions, p.clusterConfig)
+		})
+	}
+}
+
+func TestTfpProvisionHostedTestSuite(t *testing.T) {
+	suite.Run(t, new(ProvisionHostedTestSuite))
+}

--- a/tests/psact/README.md
+++ b/tests/psact/README.md
@@ -47,7 +47,7 @@ terraform:
     region: "us-east"
     linodeRootPass: "<placeholder>"
 terratest:
-  kubernetesVersion: "v1.28.6+k3s2"
+  kubernetesVersion: ""
   ```
 
 See the below examples on how to run the tests:

--- a/tests/snapshot/README.md
+++ b/tests/snapshot/README.md
@@ -48,7 +48,7 @@ Similar to the `provisioning` tests, the snapshot tests have static test cases a
 
 ```yaml
 terratest:
-  kubernetesVersion: "v1.28.6+k3s2"
+  kubernetesVersion: ""
   snapshotInput:
     upgradeKubernetesVersion: "" # If left blank, the default version in Rancher will be used.
     snapshotRestore: "all" # Options include none, kubernetesVersion, all. Option 'none' means that only the etcd will be restored.

--- a/tests/upgrading/README.md
+++ b/tests/upgrading/README.md
@@ -31,8 +31,8 @@ Similar to the `provisioning` tests, the node scaling tests have static test cas
 
 ```yaml
 terratest:
-  kubernetesVersion: "v1.27.10+k3s2"
-  upgradedKubernetesVersion: "" # If left blank or is omitted completely, the latest version in Rancher will be used
+  kubernetesVersion: ""
+  upgradedKubernetesVersion: "" # If left blank or is omitted completely, the latest version in Rancher will be used. This is only for RKE1/RKE2/K3s. Hosted clusters MUST have this filled out.
   psact: "" # Optional, can be left out or can have values `rancher-privileged` or `rancher-restricted`
   ```
 
@@ -40,7 +40,13 @@ Additionally, you will need to ensure that the initial cluster version is NOT th
 
 See the below examples on how to run the tests:
 
+### RKE1/RKE2/K3S
+
 `gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/upgrading --junitfile results.xml -- -timeout=60m -v -run "TestTfpKubernetesUpgradeTestSuite/TestTfpKubernetesUpgrade$"` \
 `gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/upgrading --junitfile results.xml -- -timeout=60m -v -run "TestTfpKubernetesUpgradeTestSuite/TestTfpKubernetesUpgradeDynamicInput$"`
+
+### Hosted
+
+`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/upgrading --junitfile results.xml -- -timeout=60m -v -run "TestTfpKubernetesUpgradeHostedTestSuite/TestTfpKubernetesUpgradeHosted$"`
 
 If the specified test passes immediately without warning, try adding the -count=1 flag to get around this issue. This will avoid previous results from interfering with the new test run.

--- a/tests/upgrading/kubernetes_hosted_test.go
+++ b/tests/upgrading/kubernetes_hosted_test.go
@@ -1,0 +1,105 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/extensions/users"
+	password "github.com/rancher/shepherd/extensions/users/passwordgenerator"
+	ranchFrame "github.com/rancher/shepherd/pkg/config"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/framework"
+	cleanup "github.com/rancher/tfp-automation/framework/cleanup"
+	"github.com/rancher/tfp-automation/tests/extensions/provisioning"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type KubernetesUpgradeHostedTestSuite struct {
+	suite.Suite
+	client             *rancher.Client
+	standardUserClient *rancher.Client
+	session            *session.Session
+	terraformConfig    *config.TerraformConfig
+	clusterConfig      *config.TerratestConfig
+	terraformOptions   *terraform.Options
+}
+
+func (k *KubernetesUpgradeHostedTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	k.session = testSession
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(k.T(), err)
+
+	k.client = client
+
+	enabled := true
+	var testuser = namegen.AppendRandomString("testuser-")
+	var testpassword = password.GenerateUserPassword("testpass-")
+	user := &management.User{
+		Username: testuser,
+		Password: testpassword,
+		Name:     testuser,
+		Enabled:  &enabled,
+	}
+
+	newUser, err := users.CreateUserWithRole(client, user, "user")
+	require.NoError(k.T(), err)
+
+	newUser.Password = user.Password
+
+	standardUserClient, err := client.AsUser(newUser)
+	require.NoError(k.T(), err)
+
+	k.standardUserClient = standardUserClient
+
+	terraformConfig := new(config.TerraformConfig)
+	ranchFrame.LoadConfig(config.TerraformConfigurationFileKey, terraformConfig)
+
+	k.terraformConfig = terraformConfig
+
+	clusterConfig := new(config.TerratestConfig)
+	ranchFrame.LoadConfig(config.TerratestConfigurationFileKey, clusterConfig)
+
+	k.clusterConfig = clusterConfig
+
+	terraformOptions := framework.Setup(k.T())
+	k.terraformOptions = terraformOptions
+}
+
+func (k *KubernetesUpgradeHostedTestSuite) TestTfpKubernetesUpgradeHosted() {
+	tests := []struct {
+		name   string
+		client *rancher.Client
+	}{
+		{config.StandardClientName.String(), k.standardUserClient},
+	}
+
+	for _, tt := range tests {
+		tt.name = tt.name + " Module: " + k.terraformConfig.Module + " Kubernetes version: " + k.clusterConfig.KubernetesVersion
+
+		clusterName := namegen.AppendRandomString(provisioning.TFP)
+		poolName := namegen.AppendRandomString(provisioning.TFP)
+
+		k.Run((tt.name), func() {
+			defer cleanup.Cleanup(k.T(), k.terraformOptions)
+
+			provisioning.Provision(k.T(), tt.client, clusterName, poolName, k.clusterConfig, k.terraformOptions)
+			provisioning.VerifyCluster(k.T(), k.client, clusterName, k.terraformConfig, k.terraformOptions, k.clusterConfig)
+
+			provisioning.KubernetesUpgrade(k.T(), tt.client, clusterName, poolName, k.terraformOptions, k.terraformConfig, k.clusterConfig)
+			provisioning.VerifyCluster(k.T(), k.client, clusterName, k.terraformConfig, k.terraformOptions, k.clusterConfig)
+			provisioning.VerifyUpgradedKubernetesVersion(k.T(), k.client, k.terraformConfig, clusterName,
+				k.clusterConfig.UpgradedKubernetesVersion)
+		})
+	}
+}
+
+func TestTfpKubernetesUpgradeHostedTestSuite(t *testing.T) {
+	suite.Run(t, new(KubernetesUpgradeHostedTestSuite))
+}


### PR DESCRIPTION
### Issue: [Refactor hosted clusters tests in tfp-automation to have parity with Rancher clusters](https://github.com/rancher/qa-tasks/issues/1225)

### PR Description
The `tfp-automation` framework supported hosted clusters as part of the initial MVP. However, as it was passed off to the highlanders team, this overtime has become outdated code in the framework. As it seems there's been more of an ask to have hosted clusters again, this PR is updating the outdated code.

Additionally, it fixes underlying issues found such as the need to have them separated into their own test files. Provisioning, upgrading and node scaling are supported for AKS/EKS/GKE.