### PR TITLE
Allow second highest K8s version to be statically set

### DIFF
--- a/defaults/configs/configs.go
+++ b/defaults/configs/configs.go
@@ -6,6 +6,9 @@ const (
 	Terratest = "terratest"
 	TFP       = "tfp"
 
+	DefaultK8sVersion    = "default"
+	SecondHighestVersion = "second"
+
 	MainTF          = "/main.tf"
 	TerraformFolder = "/.terraform"
 	TFState         = "/terraform.tfstate"

--- a/tests/nodescaling/scale_hosted_test.go
+++ b/tests/nodescaling/scale_hosted_test.go
@@ -47,8 +47,6 @@ func (s *ScaleHostedTestSuite) SetupSuite() {
 
 	terraformOptions := framework.Setup(s.T())
 	s.terraformOptions = terraformOptions
-
-	provisioning.DefaultK8sVersion(s.T(), s.client, s.clusterConfig, s.terraformConfig)
 }
 
 func (s *ScaleHostedTestSuite) TestTfpScaleHosted() {

--- a/tests/nodescaling/scale_test.go
+++ b/tests/nodescaling/scale_test.go
@@ -48,7 +48,7 @@ func (s *ScaleTestSuite) SetupSuite() {
 	terraformOptions := framework.Setup(s.T())
 	s.terraformOptions = terraformOptions
 
-	provisioning.DefaultK8sVersion(s.T(), s.client, s.clusterConfig, s.terraformConfig)
+	provisioning.GetK8sVersion(s.T(), s.client, s.clusterConfig, s.terraformConfig, configs.DefaultK8sVersion)
 }
 
 func (s *ScaleTestSuite) TestTfpScale() {

--- a/tests/provisioning/provision_hosted_test.go
+++ b/tests/provisioning/provision_hosted_test.go
@@ -47,8 +47,6 @@ func (p *ProvisionHostedTestSuite) SetupSuite() {
 
 	terraformOptions := framework.Setup(p.T())
 	p.terraformOptions = terraformOptions
-
-	provisioning.DefaultK8sVersion(p.T(), p.client, p.clusterConfig, p.terraformConfig)
 }
 
 func (p *ProvisionHostedTestSuite) TestTfpProvisionHosted() {

--- a/tests/provisioning/provision_test.go
+++ b/tests/provisioning/provision_test.go
@@ -48,7 +48,7 @@ func (p *ProvisionTestSuite) SetupSuite() {
 	terraformOptions := framework.Setup(p.T())
 	p.terraformOptions = terraformOptions
 
-	provisioning.DefaultK8sVersion(p.T(), p.client, p.clusterConfig, p.terraformConfig)
+	provisioning.GetK8sVersion(p.T(), p.client, p.clusterConfig, p.terraformConfig, configs.DefaultK8sVersion)
 }
 
 func (p *ProvisionTestSuite) TestTfpProvision() {

--- a/tests/psact/psact_test.go
+++ b/tests/psact/psact_test.go
@@ -48,7 +48,7 @@ func (p *PSACTTestSuite) SetupSuite() {
 	terraformOptions := framework.Setup(p.T())
 	p.terraformOptions = terraformOptions
 
-	provisioning.DefaultK8sVersion(p.T(), p.client, p.clusterConfig, p.terraformConfig)
+	provisioning.GetK8sVersion(p.T(), p.client, p.clusterConfig, p.terraformConfig, configs.DefaultK8sVersion)
 }
 
 func (p *PSACTTestSuite) TestTfpPSACT() {

--- a/tests/snapshot/snapshot_restore_k8s_upgrade_test.go
+++ b/tests/snapshot/snapshot_restore_k8s_upgrade_test.go
@@ -48,7 +48,7 @@ func (s *SnapshotRestoreK8sUpgradeTestSuite) SetupSuite() {
 	terraformOptions := framework.Setup(s.T())
 	s.terraformOptions = terraformOptions
 
-	provisioning.DefaultK8sVersion(s.T(), s.client, s.clusterConfig, s.terraformConfig)
+	provisioning.GetK8sVersion(s.T(), s.client, s.clusterConfig, s.terraformConfig, configs.DefaultK8sVersion)
 }
 
 func (s *SnapshotRestoreK8sUpgradeTestSuite) TestTfpSnapshotRestoreK8sUpgrade() {

--- a/tests/snapshot/snapshot_restore_test.go
+++ b/tests/snapshot/snapshot_restore_test.go
@@ -48,7 +48,7 @@ func (s *SnapshotRestoreTestSuite) SetupSuite() {
 	terraformOptions := framework.Setup(s.T())
 	s.terraformOptions = terraformOptions
 
-	provisioning.DefaultK8sVersion(s.T(), s.client, s.clusterConfig, s.terraformConfig)
+	provisioning.GetK8sVersion(s.T(), s.client, s.clusterConfig, s.terraformConfig, configs.DefaultK8sVersion)
 }
 
 func (s *SnapshotRestoreTestSuite) TestTfpSnapshotRestoreETCDOnly() {

--- a/tests/snapshot/snapshot_restore_upgrade_strategy_test.go
+++ b/tests/snapshot/snapshot_restore_upgrade_strategy_test.go
@@ -48,7 +48,7 @@ func (s *SnapshotRestoreUpgradeStrategyTestSuite) SetupSuite() {
 	terraformOptions := framework.Setup(s.T())
 	s.terraformOptions = terraformOptions
 
-	provisioning.DefaultK8sVersion(s.T(), s.client, s.clusterConfig, s.terraformConfig)
+	provisioning.GetK8sVersion(s.T(), s.client, s.clusterConfig, s.terraformConfig, configs.DefaultK8sVersion)
 }
 
 func (s *SnapshotRestoreUpgradeStrategyTestSuite) TestTfpSnapshotRestoreUpgradeStrategy() {

--- a/tests/upgrading/kubernetes_upgrade_test.go
+++ b/tests/upgrading/kubernetes_upgrade_test.go
@@ -47,6 +47,8 @@ func (k *KubernetesUpgradeTestSuite) SetupSuite() {
 
 	terraformOptions := framework.Setup(k.T())
 	k.terraformOptions = terraformOptions
+
+	provisioning.GetK8sVersion(k.T(), k.client, k.clusterConfig, k.terraformConfig, configs.SecondHighestVersion)
 }
 
 func (k *KubernetesUpgradeTestSuite) TestTfpKubernetesUpgrade() {


### PR DESCRIPTION
### Issue Description: [Update TestKubernetesVersion in tfp-automation to not pull K8s version from the user defined config](https://github.com/rancher/qa-tasks/issues/1076)

### PR Description
For the `upgrading` package, we currently are having the static tests use `kubernetesVersion` initially set. We don't want to do this as since it is a static test, we should not have to rely on the config more than needed. To get around this, static tests will by default get the second highest K8s version and then upgrade to the latest K8s versions.

Dynamic tests are still free to pull whatever initial version it wants and upgrade to whatever vresion it wants.