### PR TITLE
Add support to locally report results to Qase

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -149,6 +149,7 @@ type Snapshots struct {
 
 type TerratestConfig struct {
 	KubernetesVersion         string     `json:"kubernetesVersion,omitempty" yaml:"kubernetesVersion,omitempty"`
+	LocalQaseReporting        bool       `json:"localQaseReporting,omitempty" yaml:"localQaseReporting,omitempty" default:"false"`
 	UpgradedKubernetesVersion string     `json:"upgradedKubernetesVersion,omitempty" yaml:"upgradedKubernetesVersion,omitempty"`
 	NodeCount                 int64      `json:"nodeCount,omitempty" yaml:"nodeCount,omitempty"`
 	Nodepools                 []Nodepool `json:"nodepools,omitempty" yaml:"nodepools,omitempty"`

--- a/pipeline/qase/results/results.go
+++ b/pipeline/qase/results/results.go
@@ -1,0 +1,37 @@
+package results
+
+import (
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
+)
+
+// ReportTest is a function that reports the test results.
+func ReportTest() error {
+	runID := os.Getenv("QASE_TEST_RUN_ID")
+	if runID == "" {
+		logrus.Error("QASE_TEST_RUN_ID is not set")
+		return nil
+	}
+
+	user, err := user.Current()
+	if err != nil {
+		return err
+	}
+
+	reporterPath := filepath.Join(user.HomeDir, "go/src/github.com/tfp-automation/pipeline/scripts/build_qase_reporter.sh")
+
+	cmd := exec.Command(reporterPath)
+	output, err := cmd.Output()
+	if err != nil {
+		logrus.Error("Error running reporter script: ", err)
+		return err
+	}
+
+	logrus.Info(string(output))
+
+	return nil
+}

--- a/pipeline/scripts/build_qase_reporter.sh
+++ b/pipeline/scripts/build_qase_reporter.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 set -e
+
+OS=$(uname | tr '[:upper:]' '[:lower:]')
 cd $(dirname $0)/../../
-if [[ -z "${QASE_TEST_RUN_ID}" ]]; then
+
+if [[ -z ${QASE_TEST_RUN_ID} ]]; then
   echo "no test run ID is provided"
 else
   echo "building qase reporter bin"
-  env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -buildvcs=false -o reporter ./pipeline/qase/reporter
+  env GOOS=${OS} GOARCH=amd64 CGO_ENABLED=0 go build -buildvcs=false -o reporter ./pipeline/qase/reporter
 fi

--- a/tests/nodescaling/README.md
+++ b/tests/nodescaling/README.md
@@ -15,6 +15,7 @@ Please see below for more details for your config. Please note that the config c
 ## Table of Contents
 1. [Getting Started](#Getting-Started)
 2. [Scaling Node Pools](#Scaling-Node-Pools)
+3. [Local Qase Reporting](#Local-Qase-Reporting)
 
 ## Getting Started
 In your config file, set the following:
@@ -149,11 +150,20 @@ See the below examples on how to run the tests:
 
 ### RKE1/RKE2/K3S
 
-`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/nodescaling --junitfile results.xml -- -timeout=60m -v -run "TestTfpScaleTestSuite/TestTfpScale$"` \
-`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/nodescaling --junitfile results.xml -- -timeout=60m -v -run "TestTfpScaleTestSuite/TestTfpScaleDynamicInput$"`
+`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/nodescaling --junitfile results/results.xml --jsonfile results/results.json -- -timeout=60m -v -run "TestTfpScaleTestSuite/TestTfpScale$"` \
+`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/nodescaling --junitfile results/results.xml --jsonfile results/results.json -- -timeout=60m -v -run "TestTfpScaleTestSuite/TestTfpScaleDynamicInput$"`
 
 ### Hosted
 
-`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/nodescaling --junitfile results.xml -- -timeout=60m -v -run "TestTfpScaleHostedTestSuite/TestTfpScaleHosted$"`
+`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/nodescaling --junitfile results/results.xml --jsonfile results/results.json -- -timeout=60m -v -run "TestTfpScaleHostedTestSuite/TestTfpScaleHosted$"`
 
 If the specified test passes immediately without warning, try adding the -count=1 flag to get around this issue. This will avoid previous results from interfering with the new test run.
+
+## Local Qase Reporting
+If you are planning to report to Qase locally, then you will need to have the following done:
+1. The `terratest` block in your config file must have `localQaseReporting: true`.
+2. The working shell session must have the following two environmental variables set:
+     - `QASE_AUTOMATION_TOKEN=""`
+     - `QASE_TEST_RUN_ID=""`
+3. Append `./reporter` to the end of the `gotestsum` command. See an example below::
+     - `gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/nodescaling --junitfile results/results.xml --jsonfile results/results.json -- -timeout=60m -v -run "TestTfpScaleTestSuite/TestTfpScale$";/path/to/tfp-automation/reporter`

--- a/tests/nodescaling/scale_hosted_test.go
+++ b/tests/nodescaling/scale_hosted_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rancher/tfp-automation/defaults/configs"
 	"github.com/rancher/tfp-automation/framework"
 	cleanup "github.com/rancher/tfp-automation/framework/cleanup"
+	qase "github.com/rancher/tfp-automation/pipeline/qase/results"
 	"github.com/rancher/tfp-automation/tests/extensions/provisioning"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -80,6 +81,10 @@ func (s *ScaleHostedTestSuite) TestTfpScaleHosted() {
 			provisioning.VerifyCluster(s.T(), s.client, clusterName, s.terraformConfig, s.terraformOptions, s.clusterConfig)
 			provisioning.VerifyNodeCount(s.T(), s.client, clusterName, s.terraformConfig, s.clusterConfig.ScalingInput.ScaledDownNodeCount)
 		})
+	}
+
+	if s.clusterConfig.LocalQaseReporting {
+		qase.ReportTest()
 	}
 }
 

--- a/tests/nodescaling/scale_test.go
+++ b/tests/nodescaling/scale_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rancher/tfp-automation/defaults/configs"
 	"github.com/rancher/tfp-automation/framework"
 	cleanup "github.com/rancher/tfp-automation/framework/cleanup"
+	qase "github.com/rancher/tfp-automation/pipeline/qase/results"
 	"github.com/rancher/tfp-automation/tests/extensions/provisioning"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -106,6 +107,10 @@ func (s *ScaleTestSuite) TestTfpScale() {
 			cleanup.ConfigCleanup(s.T(), s.terraformOptions)
 		})
 	}
+
+	if s.clusterConfig.LocalQaseReporting {
+		qase.ReportTest()
+	}
 }
 
 func (s *ScaleTestSuite) TestTfpScaleDynamicInput() {
@@ -139,6 +144,10 @@ func (s *ScaleTestSuite) TestTfpScaleDynamicInput() {
 			provisioning.VerifyCluster(s.T(), s.client, clusterName, s.terraformConfig, s.terraformOptions, s.clusterConfig)
 			provisioning.VerifyNodeCount(s.T(), s.client, clusterName, s.terraformConfig, s.clusterConfig.ScalingInput.ScaledDownNodeCount)
 		})
+	}
+
+	if s.clusterConfig.LocalQaseReporting {
+		qase.ReportTest()
 	}
 }
 

--- a/tests/provisioning/README.md
+++ b/tests/provisioning/README.md
@@ -11,6 +11,7 @@ Please see below for more details for your config. Please note that the config c
 ## Table of Contents
 1. [Getting Started](#Getting-Started)
 2. [Provisioning Clusters](#Provisioning=Clusters)
+3. [Local Qase Reporting](#Local-Qase-Reporting)
 
 ## Getting Started
 In your config file, set the following:
@@ -37,11 +38,20 @@ See the below examples on how to run the tests:
 
 ### RKE1/RKE2/K3S
 
-`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/provisioning --junitfile results.xml -- -timeout=60m -v -run "TestTfpProvisionTestSuite/TestTfpProvision$"` \
-`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/provisioning --junitfile results.xml -- -timeout=60m -v -run "TestTfpProvisionTestSuite/TestTfpProvisionDynamicInput$"`
+`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/provisioning --junitfile results/results.xml --jsonfile results/results.json -- -timeout=60m -v -run "TestTfpProvisionTestSuite/TestTfpProvision$"` \
+`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/provisioning --junitfile results/results.xml --jsonfile results/results.json -- -timeout=60m -v -run "TestTfpProvisionTestSuite/TestTfpProvisionDynamicInput$"`
 
 ### Hosted
 
-`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/provisioning --junitfile results.xml -- -timeout=60m -v -run "TestTfpProvisionHostedTestSuite/TestTfpProvisionHosted$"`
+`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/provisioning --junitfile results/results.xml --jsonfile results/results.json -- -timeout=60m -v -run "TestTfpProvisionHostedTestSuite/TestTfpProvisionHosted$"`
 
 If the specified test passes immediately without warning, try adding the -count=1 flag to get around this issue. This will avoid previous results from interfering with the new test run.
+
+## Local Qase Reporting
+If you are planning to report to Qase locally, then you will need to have the following done:
+1. The `terratest` block in your config file must have `localQaseReporting: true`.
+2. The working shell session must have the following two environmental variables set:
+     - `QASE_AUTOMATION_TOKEN=""`
+     - `QASE_TEST_RUN_ID=""`
+3. Append `./reporter` to the end of the `gotestsum` command. See an example below::
+     - `gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/provisioning --junitfile results/results.xml --jsonfile results/results.json -- -timeout=60m -v -run "TestTfpProvisionTestSuite/TestTfpProvision$";/path/to/tfp-automation/reporter`

--- a/tests/provisioning/provision_hosted_test.go
+++ b/tests/provisioning/provision_hosted_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rancher/tfp-automation/defaults/configs"
 	"github.com/rancher/tfp-automation/framework"
 	cleanup "github.com/rancher/tfp-automation/framework/cleanup"
+	qase "github.com/rancher/tfp-automation/pipeline/qase/results"
 	"github.com/rancher/tfp-automation/tests/extensions/provisioning"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -68,6 +69,10 @@ func (p *ProvisionHostedTestSuite) TestTfpProvisionHosted() {
 			provisioning.Provision(p.T(), p.client, clusterName, poolName, p.clusterConfig, p.terraformOptions)
 			provisioning.VerifyCluster(p.T(), p.client, clusterName, p.terraformConfig, p.terraformOptions, p.clusterConfig)
 		})
+	}
+
+	if p.clusterConfig.LocalQaseReporting {
+		qase.ReportTest()
 	}
 }
 

--- a/tests/provisioning/provision_test.go
+++ b/tests/provisioning/provision_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rancher/tfp-automation/defaults/configs"
 	"github.com/rancher/tfp-automation/framework"
 	cleanup "github.com/rancher/tfp-automation/framework/cleanup"
+	qase "github.com/rancher/tfp-automation/pipeline/qase/results"
 	"github.com/rancher/tfp-automation/tests/extensions/provisioning"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -78,6 +79,10 @@ func (p *ProvisionTestSuite) TestTfpProvision() {
 			provisioning.VerifyCluster(p.T(), p.client, clusterName, p.terraformConfig, p.terraformOptions, &clusterConfig)
 		})
 	}
+
+	if p.clusterConfig.LocalQaseReporting {
+		qase.ReportTest()
+	}
 }
 
 func (p *ProvisionTestSuite) TestTfpProvisionDynamicInput() {
@@ -99,6 +104,10 @@ func (p *ProvisionTestSuite) TestTfpProvisionDynamicInput() {
 			provisioning.Provision(p.T(), p.client, clusterName, poolName, p.clusterConfig, p.terraformOptions)
 			provisioning.VerifyCluster(p.T(), p.client, clusterName, p.terraformConfig, p.terraformOptions, p.clusterConfig)
 		})
+	}
+
+	if p.clusterConfig.LocalQaseReporting {
+		qase.ReportTest()
 	}
 }
 

--- a/tests/psact/README.md
+++ b/tests/psact/README.md
@@ -17,6 +17,7 @@ Please see below for more details for your config. Please note that the config c
 ## Table of Contents
 1. [Getting Started](#Getting-Started)
 2. [Provisioning Clusters](#Provisioning=Clusters)
+3. [Local Qase Reporting](#Local-Qase-Reporting)
 
 ## Getting Started
 In your config file, set the following:
@@ -52,4 +53,13 @@ terratest:
 
 See the below examples on how to run the tests:
 
-`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/psact --junitfile results.xml -- -timeout=60m -v -run "TestTfpPSACTTestSuite/TestTfpPSACT$"`
+`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/psact --junitfile results/results.xml --jsonfile results/results.json -- -timeout=60m -v -run "TestTfpPSACTTestSuite/TestTfpPSACT$"`
+
+## Local Qase Reporting
+If you are planning to report to Qase locally, then you will need to have the following done:
+1. The `terratest` block in your config file must have `localQaseReporting: true`.
+2. The working shell session must have the following two environmental variables set:
+     - `QASE_AUTOMATION_TOKEN=""`
+     - `QASE_TEST_RUN_ID=""`
+3. Append `./reporter` to the end of the `gotestsum` command. See an example below::
+     - `gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/psact --junitfile results/results.xml --jsonfile results/results.json -- -timeout=60m -v -run "TestTfpPSACTTestSuite/TestTfpPSACT$";/path/to/tfp-automation/reporter`

--- a/tests/psact/psact_test.go
+++ b/tests/psact/psact_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rancher/tfp-automation/defaults/configs"
 	"github.com/rancher/tfp-automation/framework"
 	cleanup "github.com/rancher/tfp-automation/framework/cleanup"
+	qase "github.com/rancher/tfp-automation/pipeline/qase/results"
 	"github.com/rancher/tfp-automation/tests/extensions/provisioning"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -59,21 +60,9 @@ func (p *PSACTTestSuite) TestTfpPSACT() {
 		nodeRoles []config.Nodepool
 		psact     config.PSACT
 	}{
-		{
-			name:      "Rancher Privileged " + config.StandardClientName.String(),
-			nodeRoles: nodeRolesDedicated,
-			psact:     "rancher-privileged",
-		},
-		{
-			name:      "Rancher Restricted " + config.StandardClientName.String(),
-			nodeRoles: nodeRolesDedicated,
-			psact:     "rancher-restricted",
-		},
-		{
-			name:      "Rancher Baseline " + config.StandardClientName.String(),
-			nodeRoles: nodeRolesDedicated,
-			psact:     "rancher-baseline",
-		},
+		{"Rancher Privileged " + config.StandardClientName.String(), nodeRolesDedicated, "rancher-privileged"},
+		{"Rancher Restricted " + config.StandardClientName.String(), nodeRolesDedicated, "rancher-restricted"},
+		{"Rancher Baseline " + config.StandardClientName.String(), nodeRolesDedicated, "rancher-baseline"},
 	}
 
 	for _, tt := range tests {
@@ -92,6 +81,10 @@ func (p *PSACTTestSuite) TestTfpPSACT() {
 			provisioning.Provision(p.T(), p.client, clusterName, poolName, &clusterConfig, p.terraformOptions)
 			provisioning.VerifyCluster(p.T(), p.client, clusterName, p.terraformConfig, p.terraformOptions, &clusterConfig)
 		})
+	}
+
+	if p.clusterConfig.LocalQaseReporting {
+		qase.ReportTest()
 	}
 }
 

--- a/tests/rbac/README.md
+++ b/tests/rbac/README.md
@@ -3,6 +3,7 @@
 ## Table of Contents
 1. [RBAC](#RBAC)
 2. [Authentication Providers](#Authentication-Providers)
+3. [Local Qase Reporting](#Local-Qase-Reporting)
 
 ### RBAC
 
@@ -40,7 +41,7 @@ terraform:
 
 See the below examples on how to run the tests:
 
-`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/rbac --junitfile results.xml -- -timeout=60m -v -run "TestTfpRBACTestSuite/TestTfpRBAC$"`
+`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/rbac --junitfile results/results.xml --jsonfile results/results.json -- -timeout=60m -v -run "TestTfpRBACTestSuite/TestTfpRBAC$"`
 
 If the specified test passes immediately without warning, try adding the -count=1 flag to get around this issue. This will avoid previous results from interfering with the new test run.
 
@@ -116,6 +117,15 @@ terraform:
 
 See the below examples on how to run the tests:
 
-`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/rbac --junitfile results.xml -- -timeout=60m -v -run "TestTfpAuthConfigTestSuite/TestTfpAuthConfig$"`
+`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/rbac --junitfile results/results.xml --jsonfile results/results.json -- -timeout=60m -v -run "TestTfpAuthConfigTestSuite/TestTfpAuthConfig$"`
 
 If the specified test passes immediately without warning, try adding the -count=1 flag to get around this issue. This will avoid previous results from interfering with the new test run.
+
+## Local Qase Reporting
+If you are planning to report to Qase locally, then you will need to have the following done:
+1. The `terratest` block in your config file must have `localQaseReporting: true`.
+2. The working shell session must have the following two environmental variables set:
+     - `QASE_AUTOMATION_TOKEN=""`
+     - `QASE_TEST_RUN_ID=""`
+3. Append `./reporter` to the end of the `gotestsum` command. See an example below::
+     - `gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/rbac --junitfile results/results.xml --jsonfile results/results.json -- -timeout=60m -v -run "TestTfpRBACTestSuite/TestTfpRBAC$";/path/to/tfp-automation/reporter`

--- a/tests/rbac/auth_test.go
+++ b/tests/rbac/auth_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rancher/tfp-automation/defaults/authproviders"
 	"github.com/rancher/tfp-automation/framework"
 	"github.com/rancher/tfp-automation/framework/cleanup"
+	qase "github.com/rancher/tfp-automation/pipeline/qase/results"
 	rb "github.com/rancher/tfp-automation/tests/extensions/rbac"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -39,6 +40,11 @@ func (r *AuthConfigTestSuite) SetupSuite() {
 
 	r.terraformConfig = terraformConfig
 
+	clusterConfig := new(config.TerratestConfig)
+	ranchFrame.LoadConfig(config.TerratestConfigurationFileKey, clusterConfig)
+
+	r.clusterConfig = clusterConfig
+
 	terraformOptions := framework.Setup(r.T())
 	r.terraformOptions = terraformOptions
 }
@@ -63,6 +69,10 @@ func (r *AuthConfigTestSuite) TestTfpAuthConfig() {
 			rb.AuthConfig(r.T(), &authConfig, r.terraformOptions)
 		})
 	}
+
+	if r.clusterConfig.LocalQaseReporting {
+		qase.ReportTest()
+	}
 }
 
 func (r *AuthConfigTestSuite) TestTfpAuthConfigDynamicInput() {
@@ -82,6 +92,10 @@ func (r *AuthConfigTestSuite) TestTfpAuthConfigDynamicInput() {
 
 			rb.AuthConfig(r.T(), r.terraformConfig, r.terraformOptions)
 		})
+	}
+
+	if r.clusterConfig.LocalQaseReporting {
+		qase.ReportTest()
 	}
 }
 

--- a/tests/rbac/rbac_test.go
+++ b/tests/rbac/rbac_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rancher/tfp-automation/defaults/configs"
 	"github.com/rancher/tfp-automation/framework"
 	"github.com/rancher/tfp-automation/framework/cleanup"
+	qase "github.com/rancher/tfp-automation/pipeline/qase/results"
 	"github.com/rancher/tfp-automation/tests/extensions/provisioning"
 	rb "github.com/rancher/tfp-automation/tests/extensions/rbac"
 	"github.com/stretchr/testify/require"
@@ -80,6 +81,10 @@ func (r *RBACTestSuite) TestTfpRBAC() {
 
 			rb.RBAC(r.T(), r.client, clusterName, poolName, r.terraformOptions, &clusterConfig, tt.rbacRole)
 		})
+	}
+
+	if r.clusterConfig.LocalQaseReporting {
+		qase.ReportTest()
 	}
 }
 

--- a/tests/snapshot/README.md
+++ b/tests/snapshot/README.md
@@ -17,6 +17,7 @@ Please see below for more details for your config. Please note that the config c
 ## Table of Contents
 1. [Getting Started](#Getting-Started)
 2. [ETCD Snapshots](#ETCD-Snapshots)
+3. [Local Qase Reporting](#Local-Qase-Reporting)
 
 ## Getting Started
 In your config file, set the following:
@@ -59,7 +60,16 @@ terratest:
 See the below examples on how to run the tests:
 
 ### Snapshot restore
-`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/snapshot --junitfile results.xml -- -timeout=60m -v -run "TestTfpSnapshotRestoreTestSuite/TestTfpSnapshotRestore$"` \
-`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/snapshot --junitfile results.xml -- -timeout=60m -v -run "TestTfpSnapshotRestoreTestSuite/TestTfpSnapshotRestoreDynamicInput$"`
+`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/snapshot --junitfile results/results.xml --jsonfile results/results.json -- -timeout=60m -v -run "TestTfpSnapshotRestoreTestSuite/TestTfpSnapshotRestore$"` \
+`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/snapshot --junitfile results/results.xml --jsonfile results/results.json -- -timeout=60m -v -run "TestTfpSnapshotRestoreTestSuite/TestTfpSnapshotRestoreDynamicInput$"`
 
 If the specified test passes immediately without warning, try adding the -count=1 flag to get around this issue. This will avoid previous results from interfering with the new test run.
+
+## Local Qase Reporting
+If you are planning to report to Qase locally, then you will need to have the following done:
+1. The `terratest` block in your config file must have `localQaseReporting: true`.
+2. The working shell session must have the following two environmental variables set:
+     - `QASE_AUTOMATION_TOKEN=""`
+     - `QASE_TEST_RUN_ID=""`
+3. Append `./reporter` to the end of the `gotestsum` command. See an example below::
+     - `gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/snapshot --junitfile results/results.xml --jsonfile results/results.json -- -timeout=60m -v -run "TestTfpSnapshotRestoreTestSuite/TestTfpSnapshotRestore$";/path/to/tfp-automation/reporter`

--- a/tests/snapshot/snapshot_restore_test.go
+++ b/tests/snapshot/snapshot_restore_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rancher/tfp-automation/defaults/configs"
 	"github.com/rancher/tfp-automation/framework"
 	cleanup "github.com/rancher/tfp-automation/framework/cleanup"
+	qase "github.com/rancher/tfp-automation/pipeline/qase/results"
 	"github.com/rancher/tfp-automation/tests/extensions/provisioning"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -104,6 +105,10 @@ func (s *SnapshotRestoreTestSuite) TestTfpSnapshotRestore() {
 			snapshotRestore(s.T(), s.client, clusterName, poolName, &clusterConfig, s.terraformOptions)
 		})
 	}
+
+	if s.clusterConfig.LocalQaseReporting {
+		qase.ReportTest()
+	}
 }
 
 func (s *SnapshotRestoreTestSuite) TestTfpSnapshotRestoreDynamicInput() {
@@ -131,6 +136,10 @@ func (s *SnapshotRestoreTestSuite) TestTfpSnapshotRestoreDynamicInput() {
 
 			snapshotRestore(s.T(), s.client, clusterName, poolName, s.clusterConfig, s.terraformOptions)
 		})
+	}
+
+	if s.clusterConfig.LocalQaseReporting {
+		qase.ReportTest()
 	}
 }
 

--- a/tests/upgrading/README.md
+++ b/tests/upgrading/README.md
@@ -13,6 +13,7 @@ Please see below for more details for your config. Please note that the config c
 ## Table of Contents
 1. [Getting Started](#Getting-Started)
 2. [Upgrading Clusters](#Upgrading-Clusters)
+3. [Local Qase Reporting](#Local-Qase-Reporting)
 
 ## Getting Started
 In your config file, set the following:
@@ -42,11 +43,20 @@ See the below examples on how to run the tests:
 
 ### RKE1/RKE2/K3S
 
-`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/upgrading --junitfile results.xml -- -timeout=60m -v -run "TestTfpKubernetesUpgradeTestSuite/TestTfpKubernetesUpgrade$"` \
-`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/upgrading --junitfile results.xml -- -timeout=60m -v -run "TestTfpKubernetesUpgradeTestSuite/TestTfpKubernetesUpgradeDynamicInput$"`
+`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/upgrading --junitfile results/results.xml --jsonfile results/results.json -- -timeout=60m -v -run "TestTfpKubernetesUpgradeTestSuite/TestTfpKubernetesUpgrade$"` \
+`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/upgrading --junitfile results/results.xml --jsonfile results/results.json -- -timeout=60m -v -run "TestTfpKubernetesUpgradeTestSuite/TestTfpKubernetesUpgradeDynamicInput$"`
 
 ### Hosted
 
-`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/upgrading --junitfile results.xml -- -timeout=60m -v -run "TestTfpKubernetesUpgradeHostedTestSuite/TestTfpKubernetesUpgradeHosted$"`
+`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/upgrading --junitfile results/results.xml --jsonfile results/results.json -- -timeout=60m -v -run "TestTfpKubernetesUpgradeHostedTestSuite/TestTfpKubernetesUpgradeHosted$"`
 
 If the specified test passes immediately without warning, try adding the -count=1 flag to get around this issue. This will avoid previous results from interfering with the new test run.
+
+## Local Qase Reporting
+If you are planning to report to Qase locally, then you will need to have the following done:
+1. The `terratest` block in your config file must have `localQaseReporting: true`.
+2. The working shell session must have the following two environmental variables set:
+     - `QASE_AUTOMATION_TOKEN=""`
+     - `QASE_TEST_RUN_ID=""`
+3. Append `./reporter` to the end of the `gotestsum` command. See an example below::
+     - `gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/upgrading --junitfile results/results.xml --jsonfile results/results.json -- -timeout=60m -v -run "TestTfpKubernetesUpgradeTestSuite/TestTfpKubernetesUpgrade$";/path/to/tfp-automation/reporter`

--- a/tests/upgrading/kubernetes_hosted_test.go
+++ b/tests/upgrading/kubernetes_hosted_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rancher/tfp-automation/defaults/configs"
 	"github.com/rancher/tfp-automation/framework"
 	cleanup "github.com/rancher/tfp-automation/framework/cleanup"
+	qase "github.com/rancher/tfp-automation/pipeline/qase/results"
 	"github.com/rancher/tfp-automation/tests/extensions/provisioning"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -72,6 +73,10 @@ func (k *KubernetesUpgradeHostedTestSuite) TestTfpKubernetesUpgradeHosted() {
 			provisioning.VerifyCluster(k.T(), k.client, clusterName, k.terraformConfig, k.terraformOptions, k.clusterConfig)
 			provisioning.VerifyUpgradedKubernetesVersion(k.T(), k.client, k.terraformConfig, clusterName, k.clusterConfig.UpgradedKubernetesVersion)
 		})
+	}
+
+	if k.clusterConfig.LocalQaseReporting {
+		qase.ReportTest()
 	}
 }
 

--- a/tests/upgrading/kubernetes_upgrade_test.go
+++ b/tests/upgrading/kubernetes_upgrade_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rancher/tfp-automation/defaults/configs"
 	"github.com/rancher/tfp-automation/framework"
 	cleanup "github.com/rancher/tfp-automation/framework/cleanup"
+	qase "github.com/rancher/tfp-automation/pipeline/qase/results"
 	"github.com/rancher/tfp-automation/tests/extensions/provisioning"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -82,6 +83,10 @@ func (k *KubernetesUpgradeTestSuite) TestTfpKubernetesUpgrade() {
 				k.clusterConfig.UpgradedKubernetesVersion)
 		})
 	}
+
+	if k.clusterConfig.LocalQaseReporting {
+		qase.ReportTest()
+	}
 }
 
 func (k *KubernetesUpgradeTestSuite) TestTfpKubernetesUpgradeDynamicInput() {
@@ -108,6 +113,10 @@ func (k *KubernetesUpgradeTestSuite) TestTfpKubernetesUpgradeDynamicInput() {
 			provisioning.VerifyUpgradedKubernetesVersion(k.T(), k.client, k.terraformConfig, clusterName,
 				k.clusterConfig.UpgradedKubernetesVersion)
 		})
+	}
+
+	if k.clusterConfig.LocalQaseReporting {
+		qase.ReportTest()
 	}
 }
 


### PR DESCRIPTION
### PR Description
Currently, we utilize Qase for our test results during release testing. However, we only have the ability to do so via Jenkins. It would be desirable to have an option to locally report results as well, should we need to do so.

This PR gives the ability to do just that.