### PR TITLE
Update snapshot.go to match rancher/rancher

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -21,20 +21,6 @@ const (
 	RancherRestricted PSACT = "rancher-restricted"
 )
 
-var AllRolesNodePool = Nodepool{
-	Etcd:         true,
-	Controlplane: true,
-	Worker:       true,
-	Quantity:     1,
-}
-
-var EtcdControlPlaneNodePool = Nodepool{
-	Etcd:         true,
-	Controlplane: true,
-	Worker:       false,
-	Quantity:     1,
-}
-
 var EtcdNodePool = Nodepool{
 	Etcd:         true,
 	Controlplane: false,
@@ -54,27 +40,6 @@ var WorkerNodePool = Nodepool{
 	Controlplane: false,
 	Worker:       true,
 	Quantity:     1,
-}
-
-var ScaleUpAllRolesNodePool = Nodepool{
-	Etcd:         true,
-	Controlplane: true,
-	Worker:       true,
-	Quantity:     4,
-}
-
-var ScaleDownAllRolesNodePool = Nodepool{
-	Etcd:         true,
-	Controlplane: true,
-	Worker:       true,
-	Quantity:     3,
-}
-
-var ScaleUpEtcdControlPlaneNodePool = Nodepool{
-	Etcd:         true,
-	Controlplane: true,
-	Worker:       false,
-	Quantity:     3,
 }
 
 var ScaleUpEtcdNodePool = Nodepool{

--- a/framework/set/defaults/defaults.go
+++ b/framework/set/defaults/defaults.go
@@ -29,7 +29,7 @@ const (
 
 	MachineConfig    = "machine_config"
 	MachinePools     = "machine_pools"
-	NodePool         = "pool"
+	NodePool         = "auto-tfp-pool"
 	Etcd             = "etcd"
 	Enabled          = "enabled"
 	RancherClusterID = "cluster_id"

--- a/framework/set/provisioning/rke1/setNodePool.go
+++ b/framework/set/provisioning/rke1/setNodePool.go
@@ -35,7 +35,7 @@ func setNodePool(nodePools []config.Nodepool, count int, pool config.Nodepool, r
 
 	nodePoolBlockBody.SetAttributeRaw(defaults.RancherClusterID, clusterID)
 	nodePoolBlockBody.SetAttributeValue(defaults.ResourceName, cty.StringVal(poolName+poolNum))
-	nodePoolBlockBody.SetAttributeValue(hostnamePrefix, cty.StringVal(terraformConfig.HostnamePrefix+"-"+poolName))
+	nodePoolBlockBody.SetAttributeValue(hostnamePrefix, cty.StringVal(terraformConfig.HostnamePrefix+"-"+poolName+poolNum))
 
 	nodeTempID := hclwrite.Tokens{
 		{Type: hclsyntax.TokenIdent, Bytes: []byte(nodeTemplate + "." + nodeTemplate + ".id")},

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22
 replace (
 	github.com/rancher/rancher/pkg/apis => github.com/rancher/rancher/pkg/apis v0.0.0-20240529155832-64dbde013b4c
 	github.com/rancher/rancher/pkg/client => github.com/rancher/rancher/pkg/client v0.0.0-20240529155832-64dbde013b4c
+
 	go.qase.io/client => github.com/rancher/qase-go/client v0.0.0-20240308221502-c3b2635212be
 	k8s.io/api => k8s.io/api v0.29.3
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.29.3
@@ -25,7 +26,7 @@ require (
 	github.com/gruntwork-io/terratest v0.42.0
 	github.com/rancher/norman v0.0.0-20240503193601-9f5f6586bb5b
 	github.com/rancher/rancher/pkg/apis v0.0.0
-	github.com/rancher/shepherd v0.0.0-20240530155239-a3783b7c7f54
+	github.com/rancher/shepherd v0.0.0-20240618185935-9f1ffea0abab
 	github.com/sirupsen/logrus v1.9.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1761,8 +1761,8 @@ github.com/rancher/rancher/pkg/apis v0.0.0-20240529155832-64dbde013b4c h1:q1QAKG
 github.com/rancher/rancher/pkg/apis v0.0.0-20240529155832-64dbde013b4c/go.mod h1:5QLxSuI6bJ+eAyjOVJVDSMgu93rA6sYF9BWTvk74JRQ=
 github.com/rancher/rke v1.6.0-rc4 h1:5ytUakGjIGGwtG0uB6bnwMqbRoK8ZPiOAUPl6V12Vcw=
 github.com/rancher/rke v1.6.0-rc4/go.mod h1:zvrJLRt+84/OMOUO0AggVqW6a2RSsTjqSW8bDHvKgME=
-github.com/rancher/shepherd v0.0.0-20240530155239-a3783b7c7f54 h1:Zqd+VCeca/8yzs6N5tfknb96ctQ+Svkbb5baIxJy+Go=
-github.com/rancher/shepherd v0.0.0-20240530155239-a3783b7c7f54/go.mod h1:+1bFZ/XBf8QOu0WLJIJ+2K2x/GIjHgKXKCUfm7PnCz4=
+github.com/rancher/shepherd v0.0.0-20240618185935-9f1ffea0abab h1:dwmxKjh5emltepNXKPRatbErjmiBVtu2Vc5su9Bu+8M=
+github.com/rancher/shepherd v0.0.0-20240618185935-9f1ffea0abab/go.mod h1:+1bFZ/XBf8QOu0WLJIJ+2K2x/GIjHgKXKCUfm7PnCz4=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007 h1:ru+mqGnxMmKeU0Q3XIDxkARvInDIqT1hH2amTcsjxI4=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007/go.mod h1:Ja346o44aTPWADc/5Jm93+KgctT6KtftuOosgz0F2AM=
 github.com/rancher/wrangler v0.6.1/go.mod h1:L4HtjPeX8iqLgsxfJgz+JjKMcX2q3qbRXSeTlC/CSd4=

--- a/tests/nodescaling/scale_test.go
+++ b/tests/nodescaling/scale_test.go
@@ -52,14 +52,6 @@ func (s *ScaleTestSuite) SetupSuite() {
 }
 
 func (s *ScaleTestSuite) TestTfpScale() {
-	nodeRolesAll := []config.Nodepool{config.AllRolesNodePool}
-	scaleUpRolesAll := []config.Nodepool{config.ScaleUpAllRolesNodePool}
-	scaleDownRolesAll := []config.Nodepool{config.ScaleDownAllRolesNodePool}
-
-	nodeRolesShared := []config.Nodepool{config.EtcdControlPlaneNodePool, config.WorkerNodePool}
-	scaleUpRolesShared := []config.Nodepool{config.ScaleUpEtcdControlPlaneNodePool, config.ScaleUpWorkerNodePool}
-	scaleDownRolesShared := []config.Nodepool{config.ScaleUpEtcdControlPlaneNodePool, config.WorkerNodePool}
-
 	nodeRolesDedicated := []config.Nodepool{config.EtcdNodePool, config.ControlPlaneNodePool, config.WorkerNodePool}
 	scaleUpRolesDedicated := []config.Nodepool{config.ScaleUpEtcdNodePool, config.ScaleUpControlPlaneNodePool, config.ScaleUpWorkerNodePool}
 	scaleDownRolesDedicated := []config.Nodepool{config.ScaleUpEtcdNodePool, config.ScaleUpControlPlaneNodePool, config.WorkerNodePool}
@@ -70,8 +62,6 @@ func (s *ScaleTestSuite) TestTfpScale() {
 		scaleUpNodeRoles   []config.Nodepool
 		scaleDownNodeRoles []config.Nodepool
 	}{
-		{"Scaling 1 node all roles -> 4 nodes -> 3 nodes " + config.StandardClientName.String(), nodeRolesAll, scaleUpRolesAll, scaleDownRolesAll},
-		{"Scaling 2 nodes shared roles -> 6 nodes -> 4 nodes  " + config.StandardClientName.String(), nodeRolesShared, scaleUpRolesShared, scaleDownRolesShared},
 		{"Scaling 3 nodes dedicated roles -> 8 nodes -> 6 nodes " + config.StandardClientName.String(), nodeRolesDedicated, scaleUpRolesDedicated, scaleDownRolesDedicated},
 	}
 

--- a/tests/provisioning/provision_test.go
+++ b/tests/provisioning/provision_test.go
@@ -52,16 +52,12 @@ func (p *ProvisionTestSuite) SetupSuite() {
 }
 
 func (p *ProvisionTestSuite) TestTfpProvision() {
-	nodeRolesAll := []config.Nodepool{config.AllRolesNodePool}
-	nodeRolesShared := []config.Nodepool{config.EtcdControlPlaneNodePool, config.WorkerNodePool}
 	nodeRolesDedicated := []config.Nodepool{config.EtcdNodePool, config.ControlPlaneNodePool, config.WorkerNodePool}
 
 	tests := []struct {
 		name      string
 		nodeRoles []config.Nodepool
 	}{
-		{"1 Node all roles " + config.StandardClientName.String(), nodeRolesAll},
-		{"2 nodes - etcd|cp roles per 1 node " + config.StandardClientName.String(), nodeRolesShared},
 		{"3 nodes - 1 role per node " + config.StandardClientName.String(), nodeRolesDedicated},
 	}
 

--- a/tests/upgrading/kubernetes_upgrade_test.go
+++ b/tests/upgrading/kubernetes_upgrade_test.go
@@ -52,16 +52,12 @@ func (k *KubernetesUpgradeTestSuite) SetupSuite() {
 }
 
 func (k *KubernetesUpgradeTestSuite) TestTfpKubernetesUpgrade() {
-	nodeRolesAll := []config.Nodepool{config.AllRolesNodePool}
-	nodeRolesShared := []config.Nodepool{config.EtcdControlPlaneNodePool, config.WorkerNodePool}
 	nodeRolesDedicated := []config.Nodepool{config.EtcdNodePool, config.ControlPlaneNodePool, config.WorkerNodePool}
 
 	tests := []struct {
 		name      string
 		nodeRoles []config.Nodepool
 	}{
-		{"1 Node all roles " + config.StandardClientName.String(), nodeRolesAll},
-		{"2 nodes - etcd|cp roles per 1 node " + config.StandardClientName.String(), nodeRolesShared},
 		{"3 nodes - 1 role per node " + config.StandardClientName.String(), nodeRolesDedicated},
 	}
 


### PR DESCRIPTION
### Issue: [Move the last python backup restore test to GO](https://github.com/rancher/qa-tasks/issues/1252)

### PR Description
This PR is the tfp-automation counterpart to the linked issue. In addition, the following is done:
- Cuts back testing to just dedicated clusters to save resources / shave duplication efforts done in rancher/rancher
- Update RKE1 nodepool names (mostly for nodescaling)