### PR TITLE
Refactor framework to put constants in default folder

### DIFF
--- a/defaults/annotations/annotations.go
+++ b/defaults/annotations/annotations.go
@@ -1,0 +1,5 @@
+package annotations
+
+const (
+	MachineNameAnnotation = "cluster.x-k8s.io/machine"
+)

--- a/defaults/clusterstate/clusterstate.go
+++ b/defaults/clusterstate/clusterstate.go
@@ -1,0 +1,9 @@
+package clusterstate
+
+const (
+	ActiveState   = "active"
+	ErrorState    = "error"
+	True          = "True"
+	UpdatingState = "updating"
+	WaitingState  = "waiting"
+)

--- a/defaults/clustertypes/clustertypes.go
+++ b/defaults/clustertypes/clustertypes.go
@@ -1,0 +1,12 @@
+package clustertypes
+
+const (
+	AKS     = "aks"
+	EKS     = "eks"
+	GKE     = "gke"
+	Local   = "local"
+	RKE1    = "rke1"
+	RKE2    = "rke2"
+	K3S     = "k3s"
+	RANCHER = "-rancher"
+)

--- a/defaults/configs/configs.go
+++ b/defaults/configs/configs.go
@@ -1,0 +1,14 @@
+package configs
+
+const (
+	Rancher   = "rancher"
+	Terraform = "terraform"
+	Terratest = "terratest"
+	TFP       = "tfp"
+
+	MainTF          = "/main.tf"
+	TerraformFolder = "/.terraform"
+	TFState         = "/terraform.tfstate"
+	TFStateBackup   = "/terraform.tfstate.backup"
+	TFLockHCL       = "/.terraform.lock.hcl"
+)

--- a/defaults/kubernetes/kubernetes.go
+++ b/defaults/kubernetes/kubernetes.go
@@ -1,0 +1,17 @@
+package kubernetes
+
+const (
+	All                    = "all"
+	ContainerImage         = "nginx"
+	ContainerName          = "nginx"
+	DefaultNamespace       = "default"
+	IsCattleLabeled        = true
+	IngressPath            = "/index.html"
+	InitialIngressName     = "ingress-before-restore"
+	InitialWorkloadName    = "wload-before-restore"
+	KubernetesVersion      = "kubernetesVersion"
+	Namespace              = "fleet-default"
+	Port                   = "port"
+	ServiceAppendName      = "service-"
+	WorkloadNamePostBackup = "wload-after-backup"
+)

--- a/defaults/modules/modules.go
+++ b/defaults/modules/modules.go
@@ -1,0 +1,17 @@
+package modules
+
+const (
+	AzureRKE1   = "azure_rke1"
+	AzureRKE2   = "azure_rke2"
+	AzureK3s    = "azure_k3s"
+	EC2         = "ec2"
+	EC2RKE1     = "ec2_rke1"
+	EC2RKE2     = "ec2_rke2"
+	EC2K3s      = "ec2_k3s"
+	LinodeRKE1  = "linode_rke1"
+	LinodeRKE2  = "linode_rke2"
+	LinodeK3s   = "linode_k3s"
+	VsphereRKE1 = "vsphere_rke1"
+	VsphereRKE2 = "vsphere_rke2"
+	VsphereK3s  = "vsphere_k3s"
+)

--- a/defaults/qase/qase.go
+++ b/defaults/qase/qase.go
@@ -1,0 +1,20 @@
+package qase
+
+const (
+	AutomationSuiteID       = int32(554)
+	AutomationTestNameID    = 15
+	FailStatus              = "fail"
+	MultiSubTestPattern     = `(\w+/\w+/\w+){1,}`
+	PassStatus              = "pass"
+	QaseTokenEnvVar         = "QASE_AUTOMATION_TOKEN"
+	RancherManagerProjectID = "RM"
+	RecurringRunID          = 1
+	RunSourceID             = 16
+	SkipStatus              = "skip"
+	SubtestPattern          = `(\w+/\w+){1,1}`
+	TestResultsJSON         = "results/results.json"
+	TestRunEnvVar           = "QASE_TEST_RUN_ID"
+	TestRunNAMEEnvVar       = "TEST_RUN_NAME"
+	TestSource              = "GoValidation"
+	TestSourceID            = 14
+)

--- a/defaults/resourceblocks/nodeproviders/amazon/amazonBlocks.go
+++ b/defaults/resourceblocks/nodeproviders/amazon/amazonBlocks.go
@@ -1,0 +1,27 @@
+package amazon
+
+const (
+	EC2CredentialConfig = "amazonec2_credential_config"
+	DefaultRegion       = "default_region"
+
+	EC2Config = "amazonec2_config"
+	EKSConfig = "eks_config_v2"
+
+	Subnets        = "subnets"
+	SecurityGroups = "security_groups"
+	PrivateAccess  = "private_access"
+	PublicAccess   = "public_access"
+
+	AMI           = "ami"
+	SecurityGroup = "security_group"
+	SubnetID      = "subnet_id"
+	VPCID         = "vpc_id"
+	Zone          = "zone"
+	RootSize      = "root_size"
+
+	NodeGroups   = "node_groups"
+	InstanceType = "instance_type"
+	DesiredSize  = "desired_size"
+	MaxSize      = "max_size"
+	MinSize      = "min_size"
+)

--- a/defaults/resourceblocks/nodeproviders/azure/azureBlocks.go
+++ b/defaults/resourceblocks/nodeproviders/azure/azureBlocks.go
@@ -1,0 +1,42 @@
+package azure
+
+const (
+	AzureCredentialConfig = "azure_credential_config"
+	ClientID              = "client_id"
+	ClientSecret          = "client_secret"
+	Environment           = "environment"
+	SubscriptionID        = "subscription_id"
+	TenantID              = "tenant_id"
+
+	AKSConfig   = "aks_config_v2"
+	AzureConfig = "azure_config"
+	NodePools   = "node_pools"
+
+	ResourceGroup    = "resource_group"
+	ResourceLocation = "resource_location"
+	DNSPrefix        = "dns_prefix"
+	NetworkPlugin    = "network_plugin"
+
+	AvailabilitySet   = "availability_set"
+	CustomData        = "custom_data"
+	DiskSize          = "disk_size"
+	FaultDomainCount  = "fault_domain_count"
+	Image             = "image"
+	Location          = "location"
+	ManagedDisks      = "managed_disks"
+	NoPublicIP        = "no_public_ip"
+	OpenPort          = "open_port"
+	PrivateIPAddress  = "private_ip_address"
+	Size              = "size"
+	SSHUser           = "ssh_user"
+	StaticPublicIP    = "static_public_ip"
+	StorageType       = "storage_type"
+	UpdateDomainCount = "update_domain_count"
+	UsePrivateIP      = "use_private_ip"
+
+	AvailabilityZones   = "availability_zones"
+	Count               = "count"
+	OrchestratorVersion = "orchestrator_version"
+	OSDiskSizeGB        = "os_disk_size_gb"
+	VMSize              = "vm_size"
+)

--- a/defaults/resourceblocks/nodeproviders/google/googleBlocks.go
+++ b/defaults/resourceblocks/nodeproviders/google/googleBlocks.go
@@ -1,0 +1,17 @@
+package google
+
+const (
+	GoogleCredentialConfig = "google_credential_config"
+	AuthEncodedJSON        = "auth_encoded_json"
+	GoogleCredentialSecret = "google_credential_secret"
+	ProjectID              = "project_id"
+	Network                = "network"
+	Subnetwork             = "subnetwork"
+
+	GKEConfig = "gke_config_v2"
+
+	NodePools         = "node_pools"
+	InitialNodeCount  = "initial_node_count"
+	MaxPodsConstraint = "max_pods_constraint"
+	Version           = "version"
+)

--- a/defaults/resourceblocks/nodeproviders/linode/linodeBlocks.go
+++ b/defaults/resourceblocks/nodeproviders/linode/linodeBlocks.go
@@ -1,0 +1,9 @@
+package linode
+
+const (
+	LinodeConfig           = "linode_config"
+	LinodeCredentialConfig = "linode_credential_config"
+	Image                  = "image"
+	RootPass               = "root_pass"
+	Token                  = "token"
+)

--- a/defaults/resourceblocks/nodeproviders/vsphere/vsphereBlocks.go
+++ b/defaults/resourceblocks/nodeproviders/vsphere/vsphereBlocks.go
@@ -1,0 +1,32 @@
+package vsphere
+
+const (
+	VsphereConfig           = "vsphere_config"
+	VsphereCredentialConfig = "vsphere_credential_config"
+	Password                = "password"
+	Username                = "username"
+	Vcenter                 = "vcenter"
+	VcenterPort             = "vcenter_port"
+
+	DockerURL        = "boot2docker_url"
+	Cfgparam         = "cfgparam"
+	CloneFrom        = "clone_from"
+	CloudConfig      = "cloud_config"
+	Cloudinit        = "cloudinit"
+	ContentLibrary   = "content_library"
+	CPUCount         = "cpu_count"
+	CreationType     = "creation_type"
+	DataCenter       = "datacenter"
+	DataStore        = "datastore"
+	DatastoreCluster = "datastore_cluster"
+	DiskSize         = "disk_size"
+	Folder           = "folder"
+	HostSystem       = "hostsystem"
+	MemorySize       = "memory_size"
+	Network          = "network"
+	Pool             = "pool"
+	SSHPassword      = "ssh_password"
+	SSHPort          = "ssh_port"
+	SSHUser          = "ssh_user"
+	SSHUserGroup     = "ssh_user_group"
+)

--- a/defaults/resourceblocks/providersUsers/providersUsersBlocks.go
+++ b/defaults/resourceblocks/providersUsers/providersUsersBlocks.go
@@ -1,0 +1,24 @@
+package providersUsers
+
+const (
+	ApiURL            = "api_url"
+	Enabled           = "enabled"
+	GlobalRoleBinding = "rancher2_global_role_binding"
+	GlobalRoleID      = "global_role_id"
+	Insecure          = "insecure"
+	Name              = "name"
+	Password          = "password"
+	Provider          = "provider"
+	Rancher           = "rancher2"
+	RancherUser       = "rancher2_user"
+	RC                = "-rc"
+	RequiredProviders = "required_providers"
+	Resource          = "resource"
+	Source            = "source"
+	Terraform         = "terraform"
+	TokenKey          = "token_key"
+	Version           = "version"
+	User              = "user"
+	UserID            = "user_id"
+	Username          = "username"
+)

--- a/defaults/resourceblocks/psact/psactBlocks.go
+++ b/defaults/resourceblocks/psact/psactBlocks.go
@@ -1,0 +1,44 @@
+package psact
+
+var ExemptionsNamespaces = []string{
+	"ingress-nginx",
+	"kube-system",
+	"cattle-system",
+	"cattle-epinio-system",
+	"cattle-fleet-system",
+	"longhorn-system",
+	"cattle-neuvector-system",
+	"cattle-monitoring-system",
+	"rancher-alerting-drivers",
+	"cis-operator-system",
+	"cattle-csp-adapter-system",
+	"cattle-externalip-system",
+	"cattle-gatekeeper-system",
+	"istio-system",
+	"cattle-istio-system",
+	"cattle-logging-system",
+	"cattle-windows-gmsa-system",
+	"cattle-sriov-system",
+	"cattle-ui-plugin-system",
+	"tigera-operator",
+}
+
+const (
+	Audit           = "audit"
+	AuditVersion    = "audit_version"
+	Baseline        = "baseline"
+	Defaults        = "defaults"
+	Description     = "description"
+	Enforce         = "enforce"
+	EnforceVersion  = "enforce_version"
+	Exemptions      = "exemptions"
+	Latest          = "latest"
+	Namespaces      = "namespaces"
+	RancherBaseline = "rancher-baseline"
+	Warn            = "warn"
+	WarnVersion     = "warn_version"
+
+	BaselineDescription = "This is a custom baseline Pod Security Admission Configuration Template." +
+		"It defines a minimally restrictive policy which prevents known privilege escalations. " +
+		"This policy contains namespace level exemptions for Rancher components."
+)

--- a/defaults/resourceblocks/resourceblocks.go
+++ b/defaults/resourceblocks/resourceblocks.go
@@ -1,0 +1,38 @@
+package resourceblocks
+
+const (
+	Resource     = "resource"
+	ResourceKind = "kind"
+	ResourceName = "name"
+
+	DependsOn    = "depends_on"
+	GenerateName = "generate_name"
+
+	DefaultPodSecurityAdmission = "default_pod_security_admission_configuration_template_name"
+	PodSecurityAdmission        = "rancher2_pod_security_admission_configuration_template"
+	CloudCredential             = "rancher2_cloud_credential"
+	Cluster                     = "rancher2_cluster"
+
+	RKEConfig                           = "rke_config"
+	KubernetesVersion                   = "kubernetes_version"
+	Network                             = "network"
+	Plugin                              = "plugin"
+	Services                            = "services"
+	EnableNetworkPolicy                 = "enable_network_policy"
+	DefaultClusterRoleForProjectMembers = "default_cluster_role_for_project_members"
+
+	AccessKey         = "access_key"
+	SecretKey         = "secret_key"
+	CloudCredentialID = "cloud_credential_id"
+
+	MachineConfig = "machine_config"
+	MachinePools  = "machine_pools"
+	Pool          = "pool"
+	Etcd          = "etcd"
+	ClusterID     = "cluster_id"
+	Quantity      = "quantity"
+
+	Endpoint = "endpoint"
+	Folder   = "folder"
+	Region   = "region"
+)

--- a/defaults/resourceblocks/rke1/rke1Blocks.go
+++ b/defaults/resourceblocks/rke1/rke1Blocks.go
@@ -1,0 +1,24 @@
+package rke1
+
+const (
+	ClusterSync  = "rancher2_cluster_sync"
+	NodeTemplate = "rancher2_node_template"
+	NodePool     = "rancher2_node_pool"
+
+	BackupConfig   = "backup_config"
+	Enabled        = "enabled"
+	IntervalHours  = "interval_hours"
+	SafeTimestamp  = "safe_timestamp"
+	Timeout        = "timeout"
+	Retention      = "retention"
+	Snapshot       = "snapshot"
+	S3BackupConfig = "s3_backup_config"
+	BucketName     = "bucket_name"
+
+	HostnamePrefix = "hostname_prefix"
+	NodeTemplateID = "node_template_id"
+	ControlPlane   = "control_plane"
+	Worker         = "worker"
+	NodePoolIDs    = "node_pool_ids"
+	StateConfirm   = "state_confirm"
+)

--- a/defaults/resourceblocks/rke2k3s/rke2k3sBlocks.go
+++ b/defaults/resourceblocks/rke2k3s/rke2k3sBlocks.go
@@ -1,0 +1,24 @@
+package rke2k3s
+
+const (
+	ClusterV2       = "rancher2_cluster_v2"
+	MachineConfigV2 = "rancher2_machine_config_v2"
+
+	CloudCredentialName       = "cloud_credential_name"
+	CloudCredentialSecretName = "cloud_credential_secret_name"
+	ControlPlaneRole          = "control_plane_role"
+	EtcdRole                  = "etcd_role"
+	WorkerRole                = "worker_role"
+
+	UpgradeStrategy         = "upgrade_strategy"
+	ControlPlaneConcurrency = "control_plane_concurrency"
+	WorkerConcurrency       = "worker_concurrency"
+
+	DisableSnapshots     = "disable_snapshots"
+	SnapshotScheduleCron = "snapshot_schedule_cron"
+	SnapshotRetention    = "snapshot_retention"
+	S3Config             = "s3_config"
+	Bucket               = "bucket"
+	EndpointCA           = "endpoint_ca"
+	SkipSSLVerify        = "skip_ssl_verify"
+)

--- a/defaults/resourceblocks/snapshot/snapshotBlocks.go
+++ b/defaults/resourceblocks/snapshot/snapshotBlocks.go
@@ -1,0 +1,9 @@
+package snapshot
+
+const (
+	EtcdSnapshotCreate  = "etcd_snapshot_create"
+	EtcdSnapshotRestore = "etcd_snapshot_restore"
+
+	Generation       = "generation"
+	RestoreRKEConfig = "restore_rke_config"
+)

--- a/defaults/stevetypes/stevetypes.go
+++ b/defaults/stevetypes/stevetypes.go
@@ -1,0 +1,9 @@
+package stevetypes
+
+const (
+	DeploymentSteveType          = "apps.deployment"
+	IngressSteveType             = "networking.k8s.io.ingress"
+	MachineSteveResourceType     = "cluster.x-k8s.io.machine"
+	ProvisioningSteveResouceType = "provisioning.cattle.io.cluster"
+	ServiceType                  = "service"
+)

--- a/framework/cleanup/cleanup.go
+++ b/framework/cleanup/cleanup.go
@@ -1,4 +1,4 @@
-package framework
+package cleanup
 
 import (
 	"testing"
@@ -6,12 +6,13 @@ import (
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/tfp-automation/defaults/configs"
 )
 
 // Cleanup is a function that will run terraform destroy and cleanup Terraform resources.
 func Cleanup(t *testing.T, terraformOptions *terraform.Options) {
 	rancherConfig := new(rancher.Config)
-	config.LoadConfig("rancher", rancherConfig)
+	config.LoadConfig(configs.Rancher, rancherConfig)
 
 	if *rancherConfig.Cleanup {
 		terraform.Destroy(t, terraformOptions)

--- a/framework/cleanup/cleanupConfigTF.go
+++ b/framework/cleanup/cleanupConfigTF.go
@@ -1,8 +1,9 @@
-package framework
+package cleanup
 
 import (
 	"os"
 
+	"github.com/rancher/tfp-automation/defaults/configs"
 	set "github.com/rancher/tfp-automation/framework/set/provisioning"
 	"github.com/sirupsen/logrus"
 )
@@ -11,9 +12,10 @@ import (
 func CleanupConfigTF() error {
 	keyPath := set.SetKeyPath()
 
-	file, err := os.Create(keyPath + "/main.tf")
+	file, err := os.Create(keyPath + configs.MainTF)
 	if err != nil {
 		logrus.Errorf("Failed to overwrite main.tf file. Error: %v", err)
+
 		return err
 	}
 
@@ -22,10 +24,11 @@ func CleanupConfigTF() error {
 	_, err = file.WriteString("// Leave blank - main.tf will be set during testing")
 	if err != nil {
 		logrus.Errorf("Failed to write to main.tf file. Error: %v", err)
+
 		return err
 	}
 
-	delete_files := [3]string{"/terraform.tfstate", "/terraform.tfstate.backup", "/.terraform.lock.hcl"}
+	delete_files := [3]string{configs.TFState, configs.TFStateBackup, configs.TFLockHCL}
 
 	for _, delete_file := range delete_files {
 		delete_file = keyPath + delete_file
@@ -33,13 +36,15 @@ func CleanupConfigTF() error {
 
 		if err != nil {
 			logrus.Errorf("Failed to delete terraform.tfstate, terraform.tfstate.backup, and terraform.lock.hcl files. Error: %v", err)
+
 			return err
 		}
 	}
 
-	err = os.RemoveAll(keyPath + "/.terraform")
+	err = os.RemoveAll(keyPath + configs.TerraformFolder)
 	if err != nil {
 		logrus.Errorf("Failed to delete .terraform folder. Error: %v", err)
+
 		return err
 	}
 

--- a/framework/format/listOfStrings.go
+++ b/framework/format/listOfStrings.go
@@ -1,4 +1,4 @@
-package framework
+package format
 
 import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"

--- a/framework/set/provisioning/providers/azure/azure_config.go
+++ b/framework/set/provisioning/providers/azure/azure_config.go
@@ -3,12 +3,14 @@ package azure
 import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/resourceblocks/nodeproviders/azure"
 	"github.com/zclconf/go-cty/cty"
 )
 
-// SetAzureRKE2K3SMachineConfig is a helper function that will set the Azure RKE2/K3S Terraform machine configurations in the main.tf file.
+// SetAzureRKE2K3SMachineConfig is a helper function that will set the Azure RKE2/K3S
+// Terraform machine configurations in the main.tf file.
 func SetAzureRKE2K3SMachineConfig(machineConfigBlockBody *hclwrite.Body, terraformConfig *config.TerraformConfig) {
-	azureConfigBlock := machineConfigBlockBody.AppendNewBlock("azure_config", nil)
+	azureConfigBlock := machineConfigBlockBody.AppendNewBlock(azure.AzureConfig, nil)
 	azureConfigBlockBody := azureConfigBlock.Body()
 
 	openPorts := make([]cty.Value, len(terraformConfig.AzureConfig.OpenPort))
@@ -16,22 +18,22 @@ func SetAzureRKE2K3SMachineConfig(machineConfigBlockBody *hclwrite.Body, terrafo
 		openPorts[i] = cty.StringVal(port)
 	}
 
-	azureConfigBlockBody.SetAttributeValue("availability_set", cty.StringVal(terraformConfig.AzureConfig.AvailabilitySet))
-	azureConfigBlockBody.SetAttributeValue("custom_data", cty.StringVal(terraformConfig.AzureConfig.CustomData))
-	azureConfigBlockBody.SetAttributeValue("disk_size", cty.StringVal(terraformConfig.AzureConfig.DiskSize))
-	azureConfigBlockBody.SetAttributeValue("fault_domain_count", cty.StringVal(terraformConfig.AzureConfig.FaultDomainCount))
-	azureConfigBlockBody.SetAttributeValue("image", cty.StringVal(terraformConfig.AzureConfig.Image))
-	azureConfigBlockBody.SetAttributeValue("location", cty.StringVal(terraformConfig.AzureConfig.Location))
-	azureConfigBlockBody.SetAttributeValue("managed_disks", cty.BoolVal(terraformConfig.AzureConfig.ManagedDisks))
-	azureConfigBlockBody.SetAttributeValue("no_public_ip", cty.BoolVal(terraformConfig.AzureConfig.NoPublicIP))
-	azureConfigBlockBody.SetAttributeValue("open_port", cty.ListVal(openPorts))
-	azureConfigBlockBody.SetAttributeValue("private_ip_address", cty.StringVal(terraformConfig.AzureConfig.PrivateIPAddress))
-	azureConfigBlockBody.SetAttributeValue("resource_group", cty.StringVal(terraformConfig.AzureConfig.ResourceGroup))
-	azureConfigBlockBody.SetAttributeValue("size", cty.StringVal(terraformConfig.AzureConfig.Size))
-	azureConfigBlockBody.SetAttributeValue("ssh_user", cty.StringVal(terraformConfig.AzureConfig.SSHUser))
-	azureConfigBlockBody.SetAttributeValue("static_public_ip", cty.BoolVal(terraformConfig.AzureConfig.StaticPublicIP))
-	azureConfigBlockBody.SetAttributeValue("storage_type", cty.StringVal(terraformConfig.AzureConfig.StorageType))
-	azureConfigBlockBody.SetAttributeValue("tenant_id", cty.StringVal(terraformConfig.AzureConfig.TenantID))
-	azureConfigBlockBody.SetAttributeValue("update_domain_count", cty.StringVal(terraformConfig.AzureConfig.UpdateDomainCount))
-	azureConfigBlockBody.SetAttributeValue("use_private_ip", cty.BoolVal(terraformConfig.AzureConfig.UsePrivateIP))
+	azureConfigBlockBody.SetAttributeValue(azure.AvailabilitySet, cty.StringVal(terraformConfig.AzureConfig.AvailabilitySet))
+	azureConfigBlockBody.SetAttributeValue(azure.CustomData, cty.StringVal(terraformConfig.AzureConfig.CustomData))
+	azureConfigBlockBody.SetAttributeValue(azure.DiskSize, cty.StringVal(terraformConfig.AzureConfig.DiskSize))
+	azureConfigBlockBody.SetAttributeValue(azure.FaultDomainCount, cty.StringVal(terraformConfig.AzureConfig.FaultDomainCount))
+	azureConfigBlockBody.SetAttributeValue(azure.Image, cty.StringVal(terraformConfig.AzureConfig.Image))
+	azureConfigBlockBody.SetAttributeValue(azure.Location, cty.StringVal(terraformConfig.AzureConfig.Location))
+	azureConfigBlockBody.SetAttributeValue(azure.ManagedDisks, cty.BoolVal(terraformConfig.AzureConfig.ManagedDisks))
+	azureConfigBlockBody.SetAttributeValue(azure.NoPublicIP, cty.BoolVal(terraformConfig.AzureConfig.NoPublicIP))
+	azureConfigBlockBody.SetAttributeValue(azure.OpenPort, cty.ListVal(openPorts))
+	azureConfigBlockBody.SetAttributeValue(azure.PrivateIPAddress, cty.StringVal(terraformConfig.AzureConfig.PrivateIPAddress))
+	azureConfigBlockBody.SetAttributeValue(azure.ResourceGroup, cty.StringVal(terraformConfig.AzureConfig.ResourceGroup))
+	azureConfigBlockBody.SetAttributeValue(azure.Size, cty.StringVal(terraformConfig.AzureConfig.Size))
+	azureConfigBlockBody.SetAttributeValue(azure.SSHUser, cty.StringVal(terraformConfig.AzureConfig.SSHUser))
+	azureConfigBlockBody.SetAttributeValue(azure.StaticPublicIP, cty.BoolVal(terraformConfig.AzureConfig.StaticPublicIP))
+	azureConfigBlockBody.SetAttributeValue(azure.StorageType, cty.StringVal(terraformConfig.AzureConfig.StorageType))
+	azureConfigBlockBody.SetAttributeValue(azure.TenantID, cty.StringVal(terraformConfig.AzureConfig.TenantID))
+	azureConfigBlockBody.SetAttributeValue(azure.UpdateDomainCount, cty.StringVal(terraformConfig.AzureConfig.UpdateDomainCount))
+	azureConfigBlockBody.SetAttributeValue(azure.UsePrivateIP, cty.BoolVal(terraformConfig.AzureConfig.UsePrivateIP))
 }

--- a/framework/set/provisioning/providers/azure/azure_providers.go
+++ b/framework/set/provisioning/providers/azure/azure_providers.go
@@ -3,12 +3,15 @@ package azure
 import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/resourceblocks"
+	"github.com/rancher/tfp-automation/defaults/resourceblocks/nodeproviders/azure"
 	"github.com/zclconf/go-cty/cty"
 )
 
-// SetAzureRKE1Provider is a helper function that will set the Azure RKE1 Terraform configurations in the main.tf file.
+// SetAzureRKE1Provider is a helper function that will set the Azure RKE1
+// Terraform configurations in the main.tf file.
 func SetAzureRKE1Provider(nodeTemplateBlockBody *hclwrite.Body, terraformConfig *config.TerraformConfig) {
-	azureConfigBlock := nodeTemplateBlockBody.AppendNewBlock("azure_config", nil)
+	azureConfigBlock := nodeTemplateBlockBody.AppendNewBlock(azure.AzureConfig, nil)
 	azureConfigBlockBody := azureConfigBlock.Body()
 
 	openPorts := make([]cty.Value, len(terraformConfig.AzureConfig.OpenPort))
@@ -16,43 +19,42 @@ func SetAzureRKE1Provider(nodeTemplateBlockBody *hclwrite.Body, terraformConfig 
 		openPorts[i] = cty.StringVal(port)
 	}
 
-	azureConfigBlockBody.SetAttributeValue("availability_set", cty.StringVal(terraformConfig.LinodeConfig.LinodeImage))
-	azureConfigBlockBody.SetAttributeValue("client_id", cty.StringVal(terraformConfig.AzureConfig.ClientID))
-	azureConfigBlockBody.SetAttributeValue("client_secret", cty.StringVal(terraformConfig.AzureConfig.ClientSecret))
-	azureConfigBlockBody.SetAttributeValue("subscription_id", cty.StringVal(terraformConfig.AzureConfig.SubscriptionID))
-	azureConfigBlockBody.SetAttributeValue("environment", cty.StringVal(terraformConfig.AzureConfig.Environment))
-	azureConfigBlockBody.SetAttributeValue("availability_set", cty.StringVal(terraformConfig.AzureConfig.AvailabilitySet))
-	azureConfigBlockBody.SetAttributeValue("custom_data", cty.StringVal(terraformConfig.AzureConfig.CustomData))
-	azureConfigBlockBody.SetAttributeValue("disk_size", cty.StringVal(terraformConfig.AzureConfig.DiskSize))
-	azureConfigBlockBody.SetAttributeValue("fault_domain_count", cty.StringVal(terraformConfig.AzureConfig.FaultDomainCount))
-	azureConfigBlockBody.SetAttributeValue("image", cty.StringVal(terraformConfig.AzureConfig.Image))
-	azureConfigBlockBody.SetAttributeValue("location", cty.StringVal(terraformConfig.AzureConfig.Location))
-	azureConfigBlockBody.SetAttributeValue("managed_disks", cty.BoolVal(terraformConfig.AzureConfig.ManagedDisks))
-	azureConfigBlockBody.SetAttributeValue("no_public_ip", cty.BoolVal(terraformConfig.AzureConfig.NoPublicIP))
-	azureConfigBlockBody.SetAttributeValue("open_port", cty.ListVal(openPorts))
-	azureConfigBlockBody.SetAttributeValue("private_ip_address", cty.StringVal(terraformConfig.AzureConfig.PrivateIPAddress))
-	azureConfigBlockBody.SetAttributeValue("resource_group", cty.StringVal(terraformConfig.AzureConfig.ResourceGroup))
-	azureConfigBlockBody.SetAttributeValue("size", cty.StringVal(terraformConfig.AzureConfig.Size))
-	azureConfigBlockBody.SetAttributeValue("ssh_user", cty.StringVal(terraformConfig.AzureConfig.SSHUser))
-	azureConfigBlockBody.SetAttributeValue("static_public_ip", cty.BoolVal(terraformConfig.AzureConfig.StaticPublicIP))
-	azureConfigBlockBody.SetAttributeValue("storage_type", cty.StringVal(terraformConfig.AzureConfig.StorageType))
-	azureConfigBlockBody.SetAttributeValue("update_domain_count", cty.StringVal(terraformConfig.AzureConfig.UpdateDomainCount))
-	azureConfigBlockBody.SetAttributeValue("use_private_ip", cty.BoolVal(terraformConfig.AzureConfig.UsePrivateIP))
+	azureConfigBlockBody.SetAttributeValue(azure.AvailabilitySet, cty.StringVal(terraformConfig.AzureConfig.AvailabilitySet))
+	azureConfigBlockBody.SetAttributeValue(azure.ClientID, cty.StringVal(terraformConfig.AzureConfig.ClientID))
+	azureConfigBlockBody.SetAttributeValue(azure.ClientSecret, cty.StringVal(terraformConfig.AzureConfig.ClientSecret))
+	azureConfigBlockBody.SetAttributeValue(azure.SubscriptionID, cty.StringVal(terraformConfig.AzureConfig.SubscriptionID))
+	azureConfigBlockBody.SetAttributeValue(azure.Environment, cty.StringVal(terraformConfig.AzureConfig.Environment))
+	azureConfigBlockBody.SetAttributeValue(azure.CustomData, cty.StringVal(terraformConfig.AzureConfig.CustomData))
+	azureConfigBlockBody.SetAttributeValue(azure.DiskSize, cty.StringVal(terraformConfig.AzureConfig.DiskSize))
+	azureConfigBlockBody.SetAttributeValue(azure.FaultDomainCount, cty.StringVal(terraformConfig.AzureConfig.FaultDomainCount))
+	azureConfigBlockBody.SetAttributeValue(azure.Image, cty.StringVal(terraformConfig.AzureConfig.Image))
+	azureConfigBlockBody.SetAttributeValue(azure.Location, cty.StringVal(terraformConfig.AzureConfig.Location))
+	azureConfigBlockBody.SetAttributeValue(azure.ManagedDisks, cty.BoolVal(terraformConfig.AzureConfig.ManagedDisks))
+	azureConfigBlockBody.SetAttributeValue(azure.NoPublicIP, cty.BoolVal(terraformConfig.AzureConfig.NoPublicIP))
+	azureConfigBlockBody.SetAttributeValue(azure.OpenPort, cty.ListVal(openPorts))
+	azureConfigBlockBody.SetAttributeValue(azure.PrivateIPAddress, cty.StringVal(terraformConfig.AzureConfig.PrivateIPAddress))
+	azureConfigBlockBody.SetAttributeValue(azure.ResourceGroup, cty.StringVal(terraformConfig.AzureConfig.ResourceGroup))
+	azureConfigBlockBody.SetAttributeValue(azure.Size, cty.StringVal(terraformConfig.AzureConfig.Size))
+	azureConfigBlockBody.SetAttributeValue(azure.SSHUser, cty.StringVal(terraformConfig.AzureConfig.SSHUser))
+	azureConfigBlockBody.SetAttributeValue(azure.StaticPublicIP, cty.BoolVal(terraformConfig.AzureConfig.StaticPublicIP))
+	azureConfigBlockBody.SetAttributeValue(azure.StorageType, cty.StringVal(terraformConfig.AzureConfig.StorageType))
+	azureConfigBlockBody.SetAttributeValue(azure.UpdateDomainCount, cty.StringVal(terraformConfig.AzureConfig.UpdateDomainCount))
+	azureConfigBlockBody.SetAttributeValue(azure.UsePrivateIP, cty.BoolVal(terraformConfig.AzureConfig.UsePrivateIP))
 }
 
 // SetAzureRKE2K3SProvider is a helper function that will set the Azure RKE2/K3S Terraform provider details in the main.tf file.
 func SetAzureRKE2K3SProvider(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig) {
-	cloudCredBlock := rootBody.AppendNewBlock("resource", []string{"rancher2_cloud_credential", "rancher2_cloud_credential"})
+	cloudCredBlock := rootBody.AppendNewBlock(resourceblocks.Resource, []string{resourceblocks.CloudCredential, resourceblocks.CloudCredential})
 	cloudCredBlockBody := cloudCredBlock.Body()
 
-	cloudCredBlockBody.SetAttributeValue("name", cty.StringVal(terraformConfig.CloudCredentialName))
+	cloudCredBlockBody.SetAttributeValue(resourceblocks.ResourceName, cty.StringVal(terraformConfig.CloudCredentialName))
 
-	azureCredBlock := cloudCredBlockBody.AppendNewBlock("azure_credential_config", nil)
+	azureCredBlock := cloudCredBlockBody.AppendNewBlock(azure.AzureCredentialConfig, nil)
 	azureCredBlockBody := azureCredBlock.Body()
 
-	azureCredBlockBody.SetAttributeValue("client_id", cty.StringVal(terraformConfig.AzureConfig.ClientID))
-	azureCredBlockBody.SetAttributeValue("client_secret", cty.StringVal(terraformConfig.AzureConfig.ClientSecret))
-	azureCredBlockBody.SetAttributeValue("subscription_id", cty.StringVal(terraformConfig.AzureConfig.SubscriptionID))
-	azureCredBlockBody.SetAttributeValue("environment", cty.StringVal(terraformConfig.AzureConfig.Environment))
+	azureCredBlockBody.SetAttributeValue(azure.ClientID, cty.StringVal(terraformConfig.AzureConfig.ClientID))
+	azureCredBlockBody.SetAttributeValue(azure.ClientSecret, cty.StringVal(terraformConfig.AzureConfig.ClientSecret))
+	azureCredBlockBody.SetAttributeValue(azure.SubscriptionID, cty.StringVal(terraformConfig.AzureConfig.SubscriptionID))
+	azureCredBlockBody.SetAttributeValue(azure.Environment, cty.StringVal(terraformConfig.AzureConfig.Environment))
 
 }

--- a/framework/set/provisioning/providers/ec2/ec2_config.go
+++ b/framework/set/provisioning/providers/ec2/ec2_config.go
@@ -3,22 +3,25 @@ package ec2
 import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/resourceblocks"
+	"github.com/rancher/tfp-automation/defaults/resourceblocks/nodeproviders/amazon"
 	format "github.com/rancher/tfp-automation/framework/format"
 	"github.com/zclconf/go-cty/cty"
 )
 
-// SetEC2RKE2K3SMachineConfig is a helper function that will set the EC2 RKE2/K3S Terraform machine configurations in the main.tf file.
+// SetEC2RKE2K3SMachineConfig is a helper function that will set the EC2 RKE2/K3S
+// Terraform machine configurations in the main.tf file.
 func SetEC2RKE2K3SMachineConfig(machineConfigBlockBody *hclwrite.Body, terraformConfig *config.TerraformConfig) {
-	ec2ConfigBlock := machineConfigBlockBody.AppendNewBlock("amazonec2_config", nil)
+	ec2ConfigBlock := machineConfigBlockBody.AppendNewBlock(amazon.EC2Config, nil)
 	ec2ConfigBlockBody := ec2ConfigBlock.Body()
 
-	ec2ConfigBlockBody.SetAttributeValue("ami", cty.StringVal(terraformConfig.AWSConfig.AMI))
-	ec2ConfigBlockBody.SetAttributeValue("region", cty.StringVal(terraformConfig.AWSConfig.Region))
+	ec2ConfigBlockBody.SetAttributeValue(amazon.AMI, cty.StringVal(terraformConfig.AWSConfig.AMI))
+	ec2ConfigBlockBody.SetAttributeValue(resourceblocks.Region, cty.StringVal(terraformConfig.AWSConfig.Region))
 	awsSecGroupNames := format.ListOfStrings(terraformConfig.AWSConfig.AWSSecurityGroupNames)
-	ec2ConfigBlockBody.SetAttributeRaw("security_group", awsSecGroupNames)
-	ec2ConfigBlockBody.SetAttributeValue("subnet_id", cty.StringVal(terraformConfig.AWSConfig.AWSSubnetID))
-	ec2ConfigBlockBody.SetAttributeValue("vpc_id", cty.StringVal(terraformConfig.AWSConfig.AWSVpcID))
-	ec2ConfigBlockBody.SetAttributeValue("zone", cty.StringVal(terraformConfig.AWSConfig.AWSZoneLetter))
-	ec2ConfigBlockBody.SetAttributeValue("root_size", cty.NumberIntVal(terraformConfig.AWSConfig.AWSRootSize))
-	ec2ConfigBlockBody.SetAttributeValue("instance_type", cty.StringVal(terraformConfig.AWSConfig.AWSInstanceType))
+	ec2ConfigBlockBody.SetAttributeRaw(amazon.SecurityGroup, awsSecGroupNames)
+	ec2ConfigBlockBody.SetAttributeValue(amazon.SubnetID, cty.StringVal(terraformConfig.AWSConfig.AWSSubnetID))
+	ec2ConfigBlockBody.SetAttributeValue(amazon.VPCID, cty.StringVal(terraformConfig.AWSConfig.AWSVpcID))
+	ec2ConfigBlockBody.SetAttributeValue(amazon.Zone, cty.StringVal(terraformConfig.AWSConfig.AWSZoneLetter))
+	ec2ConfigBlockBody.SetAttributeValue(amazon.RootSize, cty.NumberIntVal(terraformConfig.AWSConfig.AWSRootSize))
+	ec2ConfigBlockBody.SetAttributeValue(amazon.InstanceType, cty.StringVal(terraformConfig.AWSConfig.AWSInstanceType))
 }

--- a/framework/set/provisioning/providers/ec2/ec2_providers.go
+++ b/framework/set/provisioning/providers/ec2/ec2_providers.go
@@ -3,38 +3,42 @@ package ec2
 import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/resourceblocks"
+	"github.com/rancher/tfp-automation/defaults/resourceblocks/nodeproviders/amazon"
 	format "github.com/rancher/tfp-automation/framework/format"
 	"github.com/zclconf/go-cty/cty"
 )
 
-// SetEC2RKE1Provider is a helper function that will set the EC2 RKE1 Terraform configurations in the main.tf file.
+// SetEC2RKE1Provider is a helper function that will set the EC2 RKE1
+// Terraform configurations in the main.tf file.
 func SetEC2RKE1Provider(nodeTemplateBlockBody *hclwrite.Body, terraformConfig *config.TerraformConfig) {
-	ec2ConfigBlock := nodeTemplateBlockBody.AppendNewBlock("amazonec2_config", nil)
+	ec2ConfigBlock := nodeTemplateBlockBody.AppendNewBlock(amazon.EC2Config, nil)
 	ec2ConfigBlockBody := ec2ConfigBlock.Body()
 
-	ec2ConfigBlockBody.SetAttributeValue("access_key", cty.StringVal(terraformConfig.AWSConfig.AWSAccessKey))
-	ec2ConfigBlockBody.SetAttributeValue("secret_key", cty.StringVal(terraformConfig.AWSConfig.AWSSecretKey))
-	ec2ConfigBlockBody.SetAttributeValue("ami", cty.StringVal(terraformConfig.AWSConfig.AMI))
-	ec2ConfigBlockBody.SetAttributeValue("region", cty.StringVal(terraformConfig.AWSConfig.Region))
+	ec2ConfigBlockBody.SetAttributeValue(resourceblocks.AccessKey, cty.StringVal(terraformConfig.AWSConfig.AWSAccessKey))
+	ec2ConfigBlockBody.SetAttributeValue(resourceblocks.SecretKey, cty.StringVal(terraformConfig.AWSConfig.AWSSecretKey))
+	ec2ConfigBlockBody.SetAttributeValue(amazon.AMI, cty.StringVal(terraformConfig.AWSConfig.AMI))
+	ec2ConfigBlockBody.SetAttributeValue(resourceblocks.Region, cty.StringVal(terraformConfig.AWSConfig.Region))
 	awsSecGroupNames := format.ListOfStrings(terraformConfig.AWSConfig.AWSSecurityGroupNames)
-	ec2ConfigBlockBody.SetAttributeRaw("security_group", awsSecGroupNames)
-	ec2ConfigBlockBody.SetAttributeValue("subnet_id", cty.StringVal(terraformConfig.AWSConfig.AWSSubnetID))
-	ec2ConfigBlockBody.SetAttributeValue("vpc_id", cty.StringVal(terraformConfig.AWSConfig.AWSVpcID))
-	ec2ConfigBlockBody.SetAttributeValue("zone", cty.StringVal(terraformConfig.AWSConfig.AWSZoneLetter))
-	ec2ConfigBlockBody.SetAttributeValue("root_size", cty.NumberIntVal(terraformConfig.AWSConfig.AWSRootSize))
-	ec2ConfigBlockBody.SetAttributeValue("instance_type", cty.StringVal(terraformConfig.AWSConfig.AWSInstanceType))
+	ec2ConfigBlockBody.SetAttributeRaw(amazon.SecurityGroup, awsSecGroupNames)
+	ec2ConfigBlockBody.SetAttributeValue(amazon.SubnetID, cty.StringVal(terraformConfig.AWSConfig.AWSSubnetID))
+	ec2ConfigBlockBody.SetAttributeValue(amazon.VPCID, cty.StringVal(terraformConfig.AWSConfig.AWSVpcID))
+	ec2ConfigBlockBody.SetAttributeValue(amazon.Zone, cty.StringVal(terraformConfig.AWSConfig.AWSZoneLetter))
+	ec2ConfigBlockBody.SetAttributeValue(amazon.RootSize, cty.NumberIntVal(terraformConfig.AWSConfig.AWSRootSize))
+	ec2ConfigBlockBody.SetAttributeValue(amazon.InstanceType, cty.StringVal(terraformConfig.AWSConfig.AWSInstanceType))
 }
 
-// SetEC2RKE2K3SProvider is a helper function that will set the EC2 RKE2/K3S Terraform provider details in the main.tf file.
+// SetEC2RKE2K3SProvider is a helper function that will set the EC2 RKE2/K3S
+// Terraform provider details in the main.tf file.
 func SetEC2RKE2K3SProvider(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig) {
-	cloudCredBlock := rootBody.AppendNewBlock("resource", []string{"rancher2_cloud_credential", "rancher2_cloud_credential"})
+	cloudCredBlock := rootBody.AppendNewBlock(resourceblocks.Resource, []string{resourceblocks.CloudCredential, resourceblocks.CloudCredential})
 	cloudCredBlockBody := cloudCredBlock.Body()
 
-	cloudCredBlockBody.SetAttributeValue("name", cty.StringVal(terraformConfig.CloudCredentialName))
+	cloudCredBlockBody.SetAttributeValue(resourceblocks.ResourceName, cty.StringVal(terraformConfig.CloudCredentialName))
 
-	ec2CredBlock := cloudCredBlockBody.AppendNewBlock("amazonec2_credential_config", nil)
+	ec2CredBlock := cloudCredBlockBody.AppendNewBlock(amazon.EC2CredentialConfig, nil)
 	ec2CredBlockBody := ec2CredBlock.Body()
 
-	ec2CredBlockBody.SetAttributeValue("access_key", cty.StringVal(terraformConfig.AWSConfig.AWSAccessKey))
-	ec2CredBlockBody.SetAttributeValue("secret_key", cty.StringVal(terraformConfig.AWSConfig.AWSSecretKey))
+	ec2CredBlockBody.SetAttributeValue(resourceblocks.AccessKey, cty.StringVal(terraformConfig.AWSConfig.AWSAccessKey))
+	ec2CredBlockBody.SetAttributeValue(resourceblocks.SecretKey, cty.StringVal(terraformConfig.AWSConfig.AWSSecretKey))
 }

--- a/framework/set/provisioning/providers/linode/linode_config.go
+++ b/framework/set/provisioning/providers/linode/linode_config.go
@@ -3,16 +3,19 @@ package linode
 import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/resourceblocks"
+	"github.com/rancher/tfp-automation/defaults/resourceblocks/nodeproviders/linode"
 	"github.com/zclconf/go-cty/cty"
 )
 
-// SetLinodeRKE2K3SMachineConfig is a helper function that will set the EC2 RKE2/K3S Terraform machine configurations in the main.tf file.
+// SetLinodeRKE2K3SMachineConfig is a helper function that will set the Linode RKE2/K3S
+// Terraform machine configurations in the main.tf file.
 func SetLinodeRKE2K3SMachineConfig(machineConfigBlockBody *hclwrite.Body, terraformConfig *config.TerraformConfig) {
-	linodeConfigBlock := machineConfigBlockBody.AppendNewBlock("linode_config", nil)
+	linodeConfigBlock := machineConfigBlockBody.AppendNewBlock(linode.LinodeConfig, nil)
 	linodeConfigBlockBody := linodeConfigBlock.Body()
 
-	linodeConfigBlockBody.SetAttributeValue("image", cty.StringVal(terraformConfig.LinodeConfig.LinodeImage))
-	linodeConfigBlockBody.SetAttributeValue("region", cty.StringVal(terraformConfig.LinodeConfig.Region))
-	linodeConfigBlockBody.SetAttributeValue("root_pass", cty.StringVal(terraformConfig.LinodeConfig.LinodeRootPass))
-	linodeConfigBlockBody.SetAttributeValue("token", cty.StringVal(terraformConfig.LinodeConfig.LinodeToken))
+	linodeConfigBlockBody.SetAttributeValue(linode.Image, cty.StringVal(terraformConfig.LinodeConfig.LinodeImage))
+	linodeConfigBlockBody.SetAttributeValue(resourceblocks.Region, cty.StringVal(terraformConfig.LinodeConfig.Region))
+	linodeConfigBlockBody.SetAttributeValue(linode.RootPass, cty.StringVal(terraformConfig.LinodeConfig.LinodeRootPass))
+	linodeConfigBlockBody.SetAttributeValue(linode.Token, cty.StringVal(terraformConfig.LinodeConfig.LinodeToken))
 }

--- a/framework/set/provisioning/providers/linode/linode_providers.go
+++ b/framework/set/provisioning/providers/linode/linode_providers.go
@@ -3,29 +3,33 @@ package linode
 import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/resourceblocks"
+	"github.com/rancher/tfp-automation/defaults/resourceblocks/nodeproviders/linode"
 	"github.com/zclconf/go-cty/cty"
 )
 
-// SetLinodeRKE1Provider is a helper function that will set the Linode RKE1 Terraform configurations in the main.tf file.
+// SetLinodeRKE1Provider is a helper function that will set the Linode RKE1
+// Terraform configurations in the main.tf file.
 func SetLinodeRKE1Provider(nodeTemplateBlockBody *hclwrite.Body, terraformConfig *config.TerraformConfig) {
-	linodeConfigBlock := nodeTemplateBlockBody.AppendNewBlock("linode_config", nil)
+	linodeConfigBlock := nodeTemplateBlockBody.AppendNewBlock(linode.LinodeConfig, nil)
 	linodeConfigBlockBody := linodeConfigBlock.Body()
 
-	linodeConfigBlockBody.SetAttributeValue("image", cty.StringVal(terraformConfig.LinodeConfig.LinodeImage))
-	linodeConfigBlockBody.SetAttributeValue("region", cty.StringVal(terraformConfig.LinodeConfig.Region))
-	linodeConfigBlockBody.SetAttributeValue("root_pass", cty.StringVal(terraformConfig.LinodeConfig.LinodeRootPass))
-	linodeConfigBlockBody.SetAttributeValue("token", cty.StringVal(terraformConfig.LinodeConfig.LinodeToken))
+	linodeConfigBlockBody.SetAttributeValue(linode.Image, cty.StringVal(terraformConfig.LinodeConfig.LinodeImage))
+	linodeConfigBlockBody.SetAttributeValue(resourceblocks.Region, cty.StringVal(terraformConfig.LinodeConfig.Region))
+	linodeConfigBlockBody.SetAttributeValue(linode.RootPass, cty.StringVal(terraformConfig.LinodeConfig.LinodeRootPass))
+	linodeConfigBlockBody.SetAttributeValue(linode.Token, cty.StringVal(terraformConfig.LinodeConfig.LinodeToken))
 }
 
-// SetLinodeRKE2K3SProvider is a helper function that will set the Linode RKE2/K3S Terraform provider details in the main.tf file.
+// SetLinodeRKE2K3SProvider is a helper function that will set the Linode RKE2/K3S
+// Terraform provider details in the main.tf file.
 func SetLinodeRKE2K3SProvider(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig) {
-	cloudCredBlock := rootBody.AppendNewBlock("resource", []string{"rancher2_cloud_credential", "rancher2_cloud_credential"})
+	cloudCredBlock := rootBody.AppendNewBlock(resourceblocks.Resource, []string{resourceblocks.CloudCredential, resourceblocks.CloudCredential})
 	cloudCredBlockBody := cloudCredBlock.Body()
 
-	cloudCredBlockBody.SetAttributeValue("name", cty.StringVal(terraformConfig.CloudCredentialName))
+	cloudCredBlockBody.SetAttributeValue(resourceblocks.ResourceName, cty.StringVal(terraformConfig.CloudCredentialName))
 
-	linodeCredBlock := cloudCredBlockBody.AppendNewBlock("linode_credential_config", nil)
+	linodeCredBlock := cloudCredBlockBody.AppendNewBlock(linode.LinodeCredentialConfig, nil)
 	linodeCredBlockBody := linodeCredBlock.Body()
 
-	linodeCredBlockBody.SetAttributeValue("token", cty.StringVal(terraformConfig.LinodeConfig.LinodeToken))
+	linodeCredBlockBody.SetAttributeValue(linode.Token, cty.StringVal(terraformConfig.LinodeConfig.LinodeToken))
 }

--- a/framework/set/provisioning/providers/vsphere/vshere_providers.go
+++ b/framework/set/provisioning/providers/vsphere/vshere_providers.go
@@ -3,12 +3,15 @@ package vsphere
 import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/resourceblocks"
+	"github.com/rancher/tfp-automation/defaults/resourceblocks/nodeproviders/vsphere"
 	"github.com/zclconf/go-cty/cty"
 )
 
-// SetVsphereRKE1Provider is a helper function that will set the Vsphere RKE1 Terraform provider details in the main.tf file.
+// SetVsphereRKE1Provider is a helper function that will set the Vsphere RKE1
+// Terraform provider details in the main.tf file.
 func SetVsphereRKE1Provider(nodeTemplateBlockBody *hclwrite.Body, terraformConfig *config.TerraformConfig) {
-	vsphereConfigBlock := nodeTemplateBlockBody.AppendNewBlock("vsphere_config", nil)
+	vsphereConfigBlock := nodeTemplateBlockBody.AppendNewBlock(vsphere.VsphereConfig, nil)
 	vsphereConfigBlockBody := vsphereConfigBlock.Body()
 
 	cfgparams := make([]cty.Value, len(terraformConfig.VsphereConfig.Cfgparam))
@@ -21,45 +24,45 @@ func SetVsphereRKE1Provider(nodeTemplateBlockBody *hclwrite.Body, terraformConfi
 		networks[i] = cty.StringVal(network)
 	}
 
-	vsphereConfigBlockBody.SetAttributeValue("boot2docker_url", cty.StringVal(terraformConfig.VsphereConfig.Boot2dockerURL))
-	vsphereConfigBlockBody.SetAttributeValue("cfgparam", cty.ListVal(cfgparams))
-	vsphereConfigBlockBody.SetAttributeValue("clone_from", cty.StringVal(terraformConfig.VsphereConfig.CloneFrom))
-	vsphereConfigBlockBody.SetAttributeValue("cloud_config", cty.StringVal(terraformConfig.VsphereConfig.CloudConfig))
-	vsphereConfigBlockBody.SetAttributeValue("cloudinit", cty.StringVal(terraformConfig.VsphereConfig.Cloudinit))
-	vsphereConfigBlockBody.SetAttributeValue("content_library", cty.StringVal(terraformConfig.VsphereConfig.ContentLibrary))
-	vsphereConfigBlockBody.SetAttributeValue("cpu_count", cty.StringVal(terraformConfig.VsphereConfig.CPUCount))
-	vsphereConfigBlockBody.SetAttributeValue("creation_type", cty.StringVal(terraformConfig.VsphereConfig.CreationType))
-	vsphereConfigBlockBody.SetAttributeValue("datacenter", cty.StringVal(terraformConfig.VsphereConfig.DataCenter))
-	vsphereConfigBlockBody.SetAttributeValue("datastore", cty.StringVal(terraformConfig.VsphereConfig.DataStore))
-	vsphereConfigBlockBody.SetAttributeValue("datastore_cluster", cty.StringVal(terraformConfig.VsphereConfig.DatastoreCluster))
-	vsphereConfigBlockBody.SetAttributeValue("disk_size", cty.StringVal(terraformConfig.VsphereConfig.DiskSize))
-	vsphereConfigBlockBody.SetAttributeValue("folder", cty.StringVal(terraformConfig.VsphereConfig.Folder))
-	vsphereConfigBlockBody.SetAttributeValue("hostsystem", cty.StringVal(terraformConfig.VsphereConfig.HostSystem))
-	vsphereConfigBlockBody.SetAttributeValue("memory_size", cty.StringVal(terraformConfig.VsphereConfig.MemorySize))
-	vsphereConfigBlockBody.SetAttributeValue("network", cty.ListVal(networks))
-	vsphereConfigBlockBody.SetAttributeValue("password", cty.StringVal(terraformConfig.VsphereConfig.Password))
-	vsphereConfigBlockBody.SetAttributeValue("pool", cty.StringVal(terraformConfig.VsphereConfig.Pool))
-	vsphereConfigBlockBody.SetAttributeValue("ssh_password", cty.StringVal(terraformConfig.VsphereConfig.SSHPassword))
-	vsphereConfigBlockBody.SetAttributeValue("ssh_port", cty.StringVal(terraformConfig.VsphereConfig.SSHPort))
-	vsphereConfigBlockBody.SetAttributeValue("ssh_user", cty.StringVal(terraformConfig.VsphereConfig.SSHUser))
-	vsphereConfigBlockBody.SetAttributeValue("ssh_user_group", cty.StringVal(terraformConfig.VsphereConfig.SSHUserGroup))
-	vsphereConfigBlockBody.SetAttributeValue("username", cty.StringVal(terraformConfig.VsphereConfig.Username))
-	vsphereConfigBlockBody.SetAttributeValue("vcenter", cty.StringVal(terraformConfig.VsphereConfig.Vcenter))
-	vsphereConfigBlockBody.SetAttributeValue("vcenter_port", cty.StringVal(terraformConfig.VsphereConfig.VcenterPort))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.DockerURL, cty.StringVal(terraformConfig.VsphereConfig.Boot2dockerURL))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.Cfgparam, cty.ListVal(cfgparams))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.CloneFrom, cty.StringVal(terraformConfig.VsphereConfig.CloneFrom))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.CloudConfig, cty.StringVal(terraformConfig.VsphereConfig.CloudConfig))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.Cloudinit, cty.StringVal(terraformConfig.VsphereConfig.Cloudinit))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.ContentLibrary, cty.StringVal(terraformConfig.VsphereConfig.ContentLibrary))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.CPUCount, cty.StringVal(terraformConfig.VsphereConfig.CPUCount))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.CreationType, cty.StringVal(terraformConfig.VsphereConfig.CreationType))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.DataCenter, cty.StringVal(terraformConfig.VsphereConfig.DataCenter))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.DataStore, cty.StringVal(terraformConfig.VsphereConfig.DataStore))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.DatastoreCluster, cty.StringVal(terraformConfig.VsphereConfig.DatastoreCluster))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.DiskSize, cty.StringVal(terraformConfig.VsphereConfig.DiskSize))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.Folder, cty.StringVal(terraformConfig.VsphereConfig.Folder))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.HostSystem, cty.StringVal(terraformConfig.VsphereConfig.HostSystem))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.MemorySize, cty.StringVal(terraformConfig.VsphereConfig.MemorySize))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.Network, cty.ListVal(networks))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.Password, cty.StringVal(terraformConfig.VsphereConfig.Password))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.Pool, cty.StringVal(terraformConfig.VsphereConfig.Pool))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.SSHPassword, cty.StringVal(terraformConfig.VsphereConfig.SSHPassword))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.SSHPort, cty.StringVal(terraformConfig.VsphereConfig.SSHPort))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.SSHUser, cty.StringVal(terraformConfig.VsphereConfig.SSHUser))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.SSHUserGroup, cty.StringVal(terraformConfig.VsphereConfig.SSHUserGroup))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.Username, cty.StringVal(terraformConfig.VsphereConfig.Username))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.Vcenter, cty.StringVal(terraformConfig.VsphereConfig.Vcenter))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.VcenterPort, cty.StringVal(terraformConfig.VsphereConfig.VcenterPort))
 }
 
 // SetVsphereRKE2K3SProvider is a helper function that will set the Vsphere RKE2/K3S Terraform provider details in the main.tf file.
 func SetVsphereRKE2K3SProvider(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig) {
-	cloudCredBlock := rootBody.AppendNewBlock("resource", []string{"rancher2_cloud_credential", "rancher2_cloud_credential"})
+	cloudCredBlock := rootBody.AppendNewBlock(resourceblocks.Resource, []string{resourceblocks.CloudCredential, resourceblocks.CloudCredential})
 	cloudCredBlockBody := cloudCredBlock.Body()
 
-	cloudCredBlockBody.SetAttributeValue("name", cty.StringVal(terraformConfig.CloudCredentialName))
+	cloudCredBlockBody.SetAttributeValue(resourceblocks.ResourceName, cty.StringVal(terraformConfig.CloudCredentialName))
 
-	vsphereCredBlock := cloudCredBlockBody.AppendNewBlock("vsphere_credential_config", nil)
+	vsphereCredBlock := cloudCredBlockBody.AppendNewBlock(vsphere.VsphereCredentialConfig, nil)
 	vsphereCredBlockBody := vsphereCredBlock.Body()
 
-	vsphereCredBlockBody.SetAttributeValue("password", cty.StringVal(terraformConfig.VsphereConfig.Password))
-	vsphereCredBlockBody.SetAttributeValue("username", cty.StringVal(terraformConfig.VsphereConfig.Username))
-	vsphereCredBlockBody.SetAttributeValue("vcenter", cty.StringVal(terraformConfig.VsphereConfig.Vcenter))
-	vsphereCredBlockBody.SetAttributeValue("vcenter_port", cty.StringVal(terraformConfig.VsphereConfig.VcenterPort))
+	vsphereCredBlockBody.SetAttributeValue(vsphere.Password, cty.StringVal(terraformConfig.VsphereConfig.Password))
+	vsphereCredBlockBody.SetAttributeValue(vsphere.Username, cty.StringVal(terraformConfig.VsphereConfig.Username))
+	vsphereCredBlockBody.SetAttributeValue(vsphere.Vcenter, cty.StringVal(terraformConfig.VsphereConfig.Vcenter))
+	vsphereCredBlockBody.SetAttributeValue(vsphere.VcenterPort, cty.StringVal(terraformConfig.VsphereConfig.VcenterPort))
 }

--- a/framework/set/provisioning/providers/vsphere/vsphere_config.go
+++ b/framework/set/provisioning/providers/vsphere/vsphere_config.go
@@ -3,12 +3,14 @@ package vsphere
 import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/resourceblocks/nodeproviders/vsphere"
 	"github.com/zclconf/go-cty/cty"
 )
 
-// SetVsphereRKE2K3SMachineConfig is a helper function that will set the Vsphere RKE2/K3S Terraform machine configurations in the main.tf file.
+// SetVsphereRKE2K3SMachineConfig is a helper function that will set the Vsphere RKE2/K3S
+// Terraform machine configurations in the main.tf file.
 func SetVsphereRKE2K3SMachineConfig(machineConfigBlockBody *hclwrite.Body, terraformConfig *config.TerraformConfig) {
-	vsphereConfigBlock := machineConfigBlockBody.AppendNewBlock("vsphere_config", nil)
+	vsphereConfigBlock := machineConfigBlockBody.AppendNewBlock(vsphere.VsphereConfig, nil)
 	vsphereConfigBlockBody := vsphereConfigBlock.Body()
 
 	cfgparams := make([]cty.Value, len(terraformConfig.VsphereConfig.Cfgparam))
@@ -21,26 +23,26 @@ func SetVsphereRKE2K3SMachineConfig(machineConfigBlockBody *hclwrite.Body, terra
 		networks[i] = cty.StringVal(network)
 	}
 
-	vsphereConfigBlockBody.SetAttributeValue("boot2docker_url", cty.StringVal(terraformConfig.VsphereConfig.Boot2dockerURL))
-	vsphereConfigBlockBody.SetAttributeValue("cfgparam", cty.ListVal(cfgparams))
-	vsphereConfigBlockBody.SetAttributeValue("clone_from", cty.StringVal(terraformConfig.VsphereConfig.CloneFrom))
-	vsphereConfigBlockBody.SetAttributeValue("cloud_config", cty.StringVal(terraformConfig.VsphereConfig.CloudConfig))
-	vsphereConfigBlockBody.SetAttributeValue("cloudinit", cty.StringVal(terraformConfig.VsphereConfig.Cloudinit))
-	vsphereConfigBlockBody.SetAttributeValue("content_library", cty.StringVal(terraformConfig.VsphereConfig.ContentLibrary))
-	vsphereConfigBlockBody.SetAttributeValue("cpu_count", cty.StringVal(terraformConfig.VsphereConfig.CPUCount))
-	vsphereConfigBlockBody.SetAttributeValue("creation_type", cty.StringVal(terraformConfig.VsphereConfig.CreationType))
-	vsphereConfigBlockBody.SetAttributeValue("datacenter", cty.StringVal(terraformConfig.VsphereConfig.DataCenter))
-	vsphereConfigBlockBody.SetAttributeValue("datastore", cty.StringVal(terraformConfig.VsphereConfig.DataStore))
-	vsphereConfigBlockBody.SetAttributeValue("datastore_cluster", cty.StringVal(terraformConfig.VsphereConfig.DatastoreCluster))
-	vsphereConfigBlockBody.SetAttributeValue("disk_size", cty.StringVal(terraformConfig.VsphereConfig.DiskSize))
-	vsphereConfigBlockBody.SetAttributeValue("folder", cty.StringVal(terraformConfig.VsphereConfig.Folder))
-	vsphereConfigBlockBody.SetAttributeValue("hostsystem", cty.StringVal(terraformConfig.VsphereConfig.HostSystem))
-	vsphereConfigBlockBody.SetAttributeValue("memory_size", cty.StringVal(terraformConfig.VsphereConfig.MemorySize))
-	vsphereConfigBlockBody.SetAttributeValue("network", cty.ListVal(networks))
-	vsphereConfigBlockBody.SetAttributeValue("password", cty.StringVal(terraformConfig.VsphereConfig.Password))
-	vsphereConfigBlockBody.SetAttributeValue("pool", cty.StringVal(terraformConfig.VsphereConfig.Pool))
-	vsphereConfigBlockBody.SetAttributeValue("ssh_password", cty.StringVal(terraformConfig.VsphereConfig.SSHPassword))
-	vsphereConfigBlockBody.SetAttributeValue("ssh_port", cty.StringVal(terraformConfig.VsphereConfig.SSHPort))
-	vsphereConfigBlockBody.SetAttributeValue("ssh_user", cty.StringVal(terraformConfig.VsphereConfig.SSHUser))
-	vsphereConfigBlockBody.SetAttributeValue("ssh_user_group", cty.StringVal(terraformConfig.VsphereConfig.SSHUserGroup))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.DockerURL, cty.StringVal(terraformConfig.VsphereConfig.Boot2dockerURL))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.Cfgparam, cty.ListVal(cfgparams))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.CloneFrom, cty.StringVal(terraformConfig.VsphereConfig.CloneFrom))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.CloudConfig, cty.StringVal(terraformConfig.VsphereConfig.CloudConfig))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.Cloudinit, cty.StringVal(terraformConfig.VsphereConfig.Cloudinit))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.ContentLibrary, cty.StringVal(terraformConfig.VsphereConfig.ContentLibrary))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.CPUCount, cty.StringVal(terraformConfig.VsphereConfig.CPUCount))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.CreationType, cty.StringVal(terraformConfig.VsphereConfig.CreationType))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.DataCenter, cty.StringVal(terraformConfig.VsphereConfig.DataCenter))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.DataStore, cty.StringVal(terraformConfig.VsphereConfig.DataStore))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.DatastoreCluster, cty.StringVal(terraformConfig.VsphereConfig.DatastoreCluster))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.DiskSize, cty.StringVal(terraformConfig.VsphereConfig.DiskSize))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.Folder, cty.StringVal(terraformConfig.VsphereConfig.Folder))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.HostSystem, cty.StringVal(terraformConfig.VsphereConfig.HostSystem))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.MemorySize, cty.StringVal(terraformConfig.VsphereConfig.MemorySize))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.Network, cty.ListVal(networks))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.Password, cty.StringVal(terraformConfig.VsphereConfig.Password))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.Pool, cty.StringVal(terraformConfig.VsphereConfig.Pool))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.SSHPassword, cty.StringVal(terraformConfig.VsphereConfig.SSHPassword))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.SSHPort, cty.StringVal(terraformConfig.VsphereConfig.SSHPort))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.SSHUser, cty.StringVal(terraformConfig.VsphereConfig.SSHUser))
+	vsphereConfigBlockBody.SetAttributeValue(vsphere.SSHUserGroup, cty.StringVal(terraformConfig.VsphereConfig.SSHUserGroup))
 }

--- a/framework/set/provisioning/setAKS.go
+++ b/framework/set/provisioning/setAKS.go
@@ -9,6 +9,9 @@ import (
 	"github.com/rancher/shepherd/clients/rancher"
 	framework "github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/configs"
+	blocks "github.com/rancher/tfp-automation/defaults/resourceblocks"
+	"github.com/rancher/tfp-automation/defaults/resourceblocks/nodeproviders/azure"
 	format "github.com/rancher/tfp-automation/framework/format"
 	"github.com/sirupsen/logrus"
 	"github.com/zclconf/go-cty/cty"
@@ -17,48 +20,48 @@ import (
 // SetAKS is a function that will set the AKS configurations in the main.tf file.
 func SetAKS(clusterName, k8sVersion string, nodePools []config.Nodepool, file *os.File) error {
 	rancherConfig := new(rancher.Config)
-	framework.LoadConfig("rancher", rancherConfig)
+	framework.LoadConfig(configs.Rancher, rancherConfig)
 
 	terraformConfig := new(config.TerraformConfig)
-	framework.LoadConfig("terraform", terraformConfig)
+	framework.LoadConfig(configs.Terraform, terraformConfig)
 
 	newFile, rootBody := SetProvidersAndUsersTF(rancherConfig, terraformConfig)
 
 	rootBody.AppendNewline()
 
-	cloudCredBlock := rootBody.AppendNewBlock("resource", []string{"rancher2_cloud_credential", "rancher2_cloud_credential"})
+	cloudCredBlock := rootBody.AppendNewBlock(blocks.Resource, []string{blocks.CloudCredential, blocks.CloudCredential})
 	cloudCredBlockBody := cloudCredBlock.Body()
 
-	cloudCredBlockBody.SetAttributeValue("name", cty.StringVal(terraformConfig.CloudCredentialName))
+	cloudCredBlockBody.SetAttributeValue(blocks.ResourceName, cty.StringVal(terraformConfig.CloudCredentialName))
 
-	azCredConfigBlock := cloudCredBlockBody.AppendNewBlock("azure_credential_config", nil)
+	azCredConfigBlock := cloudCredBlockBody.AppendNewBlock(azure.AzureCredentialConfig, nil)
 	azCredConfigBlockBody := azCredConfigBlock.Body()
 
-	azCredConfigBlockBody.SetAttributeValue("client_id", cty.StringVal(terraformConfig.AzureConfig.ClientID))
-	azCredConfigBlockBody.SetAttributeValue("client_secret", cty.StringVal(terraformConfig.AzureConfig.ClientSecret))
-	azCredConfigBlockBody.SetAttributeValue("subscription_id", cty.StringVal(terraformConfig.AzureConfig.SubscriptionID))
-	azCredConfigBlockBody.SetAttributeValue("tenant_id", cty.StringVal(terraformConfig.AzureConfig.TenantID))
+	azCredConfigBlockBody.SetAttributeValue(azure.ClientID, cty.StringVal(terraformConfig.AzureConfig.ClientID))
+	azCredConfigBlockBody.SetAttributeValue(azure.ClientSecret, cty.StringVal(terraformConfig.AzureConfig.ClientSecret))
+	azCredConfigBlockBody.SetAttributeValue(azure.SubscriptionID, cty.StringVal(terraformConfig.AzureConfig.SubscriptionID))
+	azCredConfigBlockBody.SetAttributeValue(azure.TenantID, cty.StringVal(terraformConfig.AzureConfig.TenantID))
 
 	rootBody.AppendNewline()
 
-	clusterBlock := rootBody.AppendNewBlock("resource", []string{"rancher2_cluster", "rancher2_cluster"})
+	clusterBlock := rootBody.AppendNewBlock(blocks.Resource, []string{blocks.Cluster, blocks.Cluster})
 	clusterBlockBody := clusterBlock.Body()
 
-	clusterBlockBody.SetAttributeValue("name", cty.StringVal(clusterName))
+	clusterBlockBody.SetAttributeValue(blocks.ResourceName, cty.StringVal(clusterName))
 
-	aksConfigBlock := clusterBlockBody.AppendNewBlock("aks_config_v2", nil)
+	aksConfigBlock := clusterBlockBody.AppendNewBlock(azure.AKSConfig, nil)
 	aksConfigBlockBody := aksConfigBlock.Body()
 
 	cloudCredID := hclwrite.Tokens{
-		{Type: hclsyntax.TokenIdent, Bytes: []byte(`rancher2_cloud_credential.rancher2_cloud_credential.id`)},
+		{Type: hclsyntax.TokenIdent, Bytes: []byte(blocks.CloudCredential + "." + blocks.CloudCredential + ".id")},
 	}
 
-	aksConfigBlockBody.SetAttributeRaw("cloud_credential_id", cloudCredID)
-	aksConfigBlockBody.SetAttributeValue("resource_group", cty.StringVal(terraformConfig.AzureConfig.ResourceGroup))
-	aksConfigBlockBody.SetAttributeValue("resource_location", cty.StringVal(terraformConfig.AzureConfig.ResourceLocation))
-	aksConfigBlockBody.SetAttributeValue("dns_prefix", cty.StringVal(terraformConfig.HostnamePrefix))
-	aksConfigBlockBody.SetAttributeValue("kubernetes_version", cty.StringVal(k8sVersion))
-	aksConfigBlockBody.SetAttributeValue("network_plugin", cty.StringVal(terraformConfig.NetworkPlugin))
+	aksConfigBlockBody.SetAttributeRaw(blocks.CloudCredentialID, cloudCredID)
+	aksConfigBlockBody.SetAttributeValue(azure.ResourceGroup, cty.StringVal(terraformConfig.AzureConfig.ResourceGroup))
+	aksConfigBlockBody.SetAttributeValue(azure.ResourceLocation, cty.StringVal(terraformConfig.AzureConfig.ResourceLocation))
+	aksConfigBlockBody.SetAttributeValue(azure.DNSPrefix, cty.StringVal(terraformConfig.HostnamePrefix))
+	aksConfigBlockBody.SetAttributeValue(blocks.KubernetesVersion, cty.StringVal(k8sVersion))
+	aksConfigBlockBody.SetAttributeValue(azure.NetworkPlugin, cty.StringVal(terraformConfig.NetworkPlugin))
 
 	availabilityZones := format.ListOfStrings(terraformConfig.AzureConfig.AvailabilityZones)
 
@@ -70,15 +73,15 @@ func SetAKS(clusterName, k8sVersion string, nodePools []config.Nodepool, file *o
 			return err
 		}
 
-		nodePoolsBlock := aksConfigBlockBody.AppendNewBlock("node_pools", nil)
+		nodePoolsBlock := aksConfigBlockBody.AppendNewBlock(azure.NodePools, nil)
 		nodePoolsBlockBody := nodePoolsBlock.Body()
 
-		nodePoolsBlockBody.SetAttributeRaw("availability_zones", availabilityZones)
-		nodePoolsBlockBody.SetAttributeValue("name", cty.StringVal("pool"+poolNum))
-		nodePoolsBlockBody.SetAttributeValue("count", cty.NumberIntVal(pool.Quantity))
-		nodePoolsBlockBody.SetAttributeValue("orchestrator_version", cty.StringVal(k8sVersion))
-		nodePoolsBlockBody.SetAttributeValue("os_disk_size_gb", cty.NumberIntVal(terraformConfig.AzureConfig.OSDiskSizeGB))
-		nodePoolsBlockBody.SetAttributeValue("vm_size", cty.StringVal(terraformConfig.AzureConfig.VMSize))
+		nodePoolsBlockBody.SetAttributeRaw(azure.AvailabilityZones, availabilityZones)
+		nodePoolsBlockBody.SetAttributeValue(blocks.ResourceName, cty.StringVal(blocks.Pool+poolNum))
+		nodePoolsBlockBody.SetAttributeValue(azure.Count, cty.NumberIntVal(pool.Quantity))
+		nodePoolsBlockBody.SetAttributeValue(azure.OrchestratorVersion, cty.StringVal(k8sVersion))
+		nodePoolsBlockBody.SetAttributeValue(azure.OSDiskSizeGB, cty.NumberIntVal(terraformConfig.AzureConfig.OSDiskSizeGB))
+		nodePoolsBlockBody.SetAttributeValue(azure.VMSize, cty.StringVal(terraformConfig.AzureConfig.VMSize))
 	}
 
 	_, err := file.Write(newFile.Bytes())

--- a/framework/set/provisioning/setBaselinePSACT.go
+++ b/framework/set/provisioning/setBaselinePSACT.go
@@ -5,67 +5,38 @@ import (
 
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
+	blocks "github.com/rancher/tfp-automation/defaults/resourceblocks"
+	"github.com/rancher/tfp-automation/defaults/resourceblocks/psact"
 	"github.com/zclconf/go-cty/cty"
 )
 
-const (
-	baseline    = "baseline"
-	description = "This is a custom baseline Pod Security Admission Configuration Template." + 
-	              "It defines a minimally restrictive policy which prevents known privilege escalations. " +
-	              "This policy contains namespace level exemptions for Rancher components."
-	latest      = "latest"
-)
-
-var exemptionsNamespaces = []string{
-    "ingress-nginx",
-    "kube-system",
-    "cattle-system",
-    "cattle-epinio-system",
-    "cattle-fleet-system",
-    "longhorn-system",
-    "cattle-neuvector-system",
-    "cattle-monitoring-system",
-    "rancher-alerting-drivers",
-    "cis-operator-system",
-    "cattle-csp-adapter-system",
-    "cattle-externalip-system",
-    "cattle-gatekeeper-system",
-    "istio-system",
-    "cattle-istio-system",
-    "cattle-logging-system",
-    "cattle-windows-gmsa-system",
-    "cattle-sriov-system",
-    "cattle-ui-plugin-system",
-    "tigera-operator",
-}
-
 // SetCustomPSACT is a function that will set the Custom PSACT configurations in the main.tf file.
 func SetBaselinePSACT(newFile *hclwrite.File, rootBody *hclwrite.Body) (*hclwrite.File, *hclwrite.Body) {
-	psactBlock := rootBody.AppendNewBlock("resource", []string{"rancher2_pod_security_admission_configuration_template", "rancher2_pod_security_admission_configuration_template"})
+	psactBlock := rootBody.AppendNewBlock(blocks.ResourceName, []string{blocks.PodSecurityAdmission, blocks.PodSecurityAdmission})
 	psactBlockBody := psactBlock.Body()
 
-	psactBlockBody.SetAttributeValue("name", cty.StringVal("rancher-baseline"))
-	psactBlockBody.SetAttributeValue("description", cty.StringVal(description))
+	psactBlockBody.SetAttributeValue(blocks.ResourceName, cty.StringVal(psact.RancherBaseline))
+	psactBlockBody.SetAttributeValue(psact.Description, cty.StringVal(psact.BaselineDescription))
 
-	defaultsBlock := psactBlockBody.AppendNewBlock("defaults", nil)
+	defaultsBlock := psactBlockBody.AppendNewBlock(psact.Defaults, nil)
 	defaultsBlockBody := defaultsBlock.Body()
 
-	defaultsBlockBody.SetAttributeValue("audit", cty.StringVal(baseline))
-	defaultsBlockBody.SetAttributeValue("audit_version", cty.StringVal(latest))
-	defaultsBlockBody.SetAttributeValue("enforce", cty.StringVal(baseline))
-	defaultsBlockBody.SetAttributeValue("enforce_version", cty.StringVal(latest))
-	defaultsBlockBody.SetAttributeValue("warn", cty.StringVal(baseline))
-	defaultsBlockBody.SetAttributeValue("warn_version", cty.StringVal(latest))
+	defaultsBlockBody.SetAttributeValue(psact.Audit, cty.StringVal(psact.Baseline))
+	defaultsBlockBody.SetAttributeValue(psact.AuditVersion, cty.StringVal(psact.Latest))
+	defaultsBlockBody.SetAttributeValue(psact.Enforce, cty.StringVal(psact.Baseline))
+	defaultsBlockBody.SetAttributeValue(psact.EnforceVersion, cty.StringVal(psact.Latest))
+	defaultsBlockBody.SetAttributeValue(psact.Warn, cty.StringVal(psact.Baseline))
+	defaultsBlockBody.SetAttributeValue(psact.WarnVersion, cty.StringVal(psact.Latest))
 
-	exemptionsBlock := psactBlockBody.AppendNewBlock("exemptions", nil)
+	exemptionsBlock := psactBlockBody.AppendNewBlock(psact.Exemptions, nil)
 	exemptionsBlockBody := exemptionsBlock.Body()
 
-	namespacesStr := "\"" + strings.Join(exemptionsNamespaces, "\", \"") + "\""
+	namespacesStr := "\"" + strings.Join(psact.ExemptionsNamespaces, "\", \"") + "\""
 	namespaces := hclwrite.Tokens{
 		{Type: hclsyntax.TokenIdent, Bytes: []byte("[" + namespacesStr + "]")},
 	}
-	
-	exemptionsBlockBody.SetAttributeRaw("namespaces", namespaces)
+
+	exemptionsBlockBody.SetAttributeRaw(psact.Namespaces, namespaces)
 
 	return newFile, rootBody
 }

--- a/framework/set/provisioning/setEKS.go
+++ b/framework/set/provisioning/setEKS.go
@@ -9,6 +9,9 @@ import (
 	"github.com/rancher/shepherd/clients/rancher"
 	ranchFrame "github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/configs"
+	blocks "github.com/rancher/tfp-automation/defaults/resourceblocks"
+	"github.com/rancher/tfp-automation/defaults/resourceblocks/nodeproviders/amazon"
 	format "github.com/rancher/tfp-automation/framework/format"
 	"github.com/sirupsen/logrus"
 	"github.com/zclconf/go-cty/cty"
@@ -17,50 +20,50 @@ import (
 // SetEKS is a function that will set the EKS configurations in the main.tf file.
 func SetEKS(clusterName, k8sVersion string, nodePools []config.Nodepool, file *os.File) error {
 	rancherConfig := new(rancher.Config)
-	ranchFrame.LoadConfig("rancher", rancherConfig)
+	ranchFrame.LoadConfig(configs.Rancher, rancherConfig)
 
 	terraformConfig := new(config.TerraformConfig)
-	ranchFrame.LoadConfig("terraform", terraformConfig)
+	ranchFrame.LoadConfig(configs.Terraform, terraformConfig)
 
 	newFile, rootBody := SetProvidersAndUsersTF(rancherConfig, terraformConfig)
 
 	rootBody.AppendNewline()
 
-	cloudCredBlock := rootBody.AppendNewBlock("resource", []string{"rancher2_cloud_credential", "rancher2_cloud_credential"})
+	cloudCredBlock := rootBody.AppendNewBlock(blocks.Resource, []string{blocks.CloudCredential, blocks.CloudCredential})
 	cloudCredBlockBody := cloudCredBlock.Body()
 
-	cloudCredBlockBody.SetAttributeValue("name", cty.StringVal(terraformConfig.CloudCredentialName))
+	cloudCredBlockBody.SetAttributeValue(blocks.ResourceName, cty.StringVal(terraformConfig.CloudCredentialName))
 
-	ec2CredConfigBlock := cloudCredBlockBody.AppendNewBlock("amazonec2_credential_config", nil)
+	ec2CredConfigBlock := cloudCredBlockBody.AppendNewBlock(amazon.EC2CredentialConfig, nil)
 	ec2CredConfigBlockBody := ec2CredConfigBlock.Body()
 
-	ec2CredConfigBlockBody.SetAttributeValue("access_key", cty.StringVal(terraformConfig.AWSConfig.AWSAccessKey))
-	ec2CredConfigBlockBody.SetAttributeValue("secret_key", cty.StringVal(terraformConfig.AWSConfig.AWSSecretKey))
-	ec2CredConfigBlockBody.SetAttributeValue("default_region", cty.StringVal(terraformConfig.AWSConfig.Region))
+	ec2CredConfigBlockBody.SetAttributeValue(blocks.AccessKey, cty.StringVal(terraformConfig.AWSConfig.AWSAccessKey))
+	ec2CredConfigBlockBody.SetAttributeValue(blocks.SecretKey, cty.StringVal(terraformConfig.AWSConfig.AWSSecretKey))
+	ec2CredConfigBlockBody.SetAttributeValue(amazon.DefaultRegion, cty.StringVal(terraformConfig.AWSConfig.Region))
 
 	rootBody.AppendNewline()
 
-	clusterBlock := rootBody.AppendNewBlock("resource", []string{"rancher2_cluster", "rancher2_cluster"})
+	clusterBlock := rootBody.AppendNewBlock(blocks.Resource, []string{blocks.Cluster, blocks.Cluster})
 	clusterBlockBody := clusterBlock.Body()
 
-	clusterBlockBody.SetAttributeValue("name", cty.StringVal(clusterName))
+	clusterBlockBody.SetAttributeValue(blocks.ResourceName, cty.StringVal(clusterName))
 
-	eksConfigBlock := clusterBlockBody.AppendNewBlock("eks_config_v2", nil)
+	eksConfigBlock := clusterBlockBody.AppendNewBlock(amazon.EKSConfig, nil)
 	eksConfigBlockBody := eksConfigBlock.Body()
 
 	cloudCredID := hclwrite.Tokens{
-		{Type: hclsyntax.TokenIdent, Bytes: []byte(`rancher2_cloud_credential.rancher2_cloud_credential.id`)},
+		{Type: hclsyntax.TokenIdent, Bytes: []byte(blocks.CloudCredential + "." + blocks.CloudCredential + ".id")},
 	}
 
-	eksConfigBlockBody.SetAttributeRaw("cloud_credential_id", cloudCredID)
-	eksConfigBlockBody.SetAttributeValue("region", cty.StringVal(terraformConfig.AWSConfig.Region))
-	eksConfigBlockBody.SetAttributeValue("kubernetes_version", cty.StringVal(k8sVersion))
+	eksConfigBlockBody.SetAttributeRaw(blocks.CloudCredentialID, cloudCredID)
+	eksConfigBlockBody.SetAttributeValue(blocks.Region, cty.StringVal(terraformConfig.AWSConfig.Region))
+	eksConfigBlockBody.SetAttributeValue(blocks.KubernetesVersion, cty.StringVal(k8sVersion))
 	awsSubnetsList := format.ListOfStrings(terraformConfig.AWSConfig.AWSSubnets)
-	eksConfigBlockBody.SetAttributeRaw("subnets", awsSubnetsList)
+	eksConfigBlockBody.SetAttributeRaw(amazon.Subnets, awsSubnetsList)
 	awsSecGroupsList := format.ListOfStrings(terraformConfig.AWSConfig.AWSSecurityGroups)
-	eksConfigBlockBody.SetAttributeRaw("security_groups", awsSecGroupsList)
-	eksConfigBlockBody.SetAttributeValue("private_access", cty.BoolVal(terraformConfig.AWSConfig.PrivateAccess))
-	eksConfigBlockBody.SetAttributeValue("public_access", cty.BoolVal(terraformConfig.AWSConfig.PublicAccess))
+	eksConfigBlockBody.SetAttributeRaw(amazon.SecurityGroups, awsSecGroupsList)
+	eksConfigBlockBody.SetAttributeValue(amazon.PrivateAccess, cty.BoolVal(terraformConfig.AWSConfig.PrivateAccess))
+	eksConfigBlockBody.SetAttributeValue(amazon.PublicAccess, cty.BoolVal(terraformConfig.AWSConfig.PublicAccess))
 
 	for count, pool := range nodePools {
 		poolNum := strconv.Itoa(count)
@@ -70,14 +73,14 @@ func SetEKS(clusterName, k8sVersion string, nodePools []config.Nodepool, file *o
 			return err
 		}
 
-		nodePoolsBlock := eksConfigBlockBody.AppendNewBlock("node_groups", nil)
+		nodePoolsBlock := eksConfigBlockBody.AppendNewBlock(amazon.NodeGroups, nil)
 		nodePoolsBlockBody := nodePoolsBlock.Body()
 
-		nodePoolsBlockBody.SetAttributeValue("name", cty.StringVal(terraformConfig.HostnamePrefix+`-pool`+poolNum))
-		nodePoolsBlockBody.SetAttributeValue("instance_type", cty.StringVal(pool.InstanceType))
-		nodePoolsBlockBody.SetAttributeValue("desired_size", cty.NumberIntVal(pool.DesiredSize))
-		nodePoolsBlockBody.SetAttributeValue("max_size", cty.NumberIntVal(pool.MaxSize))
-		nodePoolsBlockBody.SetAttributeValue("min_size", cty.NumberIntVal(pool.MinSize))
+		nodePoolsBlockBody.SetAttributeValue(blocks.ResourceName, cty.StringVal(terraformConfig.HostnamePrefix+`-pool`+poolNum))
+		nodePoolsBlockBody.SetAttributeValue(amazon.InstanceType, cty.StringVal(pool.InstanceType))
+		nodePoolsBlockBody.SetAttributeValue(amazon.DesiredSize, cty.NumberIntVal(pool.DesiredSize))
+		nodePoolsBlockBody.SetAttributeValue(amazon.MaxSize, cty.NumberIntVal(pool.MaxSize))
+		nodePoolsBlockBody.SetAttributeValue(amazon.MinSize, cty.NumberIntVal(pool.MinSize))
 	}
 
 	_, err := file.Write(newFile.Bytes())

--- a/framework/set/provisioning/setETCDSnapshots.go
+++ b/framework/set/provisioning/setETCDSnapshots.go
@@ -3,36 +3,40 @@ package provisioning
 import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/resourceblocks"
+	"github.com/rancher/tfp-automation/defaults/resourceblocks/snapshot"
 	"github.com/zclconf/go-cty/cty"
 )
 
-// setCreateRKE2K3SSnapshot is a function that will set the etcd_snapshot_create resource block in the main.tf file for a RKE2/K3S cluster.
+// setCreateRKE2K3SSnapshot is a function that will set the etcd_snapshot_create resource
+// block in the main.tf file for a RKE2/K3S cluster.
 func setCreateRKE2K3SSnapshot(terraformConfig *config.TerraformConfig, rkeConfigBlockBody *hclwrite.Body) {
-	createSnapshotBlock := rkeConfigBlockBody.AppendNewBlock("etcd_snapshot_create", nil)
+	createSnapshotBlock := rkeConfigBlockBody.AppendNewBlock(snapshot.EtcdSnapshotCreate, nil)
 	createSnapshotBlockBody := createSnapshotBlock.Body()
 
 	generation := int64(1)
 
-	if createSnapshotBlockBody.GetAttribute("generation") == nil {
-		createSnapshotBlockBody.SetAttributeValue("generation", cty.NumberIntVal(generation))
+	if createSnapshotBlockBody.GetAttribute(snapshot.Generation) == nil {
+		createSnapshotBlockBody.SetAttributeValue(snapshot.Generation, cty.NumberIntVal(generation))
 	} else {
-		createSnapshotBlockBody.SetAttributeValue("generation", cty.NumberIntVal(generation+1))
+		createSnapshotBlockBody.SetAttributeValue(snapshot.Generation, cty.NumberIntVal(generation+1))
 	}
 }
 
-// setRestoreRKE2K3SSnapshot is a function that will set the etcd_snapshot_restore resource block in the main.tf file for a RKE2/K3S cluster.
+// setRestoreRKE2K3SSnapshot is a function that will set the etcd_snapshot_restore
+// resource block in the main.tf file for a RKE2/K3S cluster.
 func setRestoreRKE2K3SSnapshot(terraformConfig *config.TerraformConfig, rkeConfigBlockBody *hclwrite.Body, snapshots config.Snapshots) {
-	restoreSnapshotBlock := rkeConfigBlockBody.AppendNewBlock("etcd_snapshot_restore", nil)
+	restoreSnapshotBlock := rkeConfigBlockBody.AppendNewBlock(snapshot.EtcdSnapshotRestore, nil)
 	restoreSnapshotBlockBody := restoreSnapshotBlock.Body()
 
 	generation := int64(1)
 
-	if restoreSnapshotBlockBody.GetAttribute("generation") == nil {
-		restoreSnapshotBlockBody.SetAttributeValue("generation", cty.NumberIntVal(generation))
+	if restoreSnapshotBlockBody.GetAttribute(snapshot.Generation) == nil {
+		restoreSnapshotBlockBody.SetAttributeValue(snapshot.Generation, cty.NumberIntVal(generation))
 	} else {
-		restoreSnapshotBlockBody.SetAttributeValue("generation", cty.NumberIntVal(generation+1))
+		restoreSnapshotBlockBody.SetAttributeValue(snapshot.Generation, cty.NumberIntVal(generation+1))
 	}
 
-	restoreSnapshotBlockBody.SetAttributeValue(("name"), cty.StringVal(snapshots.SnapshotName))
-	restoreSnapshotBlockBody.SetAttributeValue(("restore_rke_config"), cty.StringVal(snapshots.SnapshotRestore))
+	restoreSnapshotBlockBody.SetAttributeValue((resourceblocks.ResourceName), cty.StringVal(snapshots.SnapshotName))
+	restoreSnapshotBlockBody.SetAttributeValue((snapshot.RestoreRKEConfig), cty.StringVal(snapshots.SnapshotRestore))
 }

--- a/framework/set/provisioning/setRKE2K3sConfig.go
+++ b/framework/set/provisioning/setRKE2K3sConfig.go
@@ -10,6 +10,11 @@ import (
 	"github.com/rancher/shepherd/clients/rancher"
 	ranchFrame "github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/configs"
+	"github.com/rancher/tfp-automation/defaults/modules"
+	blocks "github.com/rancher/tfp-automation/defaults/resourceblocks"
+	psactBlock "github.com/rancher/tfp-automation/defaults/resourceblocks/psact"
+	v2Block "github.com/rancher/tfp-automation/defaults/resourceblocks/rke2k3s"
 	azure "github.com/rancher/tfp-automation/framework/set/provisioning/providers/azure"
 	ec2 "github.com/rancher/tfp-automation/framework/set/provisioning/providers/ec2"
 	linode "github.com/rancher/tfp-automation/framework/set/provisioning/providers/linode"
@@ -21,7 +26,7 @@ import (
 // SetRKE2K3s is a function that will set the RKE2/K3S configurations in the main.tf file.
 func SetRKE2K3s(clusterName, poolName, k8sVersion, psact string, nodePools []config.Nodepool, snapshots config.Snapshots, file *os.File) error {
 	rancherConfig := new(rancher.Config)
-	ranchFrame.LoadConfig("rancher", rancherConfig)
+	ranchFrame.LoadConfig(configs.Rancher, rancherConfig)
 
 	terraformConfig := new(config.TerraformConfig)
 	ranchFrame.LoadConfig(config.TerraformConfigurationFileKey, terraformConfig)
@@ -34,61 +39,61 @@ func SetRKE2K3s(clusterName, poolName, k8sVersion, psact string, nodePools []con
 	rootBody.AppendNewline()
 
 	switch {
-	case terraformConfig.Module == azure_rke2 || terraformConfig.Module == azure_k3s:
+	case terraformConfig.Module == modules.AzureRKE2 || terraformConfig.Module == modules.AzureK3s:
 		azure.SetAzureRKE2K3SProvider(rootBody, terraformConfig)
-	case terraformConfig.Module == ec2RKE2 || terraformConfig.Module == ec2K3s:
+	case terraformConfig.Module == modules.EC2RKE2 || terraformConfig.Module == modules.EC2K3s:
 		ec2.SetEC2RKE2K3SProvider(rootBody, terraformConfig)
-	case terraformConfig.Module == linodeRKE2 || terraformConfig.Module == linodeK3s:
+	case terraformConfig.Module == modules.LinodeRKE2 || terraformConfig.Module == modules.LinodeK3s:
 		linode.SetLinodeRKE2K3SProvider(rootBody, terraformConfig)
-	case terraformConfig.Module == vsphereRKE2 || terraformConfig.Module == vsphereK3s:
+	case terraformConfig.Module == modules.VsphereRKE2 || terraformConfig.Module == modules.VsphereK3s:
 		vsphere.SetVsphereRKE2K3SProvider(rootBody, terraformConfig)
 	}
 
 	rootBody.AppendNewline()
 
-	if strings.Contains(psact, rancherBaseline) {
+	if strings.Contains(psact, psactBlock.RancherBaseline) {
 		newFile, rootBody = SetBaselinePSACT(newFile, rootBody)
 
 		rootBody.AppendNewline()
 	}
 
-	machineConfigBlock := rootBody.AppendNewBlock("resource", []string{"rancher2_machine_config_v2", "rancher2_machine_config_v2"})
+	machineConfigBlock := rootBody.AppendNewBlock(blocks.Resource, []string{v2Block.MachineConfigV2, v2Block.MachineConfigV2})
 	machineConfigBlockBody := machineConfigBlock.Body()
 
-	if psact == "rancher-baseline" {
+	if psact == psactBlock.RancherBaseline {
 		dependsOnTemp := hclwrite.Tokens{
-			{Type: hclsyntax.TokenIdent, Bytes: []byte("[rancher2_pod_security_admission_configuration_template." +
-				"rancher2_pod_security_admission_configuration_template]")},
+			{Type: hclsyntax.TokenIdent, Bytes: []byte("[" + blocks.PodSecurityAdmission + "." +
+				blocks.PodSecurityAdmission + "]")},
 		}
 
-		machineConfigBlockBody.SetAttributeRaw("depends_on", dependsOnTemp)
+		machineConfigBlockBody.SetAttributeRaw(blocks.DependsOn, dependsOnTemp)
 	}
 
-	machineConfigBlockBody.SetAttributeValue("generate_name", cty.StringVal(terraformConfig.MachineConfigName))
+	machineConfigBlockBody.SetAttributeValue(blocks.GenerateName, cty.StringVal(terraformConfig.MachineConfigName))
 
 	switch {
-	case terraformConfig.Module == azure_rke2 || terraformConfig.Module == azure_k3s:
+	case terraformConfig.Module == modules.AzureRKE2 || terraformConfig.Module == modules.AzureK3s:
 		azure.SetAzureRKE2K3SMachineConfig(machineConfigBlockBody, terraformConfig)
-	case terraformConfig.Module == ec2RKE2 || terraformConfig.Module == ec2K3s:
+	case terraformConfig.Module == modules.EC2RKE2 || terraformConfig.Module == modules.EC2K3s:
 		ec2.SetEC2RKE2K3SMachineConfig(machineConfigBlockBody, terraformConfig)
-	case terraformConfig.Module == linodeRKE2 || terraformConfig.Module == linodeK3s:
+	case terraformConfig.Module == modules.LinodeRKE2 || terraformConfig.Module == modules.LinodeK3s:
 		linode.SetLinodeRKE2K3SMachineConfig(machineConfigBlockBody, terraformConfig)
-	case terraformConfig.Module == vsphereRKE2 || terraformConfig.Module == vsphereK3s:
+	case terraformConfig.Module == modules.VsphereRKE2 || terraformConfig.Module == modules.VsphereK3s:
 		vsphere.SetVsphereRKE2K3SMachineConfig(machineConfigBlockBody, terraformConfig)
 	}
 
 	rootBody.AppendNewline()
 
-	clusterBlock := rootBody.AppendNewBlock("resource", []string{"rancher2_cluster_v2", "rancher2_cluster_v2"})
+	clusterBlock := rootBody.AppendNewBlock(blocks.Resource, []string{v2Block.ClusterV2, v2Block.ClusterV2})
 	clusterBlockBody := clusterBlock.Body()
 
-	clusterBlockBody.SetAttributeValue("name", cty.StringVal(clusterName))
-	clusterBlockBody.SetAttributeValue("kubernetes_version", cty.StringVal(k8sVersion))
-	clusterBlockBody.SetAttributeValue("enable_network_policy", cty.BoolVal(terraformConfig.EnableNetworkPolicy))
-	clusterBlockBody.SetAttributeValue("default_pod_security_admission_configuration_template_name", cty.StringVal(psact))
-	clusterBlockBody.SetAttributeValue("default_cluster_role_for_project_members", cty.StringVal(terraformConfig.DefaultClusterRoleForProjectMembers))
+	clusterBlockBody.SetAttributeValue(blocks.ResourceName, cty.StringVal(clusterName))
+	clusterBlockBody.SetAttributeValue(blocks.KubernetesVersion, cty.StringVal(k8sVersion))
+	clusterBlockBody.SetAttributeValue(blocks.EnableNetworkPolicy, cty.BoolVal(terraformConfig.EnableNetworkPolicy))
+	clusterBlockBody.SetAttributeValue(blocks.DefaultPodSecurityAdmission, cty.StringVal(psact))
+	clusterBlockBody.SetAttributeValue(blocks.DefaultClusterRoleForProjectMembers, cty.StringVal(terraformConfig.DefaultClusterRoleForProjectMembers))
 
-	rkeConfigBlock := clusterBlockBody.AppendNewBlock("rke_config", nil)
+	rkeConfigBlock := clusterBlockBody.AppendNewBlock(blocks.RKEConfig, nil)
 	rkeConfigBlockBody := rkeConfigBlock.Body()
 
 	for count, pool := range nodePools {
@@ -99,68 +104,66 @@ func SetRKE2K3s(clusterName, poolName, k8sVersion, psact string, nodePools []con
 			return err
 		}
 
-		machinePoolsBlock := rkeConfigBlockBody.AppendNewBlock("machine_pools", nil)
+		machinePoolsBlock := rkeConfigBlockBody.AppendNewBlock(blocks.MachinePools, nil)
 		machinePoolsBlockBody := machinePoolsBlock.Body()
 
-		machinePoolsBlockBody.SetAttributeValue("name", cty.StringVal(poolName+poolNum))
+		machinePoolsBlockBody.SetAttributeValue(blocks.ResourceName, cty.StringVal(poolName+poolNum))
 
 		cloudCredSecretName := hclwrite.Tokens{
-			{Type: hclsyntax.TokenIdent, Bytes: []byte("rancher2_cloud_credential.rancher2_cloud_credential.id")},
+			{Type: hclsyntax.TokenIdent, Bytes: []byte(blocks.CloudCredential + "." + blocks.CloudCredential + ".id")},
 		}
 
-		machinePoolsBlockBody.SetAttributeRaw("cloud_credential_secret_name", cloudCredSecretName)
-		machinePoolsBlockBody.SetAttributeValue("control_plane_role", cty.BoolVal(pool.Controlplane))
-		machinePoolsBlockBody.SetAttributeValue("etcd_role", cty.BoolVal(pool.Etcd))
-		machinePoolsBlockBody.SetAttributeValue("worker_role", cty.BoolVal(pool.Worker))
-		machinePoolsBlockBody.SetAttributeValue("quantity", cty.NumberIntVal(pool.Quantity))
+		machinePoolsBlockBody.SetAttributeRaw(v2Block.CloudCredentialSecretName, cloudCredSecretName)
+		machinePoolsBlockBody.SetAttributeValue(v2Block.ControlPlaneRole, cty.BoolVal(pool.Controlplane))
+		machinePoolsBlockBody.SetAttributeValue(v2Block.EtcdRole, cty.BoolVal(pool.Etcd))
+		machinePoolsBlockBody.SetAttributeValue(v2Block.WorkerRole, cty.BoolVal(pool.Worker))
+		machinePoolsBlockBody.SetAttributeValue(blocks.Quantity, cty.NumberIntVal(pool.Quantity))
 
-		machineConfigBlock := machinePoolsBlockBody.AppendNewBlock("machine_config", nil)
+		machineConfigBlock := machinePoolsBlockBody.AppendNewBlock(blocks.MachineConfig, nil)
 		machineConfigBlockBody := machineConfigBlock.Body()
 
 		kind := hclwrite.Tokens{
-			{Type: hclsyntax.TokenIdent, Bytes: []byte("rancher2_machine_config_v2.rancher2_machine_config_v2.kind")},
+			{Type: hclsyntax.TokenIdent, Bytes: []byte(v2Block.MachineConfigV2 + "." + v2Block.MachineConfigV2 + ".kind")},
 		}
 
-		machineConfigBlockBody.SetAttributeRaw("kind", kind)
+		machineConfigBlockBody.SetAttributeRaw(blocks.ResourceKind, kind)
 
 		name := hclwrite.Tokens{
-			{Type: hclsyntax.TokenIdent, Bytes: []byte("rancher2_machine_config_v2.rancher2_machine_config_v2.name")},
+			{Type: hclsyntax.TokenIdent, Bytes: []byte(v2Block.MachineConfigV2 + "." + v2Block.MachineConfigV2 + ".name")},
 		}
 
-		machineConfigBlockBody.SetAttributeRaw("name", name)
-
-		count++
+		machineConfigBlockBody.SetAttributeRaw(blocks.ResourceName, name)
 	}
 
-	upgradeStrategyBlock := rkeConfigBlockBody.AppendNewBlock("upgrade_strategy", nil)
+	upgradeStrategyBlock := rkeConfigBlockBody.AppendNewBlock(v2Block.UpgradeStrategy, nil)
 	upgradeStrategyBlockBody := upgradeStrategyBlock.Body()
 
-	upgradeStrategyBlockBody.SetAttributeValue("control_plane_concurrency", cty.StringVal(("10%")))
-	upgradeStrategyBlockBody.SetAttributeValue("worker_concurrency", cty.StringVal(("10%")))
+	upgradeStrategyBlockBody.SetAttributeValue(v2Block.ControlPlaneConcurrency, cty.StringVal(("10%")))
+	upgradeStrategyBlockBody.SetAttributeValue(v2Block.WorkerConcurrency, cty.StringVal(("10%")))
 
 	if terraformConfig.ETCD != nil {
-		snapshotBlock := rkeConfigBlockBody.AppendNewBlock("etcd", nil)
+		snapshotBlock := rkeConfigBlockBody.AppendNewBlock(blocks.Etcd, nil)
 		snapshotBlockBody := snapshotBlock.Body()
 
-		snapshotBlockBody.SetAttributeValue("disable_snapshots", cty.BoolVal(terraformConfig.ETCD.DisableSnapshots))
-		snapshotBlockBody.SetAttributeValue("snapshot_schedule_cron", cty.StringVal(terraformConfig.ETCD.SnapshotScheduleCron))
-		snapshotBlockBody.SetAttributeValue("snapshot_retention", cty.NumberIntVal(int64(terraformConfig.ETCD.SnapshotRetention)))
+		snapshotBlockBody.SetAttributeValue(v2Block.DisableSnapshots, cty.BoolVal(terraformConfig.ETCD.DisableSnapshots))
+		snapshotBlockBody.SetAttributeValue(v2Block.SnapshotScheduleCron, cty.StringVal(terraformConfig.ETCD.SnapshotScheduleCron))
+		snapshotBlockBody.SetAttributeValue(v2Block.SnapshotRetention, cty.NumberIntVal(int64(terraformConfig.ETCD.SnapshotRetention)))
 
-		if strings.Contains(terraformConfig.Module, "ec2") && terraformConfig.ETCD.S3 != nil {
-			s3ConfigBlock := snapshotBlockBody.AppendNewBlock("s3_config", nil)
+		if strings.Contains(terraformConfig.Module, modules.EC2) && terraformConfig.ETCD.S3 != nil {
+			s3ConfigBlock := snapshotBlockBody.AppendNewBlock(v2Block.S3Config, nil)
 			s3ConfigBlockBody := s3ConfigBlock.Body()
 
 			cloudCredSecretName := hclwrite.Tokens{
-				{Type: hclsyntax.TokenIdent, Bytes: []byte("rancher2_cloud_credential.rancher2_cloud_credential.id")},
+				{Type: hclsyntax.TokenIdent, Bytes: []byte(blocks.CloudCredential + "." + blocks.CloudCredential + ".id")},
 			}
 
-			s3ConfigBlockBody.SetAttributeValue("bucket", cty.StringVal(terraformConfig.ETCD.S3.Bucket))
-			s3ConfigBlockBody.SetAttributeValue("endpoint", cty.StringVal(terraformConfig.ETCD.S3.Endpoint))
-			s3ConfigBlockBody.SetAttributeRaw("cloud_credential_name", cloudCredSecretName)
-			s3ConfigBlockBody.SetAttributeValue("endpoint_ca", cty.StringVal(terraformConfig.ETCD.S3.EndpointCA))
-			s3ConfigBlockBody.SetAttributeValue("folder", cty.StringVal(terraformConfig.ETCD.S3.Folder))
-			s3ConfigBlockBody.SetAttributeValue("region", cty.StringVal(terraformConfig.ETCD.S3.Region))
-			s3ConfigBlockBody.SetAttributeValue("skip_ssl_verify", cty.BoolVal(terraformConfig.ETCD.S3.SkipSSLVerify))
+			s3ConfigBlockBody.SetAttributeValue(v2Block.Bucket, cty.StringVal(terraformConfig.ETCD.S3.Bucket))
+			s3ConfigBlockBody.SetAttributeValue(blocks.Endpoint, cty.StringVal(terraformConfig.ETCD.S3.Endpoint))
+			s3ConfigBlockBody.SetAttributeRaw(v2Block.CloudCredentialName, cloudCredSecretName)
+			s3ConfigBlockBody.SetAttributeValue(v2Block.EndpointCA, cty.StringVal(terraformConfig.ETCD.S3.EndpointCA))
+			s3ConfigBlockBody.SetAttributeValue(blocks.Folder, cty.StringVal(terraformConfig.ETCD.S3.Folder))
+			s3ConfigBlockBody.SetAttributeValue(blocks.Region, cty.StringVal(terraformConfig.ETCD.S3.Region))
+			s3ConfigBlockBody.SetAttributeValue(v2Block.SkipSSLVerify, cty.BoolVal(terraformConfig.ETCD.S3.SkipSSLVerify))
 		}
 	}
 

--- a/framework/set/provisioning/setResourceNodepoolValdiation.go
+++ b/framework/set/provisioning/setResourceNodepoolValdiation.go
@@ -6,29 +6,31 @@ import (
 
 	ranchFrame "github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/clustertypes"
+	"github.com/rancher/tfp-automation/defaults/configs"
 )
 
 // SetResourceNodepoolValidation is a function that will validate the nodepool configurations.
 func SetResourceNodepoolValidation(pool config.Nodepool, poolNum string) (bool, error) {
 	terraformConfig := new(config.TerraformConfig)
-	ranchFrame.LoadConfig("terraform", terraformConfig)
+	ranchFrame.LoadConfig(configs.Terraform, terraformConfig)
 
 	module := terraformConfig.Module
 
 	switch {
-	case module == aks || module == gke:
+	case module == clustertypes.AKS || module == clustertypes.GKE:
 		if pool.Quantity <= 0 {
 			return false, fmt.Errorf(`Invalid quantity specified for pool %v. Quantity must be greater than 0.`, poolNum)
 		}
 
 		return true, nil
-	case module == eks:
+	case module == clustertypes.EKS:
 		if pool.DesiredSize <= 0 {
 			return false, fmt.Errorf(`Invalid desired size specified for pool %v. Desired size must be greater than 0.`, poolNum)
 		}
 
 		return true, nil
-	case strings.Contains(module, rke1) || strings.Contains(module, rke2) || strings.Contains(module, k3s):
+	case strings.Contains(module, clustertypes.RKE1) || strings.Contains(module, clustertypes.RKE2) || strings.Contains(module, clustertypes.K3S):
 		if !pool.Etcd && !pool.Controlplane && !pool.Worker {
 			return false, fmt.Errorf(`No roles selected for pool %v. At least one role is required`, poolNum)
 		}

--- a/framework/wait/state/activeNodes.go
+++ b/framework/wait/state/activeNodes.go
@@ -1,18 +1,20 @@
-package framework
+package state
 
 import (
+	"context"
 	"time"
 
 	"github.com/rancher/norman/types"
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/shepherd/extensions/defaults"
+	"github.com/rancher/tfp-automation/defaults/clusterstate"
 	"github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/util/wait"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
 )
 
 // AreNodesActive is a function that will wait for all nodes in the cluster to be in an active state.
 func AreNodesActive(client *rancher.Client, clusterID string) error {
-	err := wait.Poll(10*time.Second, defaults.ThirtyMinuteTimeout, func() (bool, error) {
+	err := kwait.PollUntilContextTimeout(context.TODO(), 10*time.Second, defaults.ThirtyMinuteTimeout, true, func(ctx context.Context) (done bool, err error) {
 		nodes, err := client.Management.Node.ListAll(&types.ListOpts{
 			Filters: map[string]interface{}{
 				"clusterId": clusterID,
@@ -28,17 +30,18 @@ func AreNodesActive(client *rancher.Client, clusterID string) error {
 				return false, nil
 			}
 
-			if node.State == errorState {
+			if node.State == clusterstate.ErrorState {
 				logrus.Warnf("Node %s is in error state", node.Name)
 				return false, nil
 			}
 
-			if node.State != activeState {
+			if node.State != clusterstate.ActiveState {
 				return false, nil
 			}
 		}
 
 		logrus.Infof("All nodes in the cluster are in an active state!")
+
 		return true, nil
 	})
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/gruntwork-io/terratest v0.42.0
 	github.com/rancher/norman v0.0.0-20230831160711-5de27f66385d
 	github.com/rancher/rancher/pkg/apis v0.0.0
-	github.com/rancher/shepherd v0.0.0-20240327192714-e69b22cd17df
+	github.com/rancher/shepherd v0.0.0-20240412143227-f816adca9592
 	github.com/sirupsen/logrus v1.9.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1116,8 +1116,8 @@ github.com/rancher/rancher/pkg/apis v0.0.0-20230525094739-ff2e09449efc h1:NuDuqL
 github.com/rancher/rancher/pkg/apis v0.0.0-20230525094739-ff2e09449efc/go.mod h1:4KAasaWJ3wmljgFGP4z08SVP4Snr1CWeY7McL4JFn+o=
 github.com/rancher/rke v1.5.0 h1:M/YryKnBs7IwzMGA2kh1EiypVQkme6o9KSg0hlllQa4=
 github.com/rancher/rke v1.5.0/go.mod h1:wZaVWzW46OTuGvyxgRHXGUyJ/QP0zOkKESO9hBOwTaY=
-github.com/rancher/shepherd v0.0.0-20240327192714-e69b22cd17df h1:eXq5QDlpTD/6+RNftVvsAHnZqpj2wcmf1va8s2BKNzY=
-github.com/rancher/shepherd v0.0.0-20240327192714-e69b22cd17df/go.mod h1:CSj1hioOlfZpsd3Upu4A1bgv1jOf1eMICz4LL0KEJKA=
+github.com/rancher/shepherd v0.0.0-20240412143227-f816adca9592 h1:5Pb3GA8GoveL05js5ncMDn4i0IUhGdBMBUI/fjCE0Y8=
+github.com/rancher/shepherd v0.0.0-20240412143227-f816adca9592/go.mod h1:CSj1hioOlfZpsd3Upu4A1bgv1jOf1eMICz4LL0KEJKA=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007 h1:ru+mqGnxMmKeU0Q3XIDxkARvInDIqT1hH2amTcsjxI4=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007/go.mod h1:Ja346o44aTPWADc/5Jm93+KgctT6KtftuOosgz0F2AM=
 github.com/rancher/wrangler v0.6.1/go.mod h1:L4HtjPeX8iqLgsxfJgz+JjKMcX2q3qbRXSeTlC/CSd4=

--- a/pipeline/qase/defaults.go
+++ b/pipeline/qase/defaults.go
@@ -1,8 +1,0 @@
-package qase
-
-const (
-	RancherManagerProjectID = "RM"
-	QaseTokenEnvVar         = "QASE_AUTOMATION_TOKEN"
-	TestRunEnvVar           = "QASE_TEST_RUN_ID"
-	TestRunNAMEEnvVar       = "TEST_RUN_NAME"
-)

--- a/pipeline/qase/testrun/main.go
+++ b/pipeline/qase/testrun/main.go
@@ -1,4 +1,4 @@
-package main
+package testrun
 
 import (
 	"context"
@@ -7,20 +7,10 @@ import (
 	"log"
 	"os"
 
-	qasedefaults "github.com/rancher/tfp-automation/pipeline/qase"
+	defaults "github.com/rancher/tfp-automation/defaults/qase"
 	"github.com/sirupsen/logrus"
 	qase "go.qase.io/client"
 	"gopkg.in/yaml.v2"
-)
-
-const (
-	runSourceID    = 16
-	recurringRunID = 1
-)
-
-var (
-	testRunName = os.Getenv(qasedefaults.TestRunNAMEEnvVar)
-	qaseToken   = os.Getenv(qasedefaults.QaseTokenEnvVar)
 )
 
 type RecurringTestRun struct {
@@ -32,13 +22,17 @@ func main() {
 	startRun := flag.Bool("startRun", false, "commandline flag that determines when to start a run, and conversely when to end it.")
 	flag.Parse()
 
+	qaseToken := os.Getenv(defaults.QaseTokenEnvVar)
+
 	cfg := qase.NewConfiguration()
 	cfg.AddDefaultHeader("Token", qaseToken)
 	client := qase.NewAPIClient(cfg)
 
 	if *startRun {
 		// create test run
-		resp, err := createTestRun(client, testRunName)
+		runIDEnvVar := os.Getenv(defaults.TestRunNAMEEnvVar)
+
+		resp, err := createTestRun(client, runIDEnvVar)
 		if err != nil {
 			logrus.Error("error creating test run: ", err)
 		}
@@ -57,7 +51,7 @@ func main() {
 			logrus.Fatalf("error reporting converting string to int32: %v", err)
 		}
 		// complete test run
-		_, _, err = client.RunsApi.CompleteRun(context.TODO(), qasedefaults.RancherManagerProjectID, int32(testRunConfig.ID))
+		_, _, err = client.RunsApi.CompleteRun(context.TODO(), defaults.RancherManagerProjectID, int32(testRunConfig.ID))
 		if err != nil {
 			log.Fatalf("error completing test run: %v", err)
 		}
@@ -69,11 +63,11 @@ func createTestRun(client *qase.APIClient, testRunName string) (*qase.IdResponse
 	runCreateBody := qase.RunCreate{
 		Title: testRunName,
 		CustomField: map[string]string{
-			fmt.Sprintf("%d", runSourceID): fmt.Sprintf("%d", recurringRunID),
+			fmt.Sprintf("%d", defaults.RunSourceID): fmt.Sprintf("%d", defaults.RecurringRunID),
 		},
 	}
 
-	idResponse, _, err := client.RunsApi.CreateRun(context.TODO(), runCreateBody, qasedefaults.RancherManagerProjectID)
+	idResponse, _, err := client.RunsApi.CreateRun(context.TODO(), runCreateBody, defaults.RancherManagerProjectID)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/extensions/provisioning/buildModule.go
+++ b/tests/extensions/provisioning/buildModule.go
@@ -6,19 +6,15 @@ import (
 
 	ranchFrame "github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/configs"
 	set "github.com/rancher/tfp-automation/framework/set/provisioning"
 	"github.com/sirupsen/logrus"
-)
-
-const (
-	terratest                = "terratest"
-	terraformFrameworkConfig = "terraform"
 )
 
 // BuildModule is a function that builds the Terraform module.
 func BuildModule(t *testing.T) error {
 	clusterConfig := new(config.TerratestConfig)
-	ranchFrame.LoadConfig(terratest, clusterConfig)
+	ranchFrame.LoadConfig(configs.Terratest, clusterConfig)
 
 	keyPath := set.SetKeyPath()
 
@@ -27,7 +23,7 @@ func BuildModule(t *testing.T) error {
 		return err
 	}
 
-	module, err := os.ReadFile(keyPath + "/main.tf")
+	module, err := os.ReadFile(keyPath + configs.MainTF)
 	if err != nil {
 		logrus.Errorf("Failed to read main.tf file contents. Error: %v", err)
 

--- a/tests/extensions/provisioning/defaultK8sVersion.go
+++ b/tests/extensions/provisioning/defaultK8sVersion.go
@@ -8,30 +8,24 @@ import (
 	"github.com/rancher/shepherd/extensions/clusters"
 	"github.com/rancher/shepherd/extensions/clusters/kubernetesversions"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/clustertypes"
 	"github.com/stretchr/testify/require"
-)
-
-const (
-	RKE1    = "rke1"
-	RKE2    = "rke2"
-	K3S     = "k3s"
-	RANCHER = "-rancher"
 )
 
 // DefaultK8sVersion is a function that will set the default Kubernetes version if the user has not specified one.
 func DefaultK8sVersion(t *testing.T, client *rancher.Client, clusterConfig *config.TerratestConfig, terraformConfig *config.TerraformConfig) {
 	if clusterConfig.KubernetesVersion == "" {
-		if strings.Contains(terraformConfig.Module, RKE1) {
+		if strings.Contains(terraformConfig.Module, clustertypes.RKE1) {
 			defaultVersion, err := kubernetesversions.Default(client, clusters.RKE1ClusterType.String(), nil)
 			require.NoError(t, err)
 
 			clusterConfig.KubernetesVersion = defaultVersion[0]
-		} else if strings.Contains(terraformConfig.Module, RKE2) {
+		} else if strings.Contains(terraformConfig.Module, clustertypes.RKE2) {
 			defaultVersion, err := kubernetesversions.Default(client, clusters.RKE2ClusterType.String(), nil)
 			require.NoError(t, err)
 
 			clusterConfig.KubernetesVersion = defaultVersion[0]
-		} else if strings.Contains(terraformConfig.Module, K3S) {
+		} else if strings.Contains(terraformConfig.Module, clustertypes.K3S) {
 			defaultVersion, err := kubernetesversions.Default(client, clusters.K3SClusterType.String(), nil)
 			require.NoError(t, err)
 
@@ -44,17 +38,17 @@ func DefaultK8sVersion(t *testing.T, client *rancher.Client, clusterConfig *conf
 // if the user has not specified one.
 func DefaultUpgradedK8sVersion(t *testing.T, client *rancher.Client, clusterConfig *config.TerratestConfig, terraformConfig *config.TerraformConfig) {
 	if clusterConfig.UpgradedKubernetesVersion == "" {
-		if strings.Contains(clusterConfig.KubernetesVersion, RANCHER) {
+		if strings.Contains(clusterConfig.KubernetesVersion, clustertypes.RANCHER) {
 			defaultVersion, err := kubernetesversions.Default(client, clusters.RKE1ClusterType.String(), nil)
 			require.NoError(t, err)
 
 			clusterConfig.KubernetesVersion = defaultVersion[0]
-		} else if strings.Contains(clusterConfig.KubernetesVersion, RKE2) {
+		} else if strings.Contains(clusterConfig.KubernetesVersion, clustertypes.RKE2) {
 			defaultVersion, err := kubernetesversions.Default(client, clusters.RKE2ClusterType.String(), nil)
 			require.NoError(t, err)
 
 			clusterConfig.KubernetesVersion = defaultVersion[0]
-		} else if strings.Contains(clusterConfig.KubernetesVersion, K3S) {
+		} else if strings.Contains(clusterConfig.KubernetesVersion, clustertypes.K3S) {
 			defaultVersion, err := kubernetesversions.Default(client, clusters.K3SClusterType.String(), nil)
 			require.NoError(t, err)
 

--- a/tests/extensions/provisioning/provision.go
+++ b/tests/extensions/provisioning/provision.go
@@ -9,10 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const (
-	TFP = "tfp"
-)
-
 // Provision is a function that will run terraform init and apply Terraform resources to provision a cluster.
 func Provision(t *testing.T, clusterName, poolName string, clusterConfig *config.TerratestConfig, terraformOptions *terraform.Options) {
 	err := set.SetConfigTF(clusterConfig, clusterName, poolName)

--- a/tests/extensions/provisioning/supportedModules.go
+++ b/tests/extensions/provisioning/supportedModules.go
@@ -4,30 +4,33 @@ import (
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	ranchFrame "github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/clustertypes"
+	"github.com/rancher/tfp-automation/defaults/configs"
+	"github.com/rancher/tfp-automation/defaults/modules"
 )
 
 // SupportedModules is a function that will check if the user-inputted module is supported.
 func SupportedModules(terraformOptions *terraform.Options) bool {
 	terraformConfig := new(config.TerraformConfig)
-	ranchFrame.LoadConfig(terraformFrameworkConfig, terraformConfig)
+	ranchFrame.LoadConfig(configs.Terraform, terraformConfig)
 
 	module := terraformConfig.Module
 	supportedModules := []string{
-		aks,
-		eks,
-		gke,
-		azureRKE1,
-		azureRKE2,
-		azureK3s,
-		ec2RKE1,
-		linodeRKE1,
-		ec2RKE2,
-		linodeRKE2,
-		ec2K3s,
-		linodeK3s,
-		vsphereRKE1,
-		vsphereRKE2,
-		vsphereK3s,
+		clustertypes.AKS,
+		clustertypes.EKS,
+		clustertypes.GKE,
+		modules.AzureRKE1,
+		modules.AzureRKE2,
+		modules.AzureK3s,
+		modules.EC2RKE1,
+		modules.EC2RKE2,
+		modules.EC2K3s,
+		modules.LinodeRKE1,
+		modules.LinodeRKE2,
+		modules.LinodeK3s,
+		modules.VsphereRKE1,
+		modules.VsphereRKE2,
+		modules.VsphereK3s,
 	}
 
 	for _, supportedModule := range supportedModules {

--- a/tests/extensions/provisioning/verify.go
+++ b/tests/extensions/provisioning/verify.go
@@ -1,6 +1,7 @@
 package provisioning
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -12,34 +13,12 @@ import (
 	"github.com/rancher/shepherd/extensions/psact"
 	"github.com/rancher/shepherd/extensions/workloads/pods"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/clustertypes"
 	waitState "github.com/rancher/tfp-automation/framework/wait/state"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/util/wait"
-)
-
-const (
-	machineNameAnnotation    = "cluster.x-k8s.io/machine"
-	machineSteveResourceType = "cluster.x-k8s.io.machine"
-	aks                      = "aks"
-	eks                      = "eks"
-	gke                      = "gke"
-	azureRKE1                = "azure_rke1"
-	azureRKE2                = "azure_rke2"
-	azureK3s                 = "azure_k3s"
-	ec2RKE1                  = "ec2_rke1"
-	ec2RKE2                  = "ec2_rke2"
-	ec2K3s                   = "ec2_k3s"
-	linodeRKE1               = "linode_rke1"
-	linodeRKE2               = "linode_rke2"
-	linodeK3s                = "linode_k3s"
-	vsphereRKE1              = "vsphere_rke1"
-	vsphereRKE2              = "vsphere_rke2"
-	vsphereK3s               = "vsphere_k3s"
-	rke1                     = "rke1"
-	rke2                     = "rke2"
-	k3s                      = "k3s"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
 )
 
 // VerifyCluster validates that a downstream cluster and its resources are in a good state, matching a given config.
@@ -70,7 +49,7 @@ func VerifyCluster(t *testing.T, client *rancher.Client, clusterName string, ter
 
 	// EKS is formatted this way due to EKS formatting Kubernetes versions with a
 	// random string of letters after the version.
-	if module == eks {
+	if module == clustertypes.EKS {
 		assert.Equal(t, expectedKubernetesVersion, cluster.Version.GitVersion[1:5])
 	} else {
 		assert.Equal(t, expectedKubernetesVersion, cluster.Version.GitVersion)
@@ -123,41 +102,41 @@ func VerifyNodeCount(t *testing.T, client *rancher.Client, clusterName string, t
 	clusterID, err := clusters.GetClusterIDByName(adminClient, clusterName)
 	require.NoError(t, err)
 
-	err = wait.Poll(10*time.Second, defaults.FifteenMinuteTimeout, func() (done bool, err error) {
+	err = kwait.PollUntilContextTimeout(context.TODO(), 10*time.Second, defaults.FifteenMinuteTimeout, true, func(ctx context.Context) (done bool, err error) {
 		cluster, err := adminClient.Management.Cluster.ByID(clusterID)
 		require.NoError(t, err)
 
-		if strings.Contains(terraformConfig.Module, rke1) {
-			terraformConfig.Module = rke1
-		} else if strings.Contains(terraformConfig.Module, rke2) {
-			terraformConfig.Module = rke2
-		} else if strings.Contains(terraformConfig.Module, k3s) {
-			terraformConfig.Module = k3s
+		if strings.Contains(terraformConfig.Module, clustertypes.RKE1) {
+			terraformConfig.Module = clustertypes.RKE1
+		} else if strings.Contains(terraformConfig.Module, clustertypes.RKE2) {
+			terraformConfig.Module = clustertypes.RKE2
+		} else if strings.Contains(terraformConfig.Module, clustertypes.K3S) {
+			terraformConfig.Module = clustertypes.K3S
 		}
 
 		switch terraformConfig.Module {
-		case aks:
+		case clustertypes.AKS:
 			var aksConfig = cluster.AKSConfig
 			if cluster.NodeCount == *aksConfig.NodePools[0].Count {
 				logrus.Infof("Successfully scaled cluster to %v total nodes!", *aksConfig.NodePools[0].Count)
 			}
 
 			return true, nil
-		case eks:
+		case clustertypes.EKS:
 			var eksConfig = cluster.EKSConfig
 			if cluster.NodeCount == *eksConfig.NodeGroups[0].DesiredSize {
 				logrus.Infof("Successfully scaled cluster to %v total nodes!", *eksConfig.NodeGroups[0].DesiredSize)
 			}
 
 			return true, nil
-		case gke:
+		case clustertypes.GKE:
 			var gkeConfig = cluster.GKEConfig
 			if cluster.NodeCount == *gkeConfig.NodePools[0].InitialNodeCount {
 				logrus.Infof("Successfully scaled cluster to %v total nodes!", *gkeConfig.NodePools[0].InitialNodeCount)
 			}
 
 			return true, nil
-		case rke1, rke2, k3s:
+		case clustertypes.RKE1, clustertypes.RKE2, clustertypes.K3S:
 			if cluster.NodeCount == nodeCount {
 				logrus.Infof("Successfully scaled cluster to %v total nodes!", nodeCount)
 
@@ -175,12 +154,12 @@ func VerifyNodeCount(t *testing.T, client *rancher.Client, clusterName string, t
 // checkExpectedKubernetesVersion is a helper function that verifies the expected Kubernetes version.
 func checkExpectedKubernetesVersion(clusterConfig *config.TerratestConfig, expectedKubernetesVersion, module string) string {
 	switch {
-	case module == aks || module == gke:
+	case module == clustertypes.AKS || module == clustertypes.GKE:
 		expectedKubernetesVersion = `v` + clusterConfig.KubernetesVersion
 	// Terraform requires that we input the entire RKE1 version. However, Rancher client clips the `-rancher` suffix.
-	case strings.Contains(module, rke1):
+	case strings.Contains(module, clustertypes.RKE1):
 		expectedKubernetesVersion = clusterConfig.KubernetesVersion[:len(clusterConfig.KubernetesVersion)-11]
-	case strings.Contains(module, eks) || strings.Contains(module, rke2) || strings.Contains(module, k3s):
+	case strings.Contains(module, clustertypes.EKS) || strings.Contains(module, clustertypes.RKE2) || strings.Contains(module, clustertypes.K3S):
 		expectedKubernetesVersion = clusterConfig.KubernetesVersion
 	default:
 		logrus.Errorf("Invalid module provided")

--- a/tests/nodescaling/scale_hosted_test.go
+++ b/tests/nodescaling/scale_hosted_test.go
@@ -9,6 +9,7 @@ import (
 	namegen "github.com/rancher/shepherd/pkg/namegenerator"
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/configs"
 	"github.com/rancher/tfp-automation/framework"
 	cleanup "github.com/rancher/tfp-automation/framework/cleanup"
 	"github.com/rancher/tfp-automation/tests/extensions/provisioning"
@@ -60,8 +61,8 @@ func (s *ScaleHostedTestSuite) TestTfpScaleHosted() {
 	for _, tt := range tests {
 		tt.name = tt.name + " Module: " + s.terraformConfig.Module + " Kubernetes version: " + s.clusterConfig.KubernetesVersion
 
-		clusterName := namegen.AppendRandomString(provisioning.TFP)
-		poolName := namegen.AppendRandomString(provisioning.TFP)
+		clusterName := namegen.AppendRandomString(configs.TFP)
+		poolName := namegen.AppendRandomString(configs.TFP)
 
 		s.Run((tt.name), func() {
 			defer cleanup.Cleanup(s.T(), s.terraformOptions)

--- a/tests/nodescaling/scale_test.go
+++ b/tests/nodescaling/scale_test.go
@@ -9,6 +9,7 @@ import (
 	namegen "github.com/rancher/shepherd/pkg/namegenerator"
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/configs"
 	"github.com/rancher/tfp-automation/framework"
 	cleanup "github.com/rancher/tfp-automation/framework/cleanup"
 	"github.com/rancher/tfp-automation/tests/extensions/provisioning"
@@ -93,8 +94,8 @@ func (s *ScaleTestSuite) TestTfpScale() {
 		tt.name = tt.name + " Module: " + s.terraformConfig.Module + " Kubernetes version: " +
 			s.clusterConfig.KubernetesVersion
 
-		clusterName := namegen.AppendRandomString(provisioning.TFP)
-		poolName := namegen.AppendRandomString(provisioning.TFP)
+		clusterName := namegen.AppendRandomString(configs.TFP)
+		poolName := namegen.AppendRandomString(configs.TFP)
 
 		s.Run((tt.name), func() {
 			provisioning.Provision(s.T(), clusterName, poolName, &clusterConfig, s.terraformOptions)
@@ -127,8 +128,8 @@ func (s *ScaleTestSuite) TestTfpScaleDynamicInput() {
 	for _, tt := range tests {
 		tt.name = tt.name + " Module: " + s.terraformConfig.Module + " Kubernetes version: " + s.clusterConfig.KubernetesVersion
 
-		clusterName := namegen.AppendRandomString(provisioning.TFP)
-		poolName := namegen.AppendRandomString(provisioning.TFP)
+		clusterName := namegen.AppendRandomString(configs.TFP)
+		poolName := namegen.AppendRandomString(configs.TFP)
 
 		s.Run((tt.name), func() {
 			defer cleanup.Cleanup(s.T(), s.terraformOptions)

--- a/tests/provisioning/provision_hosted_test.go
+++ b/tests/provisioning/provision_hosted_test.go
@@ -9,6 +9,7 @@ import (
 	namegen "github.com/rancher/shepherd/pkg/namegenerator"
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/configs"
 	"github.com/rancher/tfp-automation/framework"
 	cleanup "github.com/rancher/tfp-automation/framework/cleanup"
 	"github.com/rancher/tfp-automation/tests/extensions/provisioning"
@@ -60,8 +61,8 @@ func (p *ProvisionHostedTestSuite) TestTfpProvisionHosted() {
 	for _, tt := range tests {
 		tt.name = tt.name + " Module: " + p.terraformConfig.Module + " Kubernetes version: " + p.clusterConfig.KubernetesVersion
 
-		clusterName := namegen.AppendRandomString(provisioning.TFP)
-		poolName := namegen.AppendRandomString(provisioning.TFP)
+		clusterName := namegen.AppendRandomString(configs.TFP)
+		poolName := namegen.AppendRandomString(configs.TFP)
 
 		p.Run((tt.name), func() {
 			defer cleanup.Cleanup(p.T(), p.terraformOptions)

--- a/tests/provisioning/provision_test.go
+++ b/tests/provisioning/provision_test.go
@@ -9,6 +9,7 @@ import (
 	namegen "github.com/rancher/shepherd/pkg/namegenerator"
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/configs"
 	"github.com/rancher/tfp-automation/framework"
 	cleanup "github.com/rancher/tfp-automation/framework/cleanup"
 	"github.com/rancher/tfp-automation/tests/extensions/provisioning"
@@ -71,8 +72,8 @@ func (p *ProvisionTestSuite) TestTfpProvision() {
 		tt.name = tt.name + " Module: " + p.terraformConfig.Module + " Kubernetes version: " +
 			p.clusterConfig.KubernetesVersion
 
-		clusterName := namegen.AppendRandomString(provisioning.TFP)
-		poolName := namegen.AppendRandomString(provisioning.TFP)
+		clusterName := namegen.AppendRandomString(configs.TFP)
+		poolName := namegen.AppendRandomString(configs.TFP)
 
 		p.Run((tt.name), func() {
 			defer cleanup.Cleanup(p.T(), p.terraformOptions)
@@ -93,8 +94,8 @@ func (p *ProvisionTestSuite) TestTfpProvisionDynamicInput() {
 	for _, tt := range tests {
 		tt.name = tt.name + " Module: " + p.terraformConfig.Module + " Kubernetes version: " + p.clusterConfig.KubernetesVersion
 
-		clusterName := namegen.AppendRandomString(provisioning.TFP)
-		poolName := namegen.AppendRandomString(provisioning.TFP)
+		clusterName := namegen.AppendRandomString(configs.TFP)
+		poolName := namegen.AppendRandomString(configs.TFP)
 
 		p.Run((tt.name), func() {
 			defer cleanup.Cleanup(p.T(), p.terraformOptions)

--- a/tests/psact/psact_test.go
+++ b/tests/psact/psact_test.go
@@ -9,6 +9,7 @@ import (
 	namegen "github.com/rancher/shepherd/pkg/namegenerator"
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/configs"
 	"github.com/rancher/tfp-automation/framework"
 	cleanup "github.com/rancher/tfp-automation/framework/cleanup"
 	"github.com/rancher/tfp-automation/tests/extensions/provisioning"
@@ -82,8 +83,8 @@ func (p *PSACTTestSuite) TestTfpPSACT() {
 
 		tt.name = tt.name + " Module: " + p.terraformConfig.Module + " Kubernetes version: " + p.clusterConfig.KubernetesVersion
 
-		clusterName := namegen.AppendRandomString(provisioning.TFP)
-		poolName := namegen.AppendRandomString(provisioning.TFP)
+		clusterName := namegen.AppendRandomString(configs.TFP)
+		poolName := namegen.AppendRandomString(configs.TFP)
 
 		p.Run((tt.name), func() {
 			defer cleanup.Cleanup(p.T(), p.terraformOptions)

--- a/tests/snapshot/README.md
+++ b/tests/snapshot/README.md
@@ -59,8 +59,8 @@ terratest:
 See the below examples on how to run the tests:
 
 ### Snapshot restore
-`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/snapshot --junitfile results.xml -- -timeout=60m -v -run "TestTfpSnapshotRestoreTestSuite/TestTfpSnapshotRestore$"` \
-`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/snapshot --junitfile results.xml -- -timeout=60m -v -run "TestTfpSnapshotRestoreTestSuite/TestTfpSnapshotRestoreDynamicInput$"`
+`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/snapshot --junitfile results.xml -- -timeout=60m -v -run "TestTfpSnapshotRestoreTestSuite/TestTfpSnapshotRestoreETCDOnly$"` \
+`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/snapshot --junitfile results.xml -- -timeout=60m -v -run "TestTfpSnapshotRestoreTestSuite/TestTfpSnapshotRestoreETCDOnlyDynamicInput$"`
 
 ### Snapshot restore with K8s upgrade
 `gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/snapshot --junitfile results.xml -- -timeout=60m -v -run "TestTfpSnapshotRestoreK8sUpgradeTestSuite/TestTfpSnapshotRestoreK8sUpgrade$"` \

--- a/tests/snapshot/snapshot_restore_k8s_upgrade_test.go
+++ b/tests/snapshot/snapshot_restore_k8s_upgrade_test.go
@@ -9,6 +9,7 @@ import (
 	namegen "github.com/rancher/shepherd/pkg/namegenerator"
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/configs"
 	"github.com/rancher/tfp-automation/framework"
 	cleanup "github.com/rancher/tfp-automation/framework/cleanup"
 	"github.com/rancher/tfp-automation/tests/extensions/provisioning"
@@ -90,8 +91,8 @@ func (s *SnapshotRestoreK8sUpgradeTestSuite) TestTfpSnapshotRestoreK8sUpgrade() 
 
 		tt.name = tt.name + " Module: " + s.terraformConfig.Module + " Kubernetes version: " + s.clusterConfig.KubernetesVersion
 
-		clusterName := namegen.AppendRandomString(provisioning.TFP)
-		poolName := namegen.AppendRandomString(provisioning.TFP)
+		clusterName := namegen.AppendRandomString(configs.TFP)
+		poolName := namegen.AppendRandomString(configs.TFP)
 
 		s.Run(tt.name, func() {
 			defer cleanup.Cleanup(s.T(), s.terraformOptions)
@@ -118,8 +119,8 @@ func (s *SnapshotRestoreK8sUpgradeTestSuite) TestTfpSnapshotRestoreK8sUpgradeDyn
 	for _, tt := range tests {
 		tt.name = tt.name + " Module: " + s.terraformConfig.Module + " Kubernetes version: " + s.clusterConfig.KubernetesVersion
 
-		clusterName := namegen.AppendRandomString(provisioning.TFP)
-		poolName := namegen.AppendRandomString(provisioning.TFP)
+		clusterName := namegen.AppendRandomString(configs.TFP)
+		poolName := namegen.AppendRandomString(configs.TFP)
 
 		s.Run((tt.name), func() {
 			defer cleanup.Cleanup(s.T(), s.terraformOptions)

--- a/tests/snapshot/snapshot_restore_test.go
+++ b/tests/snapshot/snapshot_restore_test.go
@@ -9,6 +9,7 @@ import (
 	namegen "github.com/rancher/shepherd/pkg/namegenerator"
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/configs"
 	"github.com/rancher/tfp-automation/framework"
 	cleanup "github.com/rancher/tfp-automation/framework/cleanup"
 	"github.com/rancher/tfp-automation/tests/extensions/provisioning"
@@ -80,8 +81,8 @@ func (s *SnapshotRestoreTestSuite) TestTfpSnapshotRestoreETCDOnly() {
 
 		tt.name = tt.name + " Module: " + s.terraformConfig.Module + " Kubernetes version: " + s.clusterConfig.KubernetesVersion
 
-		clusterName := namegen.AppendRandomString(provisioning.TFP)
-		poolName := namegen.AppendRandomString(provisioning.TFP)
+		clusterName := namegen.AppendRandomString(configs.TFP)
+		poolName := namegen.AppendRandomString(configs.TFP)
 
 		s.Run(tt.name, func() {
 			defer cleanup.Cleanup(s.T(), s.terraformOptions)
@@ -108,8 +109,8 @@ func (s *SnapshotRestoreTestSuite) TestTfpSnapshotRestoreETCDOnlyDynamicInput() 
 	for _, tt := range tests {
 		tt.name = tt.name + " Module: " + s.terraformConfig.Module + " Kubernetes version: " + s.clusterConfig.KubernetesVersion
 
-		clusterName := namegen.AppendRandomString(provisioning.TFP)
-		poolName := namegen.AppendRandomString(provisioning.TFP)
+		clusterName := namegen.AppendRandomString(configs.TFP)
+		poolName := namegen.AppendRandomString(configs.TFP)
 
 		s.Run((tt.name), func() {
 			defer cleanup.Cleanup(s.T(), s.terraformOptions)

--- a/tests/snapshot/snapshot_restore_upgrade_strategy_test.go
+++ b/tests/snapshot/snapshot_restore_upgrade_strategy_test.go
@@ -9,6 +9,7 @@ import (
 	namegen "github.com/rancher/shepherd/pkg/namegenerator"
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/configs"
 	"github.com/rancher/tfp-automation/framework"
 	cleanup "github.com/rancher/tfp-automation/framework/cleanup"
 	"github.com/rancher/tfp-automation/tests/extensions/provisioning"
@@ -96,8 +97,8 @@ func (s *SnapshotRestoreUpgradeStrategyTestSuite) TestTfpSnapshotRestoreUpgradeS
 
 		tt.name = tt.name + " Module: " + s.terraformConfig.Module + " Kubernetes version: " + s.clusterConfig.KubernetesVersion
 
-		clusterName := namegen.AppendRandomString(provisioning.TFP)
-		poolName := namegen.AppendRandomString(provisioning.TFP)
+		clusterName := namegen.AppendRandomString(configs.TFP)
+		poolName := namegen.AppendRandomString(configs.TFP)
 
 		s.Run(tt.name, func() {
 			defer cleanup.Cleanup(s.T(), s.terraformOptions)
@@ -124,8 +125,8 @@ func (s *SnapshotRestoreUpgradeStrategyTestSuite) TestTfpSnapshotRestoreUpgradeS
 	for _, tt := range tests {
 		tt.name = tt.name + " Module: " + s.terraformConfig.Module + " Kubernetes version: " + s.clusterConfig.KubernetesVersion
 
-		clusterName := namegen.AppendRandomString(provisioning.TFP)
-		poolName := namegen.AppendRandomString(provisioning.TFP)
+		clusterName := namegen.AppendRandomString(configs.TFP)
+		poolName := namegen.AppendRandomString(configs.TFP)
 
 		s.Run((tt.name), func() {
 			defer cleanup.Cleanup(s.T(), s.terraformOptions)

--- a/tests/upgrading/kubernetes_hosted_test.go
+++ b/tests/upgrading/kubernetes_hosted_test.go
@@ -9,6 +9,7 @@ import (
 	namegen "github.com/rancher/shepherd/pkg/namegenerator"
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/configs"
 	"github.com/rancher/tfp-automation/framework"
 	cleanup "github.com/rancher/tfp-automation/framework/cleanup"
 	"github.com/rancher/tfp-automation/tests/extensions/provisioning"
@@ -58,8 +59,8 @@ func (k *KubernetesUpgradeHostedTestSuite) TestTfpKubernetesUpgradeHosted() {
 	for _, tt := range tests {
 		tt.name = tt.name + " Module: " + k.terraformConfig.Module + " Kubernetes version: " + k.clusterConfig.KubernetesVersion
 
-		clusterName := namegen.AppendRandomString(provisioning.TFP)
-		poolName := namegen.AppendRandomString(provisioning.TFP)
+		clusterName := namegen.AppendRandomString(configs.TFP)
+		poolName := namegen.AppendRandomString(configs.TFP)
 
 		k.Run((tt.name), func() {
 			defer cleanup.Cleanup(k.T(), k.terraformOptions)

--- a/tests/upgrading/kubernetes_upgrade_test.go
+++ b/tests/upgrading/kubernetes_upgrade_test.go
@@ -9,6 +9,7 @@ import (
 	namegen "github.com/rancher/shepherd/pkg/namegenerator"
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/configs"
 	"github.com/rancher/tfp-automation/framework"
 	cleanup "github.com/rancher/tfp-automation/framework/cleanup"
 	"github.com/rancher/tfp-automation/tests/extensions/provisioning"
@@ -68,8 +69,8 @@ func (k *KubernetesUpgradeTestSuite) TestTfpKubernetesUpgrade() {
 
 		tt.name = tt.name + " Module: " + k.terraformConfig.Module + " Kubernetes version: " + k.clusterConfig.KubernetesVersion
 
-		clusterName := namegen.AppendRandomString(provisioning.TFP)
-		poolName := namegen.AppendRandomString(provisioning.TFP)
+		clusterName := namegen.AppendRandomString(configs.TFP)
+		poolName := namegen.AppendRandomString(configs.TFP)
 
 		k.Run((tt.name), func() {
 			defer cleanup.Cleanup(k.T(), k.terraformOptions)
@@ -95,8 +96,8 @@ func (k *KubernetesUpgradeTestSuite) TestTfpKubernetesUpgradeDynamicInput() {
 	for _, tt := range tests {
 		tt.name = tt.name + " Module: " + k.terraformConfig.Module + " Kubernetes version: " + k.clusterConfig.KubernetesVersion
 
-		clusterName := namegen.AppendRandomString(provisioning.TFP)
-		poolName := namegen.AppendRandomString(provisioning.TFP)
+		clusterName := namegen.AppendRandomString(configs.TFP)
+		poolName := namegen.AppendRandomString(configs.TFP)
 
 		k.Run((tt.name), func() {
 			defer cleanup.Cleanup(k.T(), k.terraformOptions)


### PR DESCRIPTION
### Issue: https://github.com/rancher/qa-tasks/issues/1285

This is part one of a general refactor to the `tfp-automation` framework to provide much needed TLC. Mirroring the constants PR in the `rancher/shepherd` repo, this is placing all of our constants in a `default` folder.

As this is a big PR, testing will be a bit more thorough then usual to ensure no setbacks were introduced.