### PR TITLE
Add initial RBAC support to tfp-automation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -6,8 +6,8 @@ import (
 	"github.com/rancher/tfp-automation/config/nodeproviders"
 )
 
-// TestClientName is string enum for client/user names used in provisioning tests.
 type TestClientName string
+type Role string
 type PSACT string
 
 const (
@@ -16,6 +16,9 @@ const (
 
 	AdminClientName    TestClientName = "Admin User"
 	StandardClientName TestClientName = "Standard User"
+
+	ClusterOwner Role = "cluster-owner"
+	ProjectOwner Role = "project-owner"
 
 	RancherPrivileged PSACT = "rancher-privileged"
 	RancherRestricted PSACT = "rancher-restricted"

--- a/framework/set/provisioning/hosted/setAKS.go
+++ b/framework/set/provisioning/hosted/setAKS.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
-	"github.com/rancher/shepherd/clients/rancher"
 	framework "github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/defaults/configs"
@@ -19,16 +18,9 @@ import (
 )
 
 // SetAKS is a function that will set the AKS configurations in the main.tf file.
-func SetAKS(clusterName, k8sVersion string, nodePools []config.Nodepool, file *os.File) error {
-	rancherConfig := new(rancher.Config)
-	framework.LoadConfig(configs.Rancher, rancherConfig)
-
+func SetAKS(clusterName, k8sVersion string, nodePools []config.Nodepool, newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File) error {
 	terraformConfig := new(config.TerraformConfig)
 	framework.LoadConfig(configs.Terraform, terraformConfig)
-
-	newFile, rootBody := resources.SetProvidersAndUsersTF(rancherConfig, terraformConfig)
-
-	rootBody.AppendNewline()
 
 	cloudCredBlock := rootBody.AppendNewBlock(defaults.Resource, []string{defaults.CloudCredential, defaults.CloudCredential})
 	cloudCredBlockBody := cloudCredBlock.Body()

--- a/framework/set/provisioning/hosted/setEKS.go
+++ b/framework/set/provisioning/hosted/setEKS.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
-	"github.com/rancher/shepherd/clients/rancher"
 	ranchFrame "github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/defaults/configs"
@@ -19,16 +18,9 @@ import (
 )
 
 // SetEKS is a function that will set the EKS configurations in the main.tf file.
-func SetEKS(clusterName, k8sVersion string, nodePools []config.Nodepool, file *os.File) error {
-	rancherConfig := new(rancher.Config)
-	ranchFrame.LoadConfig(configs.Rancher, rancherConfig)
-
+func SetEKS(clusterName, k8sVersion string, nodePools []config.Nodepool, newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File) error {
 	terraformConfig := new(config.TerraformConfig)
 	ranchFrame.LoadConfig(configs.Terraform, terraformConfig)
-
-	newFile, rootBody := resources.SetProvidersAndUsersTF(rancherConfig, terraformConfig)
-
-	rootBody.AppendNewline()
 
 	cloudCredBlock := rootBody.AppendNewBlock(defaults.Resource, []string{defaults.CloudCredential, defaults.CloudCredential})
 	cloudCredBlockBody := cloudCredBlock.Body()

--- a/framework/set/provisioning/hosted/setGKE.go
+++ b/framework/set/provisioning/hosted/setGKE.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
-	"github.com/rancher/shepherd/clients/rancher"
 	framework "github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/defaults/configs"
@@ -18,16 +17,9 @@ import (
 )
 
 // SetGKE is a function that will set the GKE configurations in the main.tf file.
-func SetGKE(clusterName, k8sVersion string, nodePools []config.Nodepool, file *os.File) error {
-	rancherConfig := new(rancher.Config)
-	framework.LoadConfig(configs.Rancher, rancherConfig)
-
+func SetGKE(clusterName, k8sVersion string, nodePools []config.Nodepool, newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File) error {
 	terraformConfig := new(config.TerraformConfig)
 	framework.LoadConfig(configs.Terraform, terraformConfig)
-
-	newFile, rootBody := resources.SetProvidersAndUsersTF(rancherConfig, terraformConfig)
-
-	rootBody.AppendNewline()
 
 	cloudCredBlock := rootBody.AppendNewBlock(defaults.Resource, []string{defaults.CloudCredential, defaults.CloudCredential})
 	cloudCredBlockBody := cloudCredBlock.Body()

--- a/framework/set/rbac/setProject.go
+++ b/framework/set/rbac/setProject.go
@@ -1,0 +1,91 @@
+package rbac
+
+import (
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/framework/set/defaults"
+	"github.com/sirupsen/logrus"
+	"github.com/zclconf/go-cty/cty"
+)
+
+const (
+	project = "rancher2_project"
+	cluster = "rancher2_cluster_v2"
+
+	clusterRoleTemplateBinding = "rancher2_cluster_role_template_binding"
+	projectRoleTemplateBinding = "rancher2_project_role_template_binding"
+
+	clusterRoleTemplateBindingName = "tfp-cluster-role-template-binding"
+	projectName                    = "tfp-project"
+	projectRoleTemplateBindingName = "tfp-project-role-template-binding"
+	clusterID                      = "cluster_id"
+	projectID                      = "project_id"
+	roleTemplateID                 = "role_template_id"
+)
+
+// AddProjectMember is a helper function that will add the RBAC project member to `user` in the main.tf file.
+func AddProjectMember(client *rancher.Client, clusterName string, newFile *hclwrite.File, rootBody *hclwrite.Body,
+	clusterBlockID hclwrite.Tokens, rbacRole config.Role, newUser string, isRKE1 bool) (*hclwrite.File, *hclwrite.Body) {
+	projectBlock := rootBody.AppendNewBlock(defaults.Resource, []string{project, project})
+	projectBlockBody := projectBlock.Body()
+
+	projectBlockBody.SetAttributeValue(defaults.ResourceName, cty.StringVal(projectName))
+
+	if isRKE1 {
+		projectBlockBody.SetAttributeRaw(clusterID, clusterBlockID)
+	} else {
+		clusterBlockID, err := clusters.GetClusterIDByName(client, clusterName)
+		if err != nil {
+			return newFile, rootBody
+		}
+
+		projectBlockBody.SetAttributeValue(clusterID, cty.StringVal(clusterBlockID))
+	}
+
+	rootBody.AppendNewline()
+
+	projectRoleTemplateBindingBlock := rootBody.AppendNewBlock(defaults.Resource, []string{projectRoleTemplateBinding, projectRoleTemplateBinding})
+	projectRoleTemplateBindingBody := projectRoleTemplateBindingBlock.Body()
+
+	projectBlockID := hclwrite.Tokens{
+		{Type: hclsyntax.TokenIdent, Bytes: []byte(project + "." + project + ".id")},
+	}
+
+	projectRoleTemplateBindingBody.SetAttributeValue(defaults.ResourceName, cty.StringVal(projectRoleTemplateBindingName))
+	projectRoleTemplateBindingBody.SetAttributeRaw(projectID, projectBlockID)
+	projectRoleTemplateBindingBody.SetAttributeValue(roleTemplateID, cty.StringVal(string(rbacRole)))
+	projectRoleTemplateBindingBody.SetAttributeValue(userID, cty.StringVal(newUser))
+
+	logrus.Infof("Added project member: %s", projectName)
+
+	return newFile, rootBody
+}
+
+// AddClusterRole is a helper function that will add the RBAC cluster role to non `user` member in the main.tf file.
+func AddClusterRole(client *rancher.Client, clusterName string, newFile *hclwrite.File, rootBody *hclwrite.Body, clusterBlockID hclwrite.Tokens,
+	rbacRole config.Role, newUser string, isRKE1 bool) (*hclwrite.File, *hclwrite.Body) {
+	clusterRoleTemplateBindingBlock := rootBody.AppendNewBlock(defaults.Resource, []string{clusterRoleTemplateBinding, clusterRoleTemplateBinding})
+	clusterRoleTemplateBindingBlockBody := clusterRoleTemplateBindingBlock.Body()
+
+	if isRKE1 {
+		clusterRoleTemplateBindingBlockBody.SetAttributeRaw(clusterID, clusterBlockID)
+	} else {
+		clusterBlockID, err := clusters.GetClusterIDByName(client, clusterName)
+		if err != nil {
+			return newFile, rootBody
+		}
+
+		clusterRoleTemplateBindingBlockBody.SetAttributeValue(clusterID, cty.StringVal(clusterBlockID))
+	}
+
+	clusterRoleTemplateBindingBlockBody.SetAttributeValue(defaults.ResourceName, cty.StringVal(clusterRoleTemplateBindingName))
+	clusterRoleTemplateBindingBlockBody.SetAttributeValue(roleTemplateID, cty.StringVal(string(rbacRole)))
+	clusterRoleTemplateBindingBlockBody.SetAttributeValue(userID, cty.StringVal(newUser))
+
+	logrus.Infof("Added cluster role: %s", clusterRoleTemplateBindingName)
+
+	return newFile, rootBody
+}

--- a/framework/set/rbac/setUsers.go
+++ b/framework/set/rbac/setUsers.go
@@ -1,0 +1,65 @@
+package rbac
+
+import (
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	password "github.com/rancher/shepherd/extensions/users/passwordgenerator"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/framework/set/defaults"
+	"github.com/sirupsen/logrus"
+	"github.com/zclconf/go-cty/cty"
+)
+
+const (
+	apiURL            = "api_url"
+	globalRoleBinding = "rancher2_global_role_binding"
+	globalRoleID      = "global_role_id"
+	insecure          = "insecure"
+	name              = "name"
+	provider          = "provider"
+	rancher2          = "rancher2"
+	rancherSource     = "source"
+	rancherUser       = "rancher2_user"
+	rc                = "-rc"
+	requiredProviders = "required_providers"
+	terraform         = "terraform"
+	testPassword      = "password"
+	tokenKey          = "token_key"
+	version           = "version"
+	user              = "user"
+	userID            = "user_id"
+	username          = "username"
+)
+
+// SetUsers is a helper function that will set the RBAC users in the main.tf file.
+func SetUsers(newFile *hclwrite.File, rootBody *hclwrite.Body, rbacRole config.Role) (string, error) {
+	var testuser = namegen.AppendRandomString("testuser")
+	var testpassword = password.GenerateUserPassword("testpass")
+
+	userBlock := rootBody.AppendNewBlock(defaults.Resource, []string{rancherUser, testuser})
+	userBlockBody := userBlock.Body()
+
+	userBlockBody.SetAttributeValue(name, cty.StringVal(testuser))
+	userBlockBody.SetAttributeValue(username, cty.StringVal(testuser))
+	userBlockBody.SetAttributeValue(testPassword, cty.StringVal(testpassword))
+	userBlockBody.SetAttributeValue(defaults.Enabled, cty.BoolVal(true))
+
+	rootBody.AppendNewline()
+
+	globalRoleBindingBlock := rootBody.AppendNewBlock(defaults.Resource, []string{globalRoleBinding, testuser})
+	globalRoleBindingBlockBody := globalRoleBindingBlock.Body()
+
+	globalRoleBindingBlockBody.SetAttributeValue(name, cty.StringVal(testuser))
+	globalRoleBindingBlockBody.SetAttributeValue(globalRoleID, cty.StringVal(user))
+
+	user := hclwrite.Tokens{
+		{Type: hclsyntax.TokenIdent, Bytes: []byte(rancherUser + "." + testuser + ".id")},
+	}
+
+	globalRoleBindingBlockBody.SetAttributeRaw(userID, user)
+
+	logrus.Infof("Created new user: %s", testuser)
+
+	return testuser, nil
+}

--- a/framework/setup.go
+++ b/framework/setup.go
@@ -7,7 +7,7 @@ import (
 	framework "github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/defaults/configs"
-	"github.com/rancher/tfp-automation/framework/set/provisioning"
+	setFramework "github.com/rancher/tfp-automation/framework/set"
 	"github.com/rancher/tfp-automation/framework/set/resources"
 	"github.com/stretchr/testify/require"
 )
@@ -19,7 +19,7 @@ func Setup(t *testing.T) *terraform.Options {
 
 	keyPath := resources.SetKeyPath()
 
-	err := provisioning.SetConfigTF(clusterConfig, "", "")
+	err := setFramework.SetConfigTF(nil, clusterConfig, "", "", "")
 	require.NoError(t, err)
 
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{

--- a/tests/extensions/provisioning/buildModule.go
+++ b/tests/extensions/provisioning/buildModule.go
@@ -7,7 +7,7 @@ import (
 	ranchFrame "github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/defaults/configs"
-	"github.com/rancher/tfp-automation/framework/set/provisioning"
+	framework "github.com/rancher/tfp-automation/framework/set"
 	"github.com/rancher/tfp-automation/framework/set/resources"
 	"github.com/sirupsen/logrus"
 )
@@ -19,7 +19,7 @@ func BuildModule(t *testing.T) error {
 
 	keyPath := resources.SetKeyPath()
 
-	err := provisioning.SetConfigTF(clusterConfig, "", "")
+	err := framework.SetConfigTF(nil, clusterConfig, "", "", "")
 	if err != nil {
 		return err
 	}

--- a/tests/extensions/provisioning/kubernetesUpgrade.go
+++ b/tests/extensions/provisioning/kubernetesUpgrade.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/tfp-automation/config"
-	set "github.com/rancher/tfp-automation/framework/set/provisioning"
+	framework "github.com/rancher/tfp-automation/framework/set"
 	"github.com/stretchr/testify/require"
 )
 
@@ -16,7 +16,7 @@ func KubernetesUpgrade(t *testing.T, client *rancher.Client, clusterName, poolNa
 	terraformConfig *config.TerraformConfig, clusterConfig *config.TerratestConfig) {
 	DefaultUpgradedK8sVersion(t, client, clusterConfig, terraformConfig)
 
-	err := set.SetConfigTF(clusterConfig, clusterName, poolName)
+	err := framework.SetConfigTF(nil, clusterConfig, clusterName, poolName, "")
 	require.NoError(t, err)
 
 	terraform.Apply(t, terraformOptions)

--- a/tests/extensions/provisioning/provision.go
+++ b/tests/extensions/provisioning/provision.go
@@ -4,18 +4,19 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/tfp-automation/config"
-	set "github.com/rancher/tfp-automation/framework/set/provisioning"
+	framework "github.com/rancher/tfp-automation/framework/set"
 	"github.com/stretchr/testify/require"
 )
 
 // Provision is a function that will run terraform init and apply Terraform resources to provision a cluster.
-func Provision(t *testing.T, clusterName, poolName string, clusterConfig *config.TerratestConfig, terraformOptions *terraform.Options) {
-	err := set.SetConfigTF(clusterConfig, clusterName, poolName)
+func Provision(t *testing.T, client *rancher.Client, clusterName, poolName string, clusterConfig *config.TerratestConfig, terraformOptions *terraform.Options) {
+	err := framework.SetConfigTF(client, clusterConfig, clusterName, poolName, "")
 	require.NoError(t, err)
 
 	isSupported := SupportedModules(terraformOptions)
+	require.True(t, isSupported)
 
 	terraform.InitAndApply(t, terraformOptions)
-	require.True(t, isSupported)
 }

--- a/tests/extensions/provisioning/scale.go
+++ b/tests/extensions/provisioning/scale.go
@@ -5,14 +5,14 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/rancher/tfp-automation/config"
-	set "github.com/rancher/tfp-automation/framework/set/provisioning"
+	framework "github.com/rancher/tfp-automation/framework/set"
 	"github.com/stretchr/testify/require"
 )
 
 // Scale is a function that will run terraform apply and scale the provisioned
 // cluster, according to user's desired amount.
 func Scale(t *testing.T, clusterName, poolName string, terraformOptions *terraform.Options, clusterConfig *config.TerratestConfig) {
-	err := set.SetConfigTF(clusterConfig, clusterName, poolName)
+	err := framework.SetConfigTF(nil, clusterConfig, clusterName, poolName, "")
 	require.NoError(t, err)
 
 	terraform.Apply(t, terraformOptions)

--- a/tests/extensions/rbac/rbac.go
+++ b/tests/extensions/rbac/rbac.go
@@ -1,0 +1,20 @@
+package rbac
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/tfp-automation/config"
+	framework "github.com/rancher/tfp-automation/framework/set"
+	"github.com/stretchr/testify/require"
+)
+
+// RBAC is a function that will run terraform init and apply Terraform resources to create users.
+func RBAC(t *testing.T, client *rancher.Client, clusterName, poolName string, terraformOptions *terraform.Options,
+	clusterConfig *config.TerratestConfig, rbacRole config.Role) {
+	err := framework.SetConfigTF(client, clusterConfig, clusterName, poolName, rbacRole)
+	require.NoError(t, err)
+
+	terraform.Apply(t, terraformOptions)
+}

--- a/tests/nodescaling/scale_hosted_test.go
+++ b/tests/nodescaling/scale_hosted_test.go
@@ -65,7 +65,7 @@ func (s *ScaleHostedTestSuite) TestTfpScaleHosted() {
 		s.Run((tt.name), func() {
 			defer cleanup.ConfigCleanup(s.T(), s.terraformOptions)
 
-			provisioning.Provision(s.T(), clusterName, poolName, s.clusterConfig, s.terraformOptions)
+			provisioning.Provision(s.T(), s.client, clusterName, poolName, s.clusterConfig, s.terraformOptions)
 			provisioning.VerifyCluster(s.T(), s.client, clusterName, s.terraformConfig, s.terraformOptions, s.clusterConfig)
 
 			s.clusterConfig.Nodepools = s.clusterConfig.ScalingInput.ScaledUpNodepools

--- a/tests/nodescaling/scale_test.go
+++ b/tests/nodescaling/scale_test.go
@@ -88,7 +88,7 @@ func (s *ScaleTestSuite) TestTfpScale() {
 		poolName := namegen.AppendRandomString(configs.TFP)
 
 		s.Run((tt.name), func() {
-			provisioning.Provision(s.T(), clusterName, poolName, &clusterConfig, s.terraformOptions)
+			provisioning.Provision(s.T(), s.client, clusterName, poolName, &clusterConfig, s.terraformOptions)
 			provisioning.VerifyCluster(s.T(), s.client, clusterName, s.terraformConfig, s.terraformOptions, &clusterConfig)
 
 			clusterConfig.Nodepools = clusterConfig.ScalingInput.ScaledUpNodepools
@@ -124,7 +124,7 @@ func (s *ScaleTestSuite) TestTfpScaleDynamicInput() {
 		s.Run((tt.name), func() {
 			defer cleanup.ConfigCleanup(s.T(), s.terraformOptions)
 
-			provisioning.Provision(s.T(), clusterName, poolName, s.clusterConfig, s.terraformOptions)
+			provisioning.Provision(s.T(), s.client, clusterName, poolName, s.clusterConfig, s.terraformOptions)
 			provisioning.VerifyCluster(s.T(), s.client, clusterName, s.terraformConfig, s.terraformOptions, s.clusterConfig)
 
 			s.clusterConfig.Nodepools = s.clusterConfig.ScalingInput.ScaledUpNodepools

--- a/tests/provisioning/README.md
+++ b/tests/provisioning/README.md
@@ -4,7 +4,7 @@ In the provisioning tests, the following workflow is followed:
 
 1. Provision a downstream cluster
 2. Perform post-cluster provisioning checks
-7. Cleanup resources (Terraform explicitly needs to call its cleanup method so that each test doesn't experience caching issues)
+3. Cleanup resources (Terraform explicitly needs to call its cleanup method so that each test doesn't experience caching issues)
 
 Please see below for more details for your config. Please note that the config can be in either JSON or YAML (all examples are illustrated in YAML).
 

--- a/tests/provisioning/provision_hosted_test.go
+++ b/tests/provisioning/provision_hosted_test.go
@@ -65,7 +65,7 @@ func (p *ProvisionHostedTestSuite) TestTfpProvisionHosted() {
 		p.Run((tt.name), func() {
 			defer cleanup.ConfigCleanup(p.T(), p.terraformOptions)
 
-			provisioning.Provision(p.T(), clusterName, poolName, p.clusterConfig, p.terraformOptions)
+			provisioning.Provision(p.T(), p.client, clusterName, poolName, p.clusterConfig, p.terraformOptions)
 			provisioning.VerifyCluster(p.T(), p.client, clusterName, p.terraformConfig, p.terraformOptions, p.clusterConfig)
 		})
 	}

--- a/tests/provisioning/provision_test.go
+++ b/tests/provisioning/provision_test.go
@@ -74,7 +74,7 @@ func (p *ProvisionTestSuite) TestTfpProvision() {
 		p.Run((tt.name), func() {
 			defer cleanup.ConfigCleanup(p.T(), p.terraformOptions)
 
-			provisioning.Provision(p.T(), clusterName, poolName, &clusterConfig, p.terraformOptions)
+			provisioning.Provision(p.T(), p.client, clusterName, poolName, &clusterConfig, p.terraformOptions)
 			provisioning.VerifyCluster(p.T(), p.client, clusterName, p.terraformConfig, p.terraformOptions, &clusterConfig)
 		})
 	}
@@ -96,7 +96,7 @@ func (p *ProvisionTestSuite) TestTfpProvisionDynamicInput() {
 		p.Run((tt.name), func() {
 			defer cleanup.ConfigCleanup(p.T(), p.terraformOptions)
 
-			provisioning.Provision(p.T(), clusterName, poolName, p.clusterConfig, p.terraformOptions)
+			provisioning.Provision(p.T(), p.client, clusterName, poolName, p.clusterConfig, p.terraformOptions)
 			provisioning.VerifyCluster(p.T(), p.client, clusterName, p.terraformConfig, p.terraformOptions, p.clusterConfig)
 		})
 	}

--- a/tests/psact/psact_test.go
+++ b/tests/psact/psact_test.go
@@ -89,7 +89,7 @@ func (p *PSACTTestSuite) TestTfpPSACT() {
 		p.Run((tt.name), func() {
 			defer cleanup.ConfigCleanup(p.T(), p.terraformOptions)
 
-			provisioning.Provision(p.T(), clusterName, poolName, &clusterConfig, p.terraformOptions)
+			provisioning.Provision(p.T(), p.client, clusterName, poolName, &clusterConfig, p.terraformOptions)
 			provisioning.VerifyCluster(p.T(), p.client, clusterName, p.terraformConfig, p.terraformOptions, &clusterConfig)
 		})
 	}

--- a/tests/rbac/README.md
+++ b/tests/rbac/README.md
@@ -1,0 +1,18 @@
+# RBAC
+
+In the RBAC tests, the following workflow is followed:
+
+1. Provision a downstream cluster
+2. Perform post-cluster provisioning checks
+3. Add a cluster owner/project member to the cluster
+4. Cleanup resources (Terraform explicitly needs to call its cleanup method so that each test doesn't experience caching issues)
+
+The config file is going to be the exact same as what is seen when provisioning clusters; there are no additional details that you need to do. For reference, please see the [provisioning README](../provisioning/README.md).
+
+See the below examples on how to run the tests:
+
+### RBAC
+
+`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/rbac --junitfile results.xml -- -timeout=60m -v -run "TestTfpRBACTestSuite/TestTfpRBAC$"`
+
+If the specified test passes immediately without warning, try adding the -count=1 flag to get around this issue. This will avoid previous results from interfering with the new test run.

--- a/tests/snapshot/snapshot.go
+++ b/tests/snapshot/snapshot.go
@@ -20,7 +20,7 @@ import (
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/defaults/clustertypes"
 	"github.com/rancher/tfp-automation/defaults/stevetypes"
-	set "github.com/rancher/tfp-automation/framework/set/provisioning"
+	framework "github.com/rancher/tfp-automation/framework/set"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -116,7 +116,7 @@ func snapshotV2Prov(t *testing.T, client *rancher.Client, podTemplate corev1.Pod
 
 	clusterConfig.SnapshotInput.CreateSnapshot = true
 
-	err = set.SetConfigTF(clusterConfig, clusterName, poolName)
+	err = framework.SetConfigTF(nil, clusterConfig, clusterName, poolName, "")
 	require.NoError(t, err)
 
 	terraform.Apply(t, terraformOptions)
@@ -164,7 +164,7 @@ func snapshotV2Prov(t *testing.T, client *rancher.Client, podTemplate corev1.Pod
 		clusterConfig.KubernetesVersion = clusterObject.Spec.KubernetesVersion
 		clusterConfig.SnapshotInput.CreateSnapshot = false
 
-		err = set.SetConfigTF(clusterConfig, clusterName, poolName)
+		err = framework.SetConfigTF(nil, clusterConfig, clusterName, poolName, "")
 		require.NoError(t, err)
 
 		terraform.Apply(t, terraformOptions)
@@ -195,7 +195,7 @@ func restoreV2Prov(t *testing.T, client *rancher.Client, clusterConfig *config.T
 	clusterConfig.SnapshotInput.RestoreSnapshot = true
 	clusterConfig.SnapshotInput.SnapshotName = snapshotName
 
-	err := set.SetConfigTF(clusterConfig, clusterName, poolName)
+	err := framework.SetConfigTF(nil, clusterConfig, clusterName, poolName, "")
 	require.NoError(t, err)
 
 	terraform.Apply(t, terraformOptions)

--- a/tests/snapshot/snapshot_restore_test.go
+++ b/tests/snapshot/snapshot_restore_test.go
@@ -94,7 +94,7 @@ func (s *SnapshotRestoreTestSuite) TestTfpSnapshotRestore() {
 		s.Run(tt.name, func() {
 			defer cleanup.ConfigCleanup(s.T(), s.terraformOptions)
 
-			provisioning.Provision(s.T(), clusterName, poolName, &clusterConfig, s.terraformOptions)
+			provisioning.Provision(s.T(), s.client, clusterName, poolName, &clusterConfig, s.terraformOptions)
 			provisioning.VerifyCluster(s.T(), s.client, clusterName, s.terraformConfig, s.terraformOptions, &clusterConfig)
 
 			snapshotRestore(s.T(), s.client, clusterName, poolName, &clusterConfig, s.terraformOptions)
@@ -122,7 +122,7 @@ func (s *SnapshotRestoreTestSuite) TestTfpSnapshotRestoreDynamicInput() {
 		s.Run((tt.name), func() {
 			defer cleanup.ConfigCleanup(s.T(), s.terraformOptions)
 
-			provisioning.Provision(s.T(), clusterName, poolName, s.clusterConfig, s.terraformOptions)
+			provisioning.Provision(s.T(), s.client, clusterName, poolName, s.clusterConfig, s.terraformOptions)
 			provisioning.VerifyCluster(s.T(), s.client, clusterName, s.terraformConfig, s.terraformOptions, s.clusterConfig)
 
 			snapshotRestore(s.T(), s.client, clusterName, poolName, s.clusterConfig, s.terraformOptions)

--- a/tests/upgrading/kubernetes_hosted_test.go
+++ b/tests/upgrading/kubernetes_hosted_test.go
@@ -65,7 +65,7 @@ func (k *KubernetesUpgradeHostedTestSuite) TestTfpKubernetesUpgradeHosted() {
 		k.Run((tt.name), func() {
 			defer cleanup.ConfigCleanup(k.T(), k.terraformOptions)
 
-			provisioning.Provision(k.T(), clusterName, poolName, k.clusterConfig, k.terraformOptions)
+			provisioning.Provision(k.T(), k.client, clusterName, poolName, k.clusterConfig, k.terraformOptions)
 			provisioning.VerifyCluster(k.T(), k.client, clusterName, k.terraformConfig, k.terraformOptions, k.clusterConfig)
 
 			provisioning.KubernetesUpgrade(k.T(), k.client, clusterName, poolName, k.terraformOptions, k.terraformConfig, k.clusterConfig)

--- a/tests/upgrading/kubernetes_upgrade_test.go
+++ b/tests/upgrading/kubernetes_upgrade_test.go
@@ -73,7 +73,7 @@ func (k *KubernetesUpgradeTestSuite) TestTfpKubernetesUpgrade() {
 		k.Run((tt.name), func() {
 			defer cleanup.ConfigCleanup(k.T(), k.terraformOptions)
 
-			provisioning.Provision(k.T(), clusterName, poolName, &clusterConfig, k.terraformOptions)
+			provisioning.Provision(k.T(), k.client, clusterName, poolName, &clusterConfig, k.terraformOptions)
 			provisioning.VerifyCluster(k.T(), k.client, clusterName, k.terraformConfig, k.terraformOptions, &clusterConfig)
 
 			provisioning.KubernetesUpgrade(k.T(), k.client, clusterName, poolName, k.terraformOptions, k.terraformConfig, &clusterConfig)
@@ -100,7 +100,7 @@ func (k *KubernetesUpgradeTestSuite) TestTfpKubernetesUpgradeDynamicInput() {
 		k.Run((tt.name), func() {
 			defer cleanup.ConfigCleanup(k.T(), k.terraformOptions)
 
-			provisioning.Provision(k.T(), clusterName, poolName, k.clusterConfig, k.terraformOptions)
+			provisioning.Provision(k.T(), k.client, clusterName, poolName, k.clusterConfig, k.terraformOptions)
 			provisioning.VerifyCluster(k.T(), k.client, clusterName, k.terraformConfig, k.terraformOptions, k.clusterConfig)
 
 			provisioning.KubernetesUpgrade(k.T(), k.client, clusterName, poolName, k.terraformOptions, k.terraformConfig, k.clusterConfig)


### PR DESCRIPTION
### PR Description
This PR provides initial support for RBAC. It will provision clusters and assign a cluster owner and project member to the cluster utilizing Rancher2 Terraform resources only.

Additionally, general refactoring to adjust to RBAC (and other functionalities) has been done as well.