### PR TITLE
Updates to use standard Jenkins pem files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ COPY $CONFIG_FILE /config.yml
 
 ARG PEM_FILE
 COPY $PEM_FILE /key.pem
-RUN echo $PEM_FILE > key.pem && chmod 400 key.pem
+RUN echo $PEM_FILE > key.pem && chmod 600 key.pem
 
 RUN if [[ -z '$EXTERNAL_ENCODED_VPN' ]] ; then \
       echo 'no vpn provided' ; \


### PR DESCRIPTION
### PR Description
Updating the Jenkinsfile and Dockerfile to ensure that tfp-automation is using the standard Jenkins PEM files. We still have the ability to use custom PEM files when locally testing. However, for Jenkins testing, we will use the standard PEM files as we do in rancher/rancher.