### PR TITLE
Remove unncessary not nil line

### DIFF
--- a/tests/snapshot/snapshot_restore_test.go
+++ b/tests/snapshot/snapshot_restore_test.go
@@ -86,8 +86,6 @@ func (s *SnapshotRestoreTestSuite) TestTfpSnapshotRestore() {
 			s.T().Skip("RKE1 is not supported")
 		}
 
-		require.NotNil(s.T(), s.terraformConfig.ETCD)
-
 		if strings.Contains(s.terraformConfig.Module, "ec2") && s.terraformConfig.ETCD.S3 != nil {
 			tt.name = "S3 " + tt.name
 		} else {


### PR DESCRIPTION
### PR Description
`tfp-automation` allows for the `etcd` block to be optional in the configuration file. This line, however, is causing the test to fail if it is not defined. `etcd` block is only needed when working with S3-enabled clusters. Otherwise, it should remain optional.