### PR TITLE
Added chartValues and machineGlobalConfigValue to rke2k3s

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,13 @@ terraform:
     password: ""                              # RKE1 specific
     insecure: true
     authConfigSecretName: ""                  # RKE2/K3S specific. Secret must be created in the fleet-default namespace already
+  chartValues: |-			      # Provided as a multiline string
+    rke2-cilium:                              # RKE2/Cilium specific example of how to do a Kube-proxy Replacement deployment
+      k8sServiceHost: 127.0.0.1               
+      k8sServicePort: 6443
+      kubeProxyReplacement: true
+  cni: cilium				      # RKE2 specific
+  disable-kube-proxy: true		      # Can be "true" or "false"
 ```
 
 Note: At this time, private registries for RKE2/K3s MUST be used with provider version 3.1.1. This is due to issue https://github.com/rancher/terraform-provider-rancher2/issues/1305.

--- a/config/config.go
+++ b/config/config.go
@@ -136,6 +136,8 @@ type TerraformConfig struct {
 	AuthProvider                        string                       `json:"authProvider,omitempty" yaml:"authProvider,omitempty"`
 	CloudCredentialName                 string                       `json:"cloudCredentialName,omitempty" yaml:"cloudCredentialName,omitempty"`
 	CNI                                 string                       `json:"cni,omitempty" yaml:"cni,omitempty"`
+	ChartValues                         string                       `json:"chartValues,omitempty" yaml:"chartValues,omitempty"`
+	DisableKubeProxy                    string                       `json:"disable-kube-proxy,omitempty" yaml:"disable-kube-proxy,omitempty"`
 	DefaultClusterRoleForProjectMembers string                       `json:"defaultClusterRoleForProjectMembers,omitempty" yaml:"defaultClusterRoleForProjectMembers,omitempty"`
 	EnableNetworkPolicy                 bool                         `json:"enableNetworkPolicy,omitempty" yaml:"enableNetworkPolicy,omitempty"`
 	ETCD                                *rkev1.ETCD                  `json:"etcd,omitempty" yaml:"etcd,omitempty"`

--- a/framework/set/defaults/defaults.go
+++ b/framework/set/defaults/defaults.go
@@ -50,6 +50,7 @@ const (
 	Enabled               = "enabled"
 	RancherClusterID      = "cluster_id"
 	Quantity              = "quantity"
+	ChartValues           = "chart_values"
 
 	Endpoint = "endpoint"
 	Folder   = "folder"


### PR DESCRIPTION
Adding support to change CNI for nodedriver clusters. Also adding kubeproxyless setups, but adding a Chart Values section and ability to disable kube proxy.
Example of a terraform section using these settings.
```
terraform:
  module: vsphere_rke2
  clusterName: test
  chartValues: |-
    rke2-cilium:
      k8sServiceHost: 127.0.0.1
      k8sServicePort: 6443
      kubeProxyReplacement: true
  cni: cilium
  disable-kube-proxy: true
```
