### PR TITLE
Add support for authenticated and unauthenticated private registries

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -89,15 +89,15 @@ type Nodepool struct {
 }
 
 type PrivateRegistries struct {
+	AuthConfigSecretName   string `json:"authConfigSecretName,omitempty" yaml:"authConfigSecretName,omitempty"`
+	CABundle               string `json:"caBundle,omitempty" yaml:"caBundle,omitempty"`
 	EngineInsecureRegistry string `json:"engineInsecureRegistry,omitempty" yaml:"engineInsecureRegistry,omitempty"`
+	Insecure               bool   `json:"insecure,omitempty" yaml:"insecure,omitempty"`
 	Password               string `json:"password,omitempty" yaml:"password,omitempty"`
+	SystemDefaultRegistry  string `json:"systemDefaultRegistry,omitempty" yaml:"systemDefaultRegistry,omitempty"`
+	TLSSecretName          string `json:"tlsSecretName,omitempty" yaml:"tlsSecretName,omitempty"`
 	URL                    string `json:"url,omitempty" yaml:"url,omitempty"`
 	Username               string `json:"username,omitempty" yaml:"username,omitempty"`
-	AuthConfigSecretName   string `json:"authConfigSecretName,omitempty" yaml:"authConfigSecretName,omitempty"`
-	TLSSecretName          string `json:"tlsSecretName,omitempty" yaml:"tlsSecretName,omitempty"`
-	CABundle               string `json:"caBundle,omitempty" yaml:"caBundle,omitempty"`
-	Insecure               bool   `json:"insecure,omitempty" yaml:"insecure,omitempty"`
-	SystemDefaultRegistry  string `json:"systemDefaultRegistry,omitempty" yaml:"systemDefaultRegistry,omitempty"`
 }
 
 type Standalone struct {
@@ -109,13 +109,20 @@ type Standalone struct {
 	RancherHostname          string `json:"rancherHostname,omitempty" yaml:"rancherHostname,omitempty"`
 	RancherRepo              string `json:"rancherRepo,omitempty" yaml:"rancherRepo,omitempty"`
 	RancherTagVersion        string `json:"rancherTagVersion,omitempty" yaml:"rancherTagVersion,omitempty"`
-	RKE1User                 string `json:"rke1User,omitempty" yaml:"rke1User,omitempty"`
-	RKE2Group                string `json:"rke2Group,omitempty" yaml:"rke2Group,omitempty"`
-	RKE2User                 string `json:"rke2User,omitempty" yaml:"rke2User,omitempty"`
+	OSUser                   string `json:"osUser,omitempty" yaml:"osUser,omitempty"`
+	OSGroup                  string `json:"osGroup,omitempty" yaml:"osGroup,omitempty"`
 	RKE2Version              string `json:"rke2Version,omitempty" yaml:"rke2Version,omitempty"`
 	StagingRancherImage      string `json:"stagingRancherImage,omitempty" yaml:"stagingRancherImage,omitempty"`
 	StagingRancherAgentImage string `json:"stagingRancherAgentImage,omitempty" yaml:"stagingRancherAgentImage,omitempty"`
 	Type                     string `json:"type,omitempty" yaml:"type,omitempty"`
+}
+
+type StandaloneRegistry struct {
+	AssetsPath       string `json:"assetsPath,omitempty" yaml:"assetsPath,omitempty"`
+	Authenticated    bool   `json:"authenticated,omitempty" yaml:"authenticated,omitempty"`
+	RegistryName     string `json:"registryName,omitempty" yaml:"registryName,omitempty"`
+	RegistryPassword string `json:"registryPassword,omitempty" yaml:"registryPassword,omitempty"`
+	RegistryUsername string `json:"registryUsername,omitempty" yaml:"registryUsername,omitempty"`
 }
 
 type TerraformConfig struct {
@@ -153,6 +160,7 @@ type TerraformConfig struct {
 	PrivateKeyPath                      string                       `json:"privateKeyPath,omitempty" yaml:"privateKeyPath,omitempty"`
 	PrivateRegistries                   *PrivateRegistries           `json:"privateRegistries,omitempty" yaml:"privateRegistries,omitempty"`
 	Standalone                          *Standalone                  `json:"standalone,omitempty" yaml:"standalone,omitempty"`
+	StandaloneRegistry                  *StandaloneRegistry          `json:"standaloneRegistry,omitempty" yaml:"standaloneRegistry,omitempty"`
 }
 
 type Scaling struct {

--- a/config/nodeproviders/aws/awsConfig.go
+++ b/config/nodeproviders/aws/awsConfig.go
@@ -14,6 +14,7 @@ type Config struct {
 	AWSZoneLetter         string   `json:"awsZoneLetter,omitempty" yaml:"awsZoneLetter,omitempty"`
 	PrivateAccess         bool     `json:"privateAccess,omitempty" yaml:"privateAccess,omitempty"`
 	PublicAccess          bool     `json:"publicAccess,omitempty" yaml:"publicAccess,omitempty"`
+	RegistryRootSize      int64    `json:"registryRootSize,omitempty" yaml:"registryRootSize,omitempty"`
 	Region                string   `json:"region,omitempty" yaml:"region,omitempty"`
 	AWSUser               string   `json:"awsUser,omitempty" yaml:"awsUser,omitempty"`
 	Timeout               string   `json:"timeout,omitempty" yaml:"timeout,omitempty"`

--- a/framework/set/provisioning/airgap/registerPrivateNodes.go
+++ b/framework/set/provisioning/airgap/registerPrivateNodes.go
@@ -25,7 +25,7 @@ func registerPrivateNodes(provisionerBlockBody *hclwrite.Body, terraformConfig *
 	provisionerBlockBody.SetAttributeRaw(defaults.Inline, hclwrite.Tokens{
 		{Type: hclsyntax.TokenOQuote, Bytes: []byte(`["`), SpacesBefore: 1},
 		{Type: hclsyntax.TokenStringLit, Bytes: []byte("/tmp/register-nodes.sh " + encodedPEMFile + " " +
-			terraformConfig.Standalone.RKE2User + " " + terraformConfig.Standalone.RKE2Group + " " + bastionPublicIP + " " +
+			terraformConfig.Standalone.OSUser + " " + terraformConfig.Standalone.OSGroup + " " + bastionPublicIP + " " +
 			nodePrivateIP + " " + newCommand)},
 		{Type: hclsyntax.TokenCQuote, Bytes: []byte(`"]`), SpacesBefore: 1},
 	})

--- a/framework/set/provisioning/airgap/setConfig.go
+++ b/framework/set/provisioning/airgap/setConfig.go
@@ -31,8 +31,10 @@ func SetAirgapRKE2K3s(rancherConfig *rancher.Config, terraformConfig *config.Ter
 	v2.SetRancher2ClusterV2(rootBody, terraformConfig, terratestConfig, clusterName)
 	rootBody.AppendNewline()
 
-	createRegistrySecret(terraformConfig, clusterName, rootBody)
-	rootBody.AppendNewline()
+	if terraformConfig.StandaloneRegistry.Authenticated {
+		createRegistrySecret(terraformConfig, clusterName, rootBody)
+		rootBody.AppendNewline()
+	}
 
 	aws.CreateAWSInstances(rootBody, terraformConfig, terratestConfig, bastion)
 	rootBody.AppendNewline()

--- a/framework/set/provisioning/custom/rke2k3s/setRancher2ClusterV2.go
+++ b/framework/set/provisioning/custom/rke2k3s/setRancher2ClusterV2.go
@@ -30,6 +30,8 @@ func SetRancher2ClusterV2(rootBody *hclwrite.Body, terraformConfig *config.Terra
 	}
 
 	if terraformConfig.PrivateRegistries != nil {
+		v2.SetMachineSelectorConfig(rkeConfigBlockBody, terraformConfig)
+
 		registryBlock := rkeConfigBlockBody.AppendNewBlock(defaults.PrivateRegistries, nil)
 		registryBlockBody := registryBlock.Body()
 

--- a/framework/set/provisioning/nodedriver/rke2k3s/setConfig.go
+++ b/framework/set/provisioning/nodedriver/rke2k3s/setConfig.go
@@ -50,6 +50,7 @@ const (
 	insecure              = "insecure"
 	systemDefaultRegistry = "system-default-registry"
 	project               = "project"
+	endpoints             = "endpoints"
 )
 
 // SetRKE2K3s is a function that will set the RKE2/K3S configurations in the main.tf file.

--- a/framework/set/resources/airgap/aws/createResources.go
+++ b/framework/set/resources/airgap/aws/createResources.go
@@ -13,6 +13,7 @@ import (
 const (
 	locals            = "locals"
 	requiredProviders = "required_providers"
+	registry          = "registry"
 	rke2Bastion       = "rke2_bastion"
 	rke2ServerOne     = "rke2_server1"
 	rke2ServerTwo     = "rke2_server2"
@@ -28,10 +29,13 @@ func CreateAWSResources(file *os.File, newFile *hclwrite.File, tfBlockBody, root
 	sanity.CreateAWSProviderBlock(rootBody, terraformConfig)
 	rootBody.AppendNewline()
 
-	sanity.CreateAWSInstances(rootBody, terraformConfig, terratestConfig, rke2Bastion)
-	rootBody.AppendNewline()
+	instances := []string{rke2Bastion, registry}
+	for _, instance := range instances {
+		sanity.CreateAWSInstances(rootBody, terraformConfig, terratestConfig, instance)
+		rootBody.AppendNewline()
+	}
 
-	instances := []string{rke2ServerOne, rke2ServerTwo, rke2ServerThree}
+	instances = []string{rke2ServerOne, rke2ServerTwo, rke2ServerThree}
 	for _, instance := range instances {
 		CreateAirgappedAWSInstances(rootBody, terraformConfig, instance)
 		rootBody.AppendNewline()

--- a/framework/set/resources/airgap/createMainTF.go
+++ b/framework/set/resources/airgap/createMainTF.go
@@ -11,23 +11,27 @@ import (
 	"github.com/rancher/tfp-automation/framework/set/resources/airgap/aws"
 	"github.com/rancher/tfp-automation/framework/set/resources/airgap/rancher"
 	"github.com/rancher/tfp-automation/framework/set/resources/airgap/rke2"
+	"github.com/rancher/tfp-automation/framework/set/resources/registries"
 	"github.com/sirupsen/logrus"
 )
 
 const (
-	rke2ServerOne            = "rke2_server1"
-	rke2ServerTwo            = "rke2_server2"
-	rke2ServerThree          = "rke2_server3"
+	rke2ServerOne   = "rke2_server1"
+	rke2ServerTwo   = "rke2_server2"
+	rke2ServerThree = "rke2_server3"
+
+	registryPublicDNS        = "registry_public_dns"
 	rke2BastionPublicDNS     = "rke2_bastion_public_dns"
 	rke2ServerOnePrivateIP   = "rke2_server1_private_ip"
 	rke2ServerTwoPrivateIP   = "rke2_server2_private_ip"
 	rke2ServerThreePrivateIP = "rke2_server3_private_ip"
-	terraformConst           = "terraform"
+
+	terraformConst = "terraform"
 )
 
 // CreateMainTF is a helper function that will create the main.tf file for creating an Airgapped-Rancher server.
 func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath string, terraformConfig *config.TerraformConfig,
-	terratest *config.TerratestConfig) error {
+	terratest *config.TerratestConfig) (string, error) {
 	var file *os.File
 	file = OpenFile(file, keyPath)
 	defer file.Close()
@@ -40,20 +44,36 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 
 	file, err := aws.CreateAWSResources(file, newFile, tfBlockBody, rootBody, terraformConfig, terratest)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	terraform.InitAndApply(t, terraformOptions)
 
+	registryPublicDNS := terraform.Output(t, terraformOptions, registryPublicDNS)
 	rke2BastionPublicDNS := terraform.Output(t, terraformOptions, rke2BastionPublicDNS)
 	rke2ServerOnePrivateIP := terraform.Output(t, terraformOptions, rke2ServerOnePrivateIP)
 	rke2ServerTwoPrivateIP := terraform.Output(t, terraformOptions, rke2ServerTwoPrivateIP)
 	rke2ServerThreePrivateIP := terraform.Output(t, terraformOptions, rke2ServerThreePrivateIP)
 
 	file = OpenFile(file, keyPath)
+	if terraformConfig.StandaloneRegistry.Authenticated {
+		file, err = registries.CreateAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, registryPublicDNS)
+		if err != nil {
+			return "", err
+		}
+	} else {
+		file, err = registries.CreateNonAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, registryPublicDNS)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	terraform.InitAndApply(t, terraformOptions)
+
+	file = OpenFile(file, keyPath)
 	file, err = rke2.CreateAirgapRKE2Cluster(file, newFile, rootBody, terraformConfig, rke2BastionPublicDNS, rke2ServerOnePrivateIP, rke2ServerTwoPrivateIP, rke2ServerThreePrivateIP)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	terraform.InitAndApply(t, terraformOptions)
@@ -61,12 +81,12 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 	file = OpenFile(file, keyPath)
 	file, err = rancher.CreateAirgapRancher(file, newFile, rootBody, terraformConfig, rke2BastionPublicDNS)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	terraform.InitAndApply(t, terraformOptions)
 
-	return nil
+	return registryPublicDNS, nil
 }
 
 // OpenFile is a helper function that will open the main.tf file.

--- a/framework/set/resources/airgap/rancher/setup.sh
+++ b/framework/set/resources/airgap/rancher/setup.sh
@@ -8,9 +8,8 @@ HOSTNAME=$5
 INTERNAL_FQDN=$6
 RANCHER_TAG_VERSION=$7
 BOOTSTRAP_PASSWORD=$8
-REGISTRY=$9
-STAGING_RANCHER_IMAGE=${10}
-STAGING_RANCHER_AGENT_IMAGE=${11}
+STAGING_RANCHER_IMAGE=${9}
+STAGING_RANCHER_AGENT_IMAGE=${10}
 
 set -ex
 
@@ -39,15 +38,14 @@ if [ -z "$STAGING_RANCHER_IMAGE" ]; then
     helm upgrade --install rancher ${RANCHER_REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
                                                                                  --set hostname=${HOSTNAME} \
                                                                                  --set rancherImageTag=${RANCHER_TAG_VERSION} \
-                                                                                 --set bootstrapPassword=${BOOTSTRAP_PASSWORD} \
-                                                                                 --set systemDefaultRegistry=${REGISTRY}
+                                                                                 --set bootstrapPassword=${BOOTSTRAP_PASSWORD}
+
 else
     helm upgrade --install rancher ${RANCHER_REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
                                                                                  --set hostname=${HOSTNAME} \
                                                                                  --set rancherImageTag=${RANCHER_TAG_VERSION} \
                                                                                  --set rancherImage=${STAGING_RANCHER_IMAGE} \
-                                                                                 --set systemDefaultRegistry=${REGISTRY} \
-                                                                                 --set 'extraEnv[0].name=CATTLE_AGENT_IMAGE' \
+                                                                                 --set 'extraEnv[0].name=CATTLE_AGENT_IMAGE' \                                                                                --set 'extraEnv[0].name=CATTLE_AGENT_IMAGE' \
                                                                                  --set "extraEnv[0].value=${STAGING_RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}" \
                                                                                  --set bootstrapPassword=${BOOTSTRAP_PASSWORD} --devel
 fi

--- a/framework/set/resources/airgap/rancher/setupAirgapRancher.go
+++ b/framework/set/resources/airgap/rancher/setupAirgapRancher.go
@@ -17,7 +17,8 @@ const (
 )
 
 // CreateAirgapRancher is a function that will set the airgap Rancher configurations in the main.tf file.
-func CreateAirgapRancher(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, rke2BastionPublicDNS string) (*os.File, error) {
+func CreateAirgapRancher(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
+	rke2BastionPublicDNS string) (*os.File, error) {
 	userDir, err := os.UserHomeDir()
 	if err != nil {
 		return nil, err
@@ -35,8 +36,7 @@ func CreateAirgapRancher(file *os.File, newFile *hclwrite.File, rootBody *hclwri
 	command := "bash -c '/tmp/setup.sh " + terraformConfig.Standalone.RancherRepo + " " + terraformConfig.Standalone.RancherChartRepository + " " +
 		terraformConfig.Standalone.Type + " " + terraformConfig.Standalone.CertManagerVersion + " " +
 		terraformConfig.Standalone.RancherHostname + " " + " " + terraformConfig.Standalone.AirgapInternalFQDN + " " +
-		terraformConfig.Standalone.RancherTagVersion + " " + terraformConfig.Standalone.BootstrapPassword + " " +
-		terraformConfig.PrivateRegistries.URL
+		terraformConfig.Standalone.RancherTagVersion + " " + terraformConfig.Standalone.BootstrapPassword
 
 	if terraformConfig.Standalone.StagingRancherImage != "" {
 		command += " " + terraformConfig.Standalone.StagingRancherImage + " " + terraformConfig.Standalone.StagingRancherAgentImage

--- a/framework/set/resources/airgap/rke2/createAirgapCluster.go
+++ b/framework/set/resources/airgap/rke2/createAirgapCluster.go
@@ -63,7 +63,7 @@ func CreateAirgapRKE2Cluster(file *os.File, newFile *hclwrite.File, rootBody *hc
 		cty.StringVal("echo '" + string(bastionScriptContent) + "' > /tmp/bastion.sh"),
 		cty.StringVal("chmod +x /tmp/bastion.sh"),
 		cty.StringVal("bash -c '/tmp/bastion.sh " + terraformConfig.Standalone.RKE2Version + " " + rke2ServerOnePrivateIP + " " +
-			rke2ServerTwoPrivateIP + " " + rke2ServerThreePrivateIP + " " + terraformConfig.Standalone.RKE2User + " " + encodedPEMFile + "'"),
+			rke2ServerTwoPrivateIP + " " + rke2ServerThreePrivateIP + " " + terraformConfig.Standalone.OSUser + " " + encodedPEMFile + "'"),
 	}))
 
 	rke2Token := namegen.AppendRandomString(token)
@@ -115,7 +115,7 @@ func createAirgappedRKE2Server(rootBody *hclwrite.Body, terraformConfig *config.
 	provisionerBlockBody.SetAttributeValue(defaults.Inline, cty.ListVal([]cty.Value{
 		cty.StringVal("printf '" + string(script) + "' > /tmp/init-server.sh"),
 		cty.StringVal("chmod +x /tmp/init-server.sh"),
-		cty.StringVal("bash -c '/tmp/init-server.sh " + terraformConfig.Standalone.RKE2User + " " + terraformConfig.Standalone.RKE2Group + " " +
+		cty.StringVal("bash -c '/tmp/init-server.sh " + terraformConfig.Standalone.OSUser + " " + terraformConfig.Standalone.OSGroup + " " +
 			rke2ServerOnePrivateIP + " " + rke2Token + " " + terraformConfig.PrivateRegistries.URL + " " +
 			terraformConfig.PrivateRegistries.Username + " " + terraformConfig.PrivateRegistries.Password + "'"),
 	}))
@@ -141,7 +141,7 @@ func addAirgappedRKE2ServerNodes(rootBody *hclwrite.Body, terraformConfig *confi
 		provisionerBlockBody.SetAttributeValue(defaults.Inline, cty.ListVal([]cty.Value{
 			cty.StringVal("printf '" + string(script) + "' > /tmp/add-servers.sh"),
 			cty.StringVal("chmod +x /tmp/add-servers.sh"),
-			cty.StringVal("bash -c '/tmp/add-servers.sh " + terraformConfig.Standalone.RKE2User + " " + terraformConfig.Standalone.RKE2Group + " " +
+			cty.StringVal("bash -c '/tmp/add-servers.sh " + terraformConfig.Standalone.OSUser + " " + terraformConfig.Standalone.OSGroup + " " +
 				rke2ServerOnePrivateIP + " " + instance + " " + rke2Token + " " + terraformConfig.PrivateRegistries.URL + " " +
 				terraformConfig.PrivateRegistries.Username + " " + terraformConfig.PrivateRegistries.Password + "'"),
 		}))

--- a/framework/set/resources/registries/auth-registry.sh
+++ b/framework/set/resources/registries/auth-registry.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/bash
+
+REGISTRY_USER=$1
+REGISTRY_PASS=$2
+REGISTRY_NAME=$3
+HOST=$4
+RANCHER_VERSION=$5
+ASSET_DIR=$6
+USER=$7
+
+set -e
+
+echo "Setting up htpasswd..."
+. /etc/os-release
+
+[[ "${ID}" == "ubuntu" || "${ID}" == "debian" ]] && sudo apt update && sudo apt install -y apache2-utils wget
+[[ "${ID}" == "rhel" || "${ID}" == "fedora" ]] && sudo yum install -y httpd-tools wget
+[[ "${ID}" == "opensuse-leap" || "${ID}" == "sles" ]] && sudo zypper install -y apache2-utils wget
+
+sudo mkdir -p /home/${USER}/auth
+sudo htpasswd -Bbn ${REGISTRY_USER} ${REGISTRY_PASS} | sudo tee /home/${USER}/auth/htpasswd
+
+echo "Creating a self-signed certificate..."
+sudo mkdir -p /home/${USER}/certs
+sudo openssl req -newkey rsa:4096 -nodes -sha256 -keyout /home/${USER}/certs/domain.key -addext "subjectAltName = DNS:${HOST}" -x509 -days 365 -out /home/${USER}/certs/domain.crt -subj "/C=US/ST=CA/L=SUSE/O=Dis/CN=${HOST}"
+
+echo "Copying the certificate to the /etc/docker/certs.d/${HOST} directory..."
+sudo mkdir -p /etc/docker/certs.d/${HOST}
+sudo cp /home/${USER}/certs/domain.crt /etc/docker/certs.d/${HOST}/ca.crt
+
+echo "Creating a private registry..."
+sudo docker run -d --restart=always --name "${REGISTRY_NAME}" -v /home/${USER}/auth:/auth -v /home/${USER}/certs:/certs -v /home/${USER}/certs:/certs \
+                                                                                                  -e REGISTRY_AUTH=htpasswd \
+                                                                                                  -e REGISTRY_AUTH_HTPASSWD_REALM="Registry Realm" \
+                                                                                                  -e REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd \
+                                                                                                  -e REGISTRY_HTTP_ADDR=0.0.0.0:443 \
+                                                                                                  -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt \
+                                                                                                  -e REGISTRY_HTTP_TLS_KEY=/certs/domain.key \
+                                                                                                  -p 443:443 \
+                                                                                                  registry:2
+
+
+echo "Logging into the private registry..."
+sudo docker login https://${HOST} -u ${REGISTRY_USER} -p ${REGISTRY_PASS}
+
+sudo wget ${ASSET_DIR}${RANCHER_VERSION}/rancher-images.txt -O /home/${USER}/rancher-images.txt
+sudo wget ${ASSET_DIR}${RANCHER_VERSION}/rancher-save-images.sh -O /home/${USER}/rancher-save-images.sh
+sudo wget ${ASSET_DIR}${RANCHER_VERSION}/rancher-load-images.sh -O /home/${USER}/rancher-load-images.sh
+    
+sudo chmod +x /home/${USER}/rancher-save-images.sh && sudo chmod +x /home/${USER}/rancher-load-images.sh
+sudo sed -i "s/docker save/# docker save /g" /home/${USER}/rancher-save-images.sh
+sudo sed -i "s/docker load/# docker load /g" /home/${USER}/rancher-load-images.sh
+    
+echo "Saving the images..."
+sudo /home/${USER}/rancher-save-images.sh --image-list /home/${USER}/rancher-images.txt
+
+echo "Tagging the images..."
+for IMAGE in $(cat /home/$USER/rancher-images.txt); do
+    sudo docker tag ${IMAGE} ${HOST}/${IMAGE}
+done
+
+echo "Pushing the newly tagged images..."
+for IMAGE in $(cat /home/$USER/rancher-images.txt); do
+    sudo docker push ${HOST}/${IMAGE}
+done

--- a/framework/set/resources/registries/createRegistry.go
+++ b/framework/set/resources/registries/createRegistry.go
@@ -1,0 +1,87 @@
+package registries
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/framework/set/defaults"
+	"github.com/rancher/tfp-automation/framework/set/resources/sanity/rke2"
+	"github.com/sirupsen/logrus"
+	"github.com/zclconf/go-cty/cty"
+)
+
+const (
+	authRegistry    = "auth_registry"
+	nonAuthRegistry = "non_auth_registry"
+)
+
+// CreateAuthenticatedRegistry is a helper function that will create an authenticated registry.
+func CreateAuthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
+	rke2AuthRegistryPublicDNS string) (*os.File, error) {
+	userDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+
+	registryScriptPath := filepath.Join(userDir, "go/src/github.com/rancher/tfp-automation/framework/set/resources/registries/auth-registry.sh")
+
+	registryScriptContent, err := os.ReadFile(registryScriptPath)
+	if err != nil {
+		return nil, err
+	}
+
+	_, provisionerBlockBody := rke2.CreateNullResource(rootBody, terraformConfig, rke2AuthRegistryPublicDNS, authRegistry)
+
+	provisionerBlockBody.SetAttributeValue(defaults.Inline, cty.ListVal([]cty.Value{
+		cty.StringVal("echo '" + string(registryScriptContent) + "' > /tmp/auth-registry.sh"),
+		cty.StringVal("chmod +x /tmp/auth-registry.sh"),
+		cty.StringVal("bash -c '/tmp/auth-registry.sh " + terraformConfig.StandaloneRegistry.RegistryUsername + " " +
+			terraformConfig.StandaloneRegistry.RegistryPassword + " " + terraformConfig.StandaloneRegistry.RegistryName + " " +
+			rke2AuthRegistryPublicDNS + " " + terraformConfig.Standalone.RancherTagVersion + " " +
+			terraformConfig.StandaloneRegistry.AssetsPath + " " + terraformConfig.Standalone.OSUser + "'"),
+	}))
+
+	_, err = file.Write(newFile.Bytes())
+	if err != nil {
+		logrus.Infof("Failed to append configurations to main.tf file. Error: %v", err)
+		return nil, err
+	}
+
+	return file, nil
+}
+
+// CreateNonAuthenticatedRegistry is a helper function that will create a non-authenticated registry.
+func CreateNonAuthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
+	rke2NonAuthRegistryPublicDNS string) (*os.File, error) {
+	userDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+
+	registryScriptPath := filepath.Join(userDir, "go/src/github.com/rancher/tfp-automation/framework/set/resources/registries/non-auth-registry.sh")
+
+	registryScriptContent, err := os.ReadFile(registryScriptPath)
+	if err != nil {
+		return nil, err
+	}
+
+	_, provisionerBlockBody := rke2.CreateNullResource(rootBody, terraformConfig, rke2NonAuthRegistryPublicDNS, nonAuthRegistry)
+
+	provisionerBlockBody.SetAttributeValue(defaults.Inline, cty.ListVal([]cty.Value{
+		cty.StringVal("echo '" + string(registryScriptContent) + "' > /tmp/non-auth-registry.sh"),
+		cty.StringVal("chmod +x /tmp/non-auth-registry.sh"),
+		cty.StringVal("bash -c '/tmp/non-auth-registry.sh " + terraformConfig.StandaloneRegistry.RegistryName + " " +
+			rke2NonAuthRegistryPublicDNS + " " + terraformConfig.Standalone.RancherTagVersion + " " +
+			terraformConfig.StandaloneRegistry.AssetsPath + " " + terraformConfig.Standalone.OSUser + "'"),
+	}))
+
+	_, err = file.Write(newFile.Bytes())
+	if err != nil {
+		logrus.Infof("Failed to append configurations to main.tf file. Error: %v", err)
+		return nil, err
+	}
+
+	return file, nil
+}

--- a/framework/set/resources/registries/non-auth-registry.sh
+++ b/framework/set/resources/registries/non-auth-registry.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/bash
+
+REGISTRY_NAME=$1
+HOST=$2
+RANCHER_VERSION=$3
+ASSET_DIR=$4
+USER=$5
+
+HOST="${HOST}:5000"
+
+set -e
+
+echo "Creating a private registry..."
+sudo docker run -d --restart=always --name ${REGISTRY_NAME} -p 5000:5000 registry:2
+
+echo "Setting insecure registry in /etc/docker/daemon.json..."
+sudo touch /etc/docker/daemon.json
+echo "{ \"insecure-registries\": [\"${HOST}\"] }" | sudo tee /etc/docker/daemon.json
+sudo systemctl restart docker && sudo systemctl daemon-reload
+
+sudo wget ${ASSET_DIR}${RANCHER_VERSION}/rancher-images.txt -O /home/${USER}/rancher-images.txt
+sudo wget ${ASSET_DIR}${RANCHER_VERSION}/rancher-save-images.sh -O /home/${USER}/rancher-save-images.sh
+sudo wget ${ASSET_DIR}${RANCHER_VERSION}/rancher-load-images.sh -O /home/${USER}/rancher-load-images.sh
+    
+sudo chmod +x /home/${USER}/rancher-save-images.sh && sudo chmod +x /home/${USER}/rancher-load-images.sh
+sudo sed -i "s/docker save/# docker save /g" /home/${USER}/rancher-save-images.sh
+sudo sed -i "s/docker load/# docker load /g" /home/${USER}/rancher-load-images.sh
+    
+echo "Saving the images..."
+sudo /home/${USER}/rancher-save-images.sh --image-list /home/${USER}/rancher-images.txt
+
+echo "Tagging the images..."
+for IMAGE in $(cat /home/$USER/rancher-images.txt); do
+    sudo docker tag ${IMAGE} ${HOST}/${IMAGE}
+done
+
+echo "Pushing the newly tagged images..."
+for IMAGE in $(cat /home/$USER/rancher-images.txt); do
+    sudo docker push ${HOST}/${IMAGE}
+done

--- a/framework/set/resources/rke/rke/createCluster.go
+++ b/framework/set/resources/rke/rke/createCluster.go
@@ -40,7 +40,7 @@ func CreateRKECluster(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.
 		}
 
 		nodesBlockBody.SetAttributeRaw(address, values)
-		nodesBlockBody.SetAttributeValue(user, cty.StringVal(terraformConfig.Standalone.RKE1User))
+		nodesBlockBody.SetAttributeValue(user, cty.StringVal(terraformConfig.Standalone.OSUser))
 
 		rolesExpression := fmt.Sprintf(`["controlplane", "etcd", "worker"]`)
 		values = hclwrite.Tokens{

--- a/framework/set/resources/sanity/aws/instances.go
+++ b/framework/set/resources/sanity/aws/instances.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
@@ -36,7 +37,12 @@ func CreateAWSInstances(rootBody *hclwrite.Body, terraformConfig *config.Terrafo
 
 	rootBlockDevice := configBlockBody.AppendNewBlock(defaults.RootBlockDevice, nil)
 	rootBlockDeviceBody := rootBlockDevice.Body()
-	rootBlockDeviceBody.SetAttributeValue(defaults.VolumeSize, cty.NumberIntVal(terraformConfig.AWSConfig.AWSRootSize))
+
+	if strings.Contains(hostnamePrefix, "registry") {
+		rootBlockDeviceBody.SetAttributeValue(defaults.VolumeSize, cty.NumberIntVal(terraformConfig.AWSConfig.RegistryRootSize))
+	} else {
+		rootBlockDeviceBody.SetAttributeValue(defaults.VolumeSize, cty.NumberIntVal(terraformConfig.AWSConfig.AWSRootSize))
+	}
 
 	configBlockBody.AppendNewline()
 

--- a/framework/set/resources/sanity/rke2/createCluster.go
+++ b/framework/set/resources/sanity/rke2/createCluster.go
@@ -90,7 +90,7 @@ func createRKE2Server(rootBody *hclwrite.Body, terraformConfig *config.Terraform
 	provisionerBlockBody.SetAttributeValue(defaults.Inline, cty.ListVal([]cty.Value{
 		cty.StringVal("printf '" + string(script) + "' > /tmp/init-server.sh"),
 		cty.StringVal("chmod +x /tmp/init-server.sh"),
-		cty.StringVal("bash -c '/tmp/init-server.sh " + terraformConfig.Standalone.RKE2User + " " + terraformConfig.Standalone.RKE2Group + " " +
+		cty.StringVal("bash -c '/tmp/init-server.sh " + terraformConfig.Standalone.OSUser + " " + terraformConfig.Standalone.OSGroup + " " +
 			terraformConfig.Standalone.RKE2Version + " " + rke2ServerOnePrivateIP + " " + rke2Token + "'"),
 	}))
 }
@@ -108,7 +108,7 @@ func addRKE2ServerNodes(rootBody *hclwrite.Body, terraformConfig *config.Terrafo
 		provisionerBlockBody.SetAttributeValue(defaults.Inline, cty.ListVal([]cty.Value{
 			cty.StringVal("printf '" + string(script) + "' > /tmp/add-servers.sh"),
 			cty.StringVal("chmod +x /tmp/add-servers.sh"),
-			cty.StringVal("bash -c '/tmp/add-servers.sh " + terraformConfig.Standalone.RKE2User + " " + terraformConfig.Standalone.RKE2Group + " " +
+			cty.StringVal("bash -c '/tmp/add-servers.sh " + terraformConfig.Standalone.OSUser + " " + terraformConfig.Standalone.OSGroup + " " +
 				terraformConfig.Standalone.RKE2Version + " " + rke2ServerOnePrivateIP + " " + rke2Token + "'"),
 		}))
 

--- a/framework/wait/state/activeCluster.go
+++ b/framework/wait/state/activeCluster.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/rancher/shepherd/clients/rancher"
-	"github.com/rancher/shepherd/extensions/defaults"
 	"github.com/rancher/tfp-automation/defaults/clusterstate"
 	"github.com/sirupsen/logrus"
 	kwait "k8s.io/apimachinery/pkg/util/wait"
@@ -13,7 +12,7 @@ import (
 
 // IsActiveCluster is a function that will wait for the cluster to be in an active state.
 func IsActiveCluster(client *rancher.Client, clusterID string) error {
-	err := kwait.PollUntilContextTimeout(context.TODO(), 10*time.Second, defaults.ThirtyMinuteTimeout, true, func(ctx context.Context) (done bool, err error) {
+	err := kwait.PollUntilContextTimeout(context.TODO(), 10*time.Second, 60*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 		cluster, err := client.Management.Cluster.ByID(clusterID)
 		if err != nil {
 			return false, err

--- a/modules/airgap/outputs.tf
+++ b/modules/airgap/outputs.tf
@@ -1,5 +1,9 @@
+output "registry_public_dns" {
+  value = aws_instance.registry.public_dns
+}
+
 output "rke2_bastion_public_dns" {
-  value = aws_instance.rke2_bastion.public_dns
+    value = aws_instance.rke2_bastion.public_dns
 }
 
 output "rke2_server1_private_ip" {

--- a/tests/airgap/README.md
+++ b/tests/airgap/README.md
@@ -16,6 +16,7 @@ Please see below for more details for your config. Please note that the config c
 ## Getting Started
 The config is split up into multiple parts. Think of the parts as follows:
 - Standalone config for setting up Rancher
+- Standalone config for setting up private registry
 - Custom cluster config for provisioning downstream clusters
 - Rancher config
 
@@ -44,12 +45,12 @@ terraform:
   nodeTemplateName: ""                            # REQUIRED - fill with desired value
   privateKeyPath: ""                              # REQUIRED - specify private key that will be used to access created instances
   privateRegistries:
-    authConfigSecretName: ""                      # REQUIRED - specify the name of the secret you wanted created
+    authConfigSecretName: ""                      # REQUIRED (authenticated registry only) - specify the name of the secret you wanted created
     insecure: true
-    url: ""                                       # REQUIRED - name of the private registry that is already created
-    systemDefaultRegistry: ""                     # REQUIRED - name of the private registry that is already created
-    username: ""                                  # REQUIRED - username of the private registry
-    password: ""                                  # REQUIRED - password of the private registry
+    url: ""                                       # LEAVE BLANK - will be set during the test
+    systemDefaultRegistry: ""                     # LEAVE BLANK - will be set during the test
+    username: ""                                  # REQUIRED (authenticated registry only) - username of the private registry
+    password: ""                                  # REQUIRED (authenticated registry only) - password of the private registry
   ##########################################
   # INFRASTRUCTURE / CUSTOM CLUSTER SETUP
   ##########################################
@@ -68,6 +69,7 @@ terraform:
     awsRoute53Zone: ""
     region: ""
     awsUser: ""
+    registryRootSize: 500
     sshConnectionType: "ssh"
     timeout: "5m"
   ###################################
@@ -77,17 +79,26 @@ terraform:
     airgapInternalFQDN: ""                        # REQUIRED - Have the same name as the rancherHostname but it must end with `-internal`
     bootstrapPassword: ""                         # REQUIRED - this is the same as the adminPassword above, make sure they match
     certManagerVersion: ""                        # REQUIRED - (e.g. v1.15.3)
+    osGroup: ""                                   # REQUIRED - fill with group of the instance created
+    osUser: ""                                    # REQUIRED - fill with username of the instance created
     rancherChartVersion: ""                       # REQUIRED - fill with desired value
     rancherChartRepository: ""                    # REQUIRED - fill with desired value. Must end with a trailing /
     rancherHostname: ""                           # REQUIRED - fill with desired value
     rancherRepo: ""                               # REQUIRED - fill with desired value
     rancherTagVersion: ""                         # REQUIRED - fill with desired value
-    rke2Group: ""                                 # REQUIRED - fill with group of the instance created
     type: ""                                      # REQUIRED - fill with desired value
-    rke2User: ""                                  # REQUIRED - fill with username of the instance created
     stagingRancherImage: ""                       # OPTIONAL - fill out only if you are using staging registry
     stagingRancherAgentImage: ""                  # OPTIONAL - fill out only if you are using staging registry
     rke2Version: ""                               # REQUIRED - the format MUST be in `v1.xx.x` (i.e. v1.31.3)
+  ####################################
+  # STANDALONE CONFIG - REGISTRY SETUP
+  ####################################
+  standaloneRegistry:
+    assetsPath: ""                                # REQUIRED - ensure that you end with a trailing `/`
+    authenticated: true                           # REQUIRED - true if you want an authenticated registry, false for a non-authenticated registry
+    registryName: ""                              # REQUIRED (authenticated registry only)
+    registryPassword: ""                          # REQUIRED (authenticated registry only)
+    registryUsername: ""                          # REQUIRED (authenticated registry only)
 ```
 
 Before running, be sure to run the following commands:

--- a/tests/extensions/provisioning/verify.go
+++ b/tests/extensions/provisioning/verify.go
@@ -6,6 +6,7 @@ import (
 
 	clusterActions "github.com/rancher/rancher/tests/v2/actions/clusters"
 	"github.com/rancher/rancher/tests/v2/actions/psact"
+	"github.com/rancher/rancher/tests/v2/actions/registries"
 	"github.com/rancher/shepherd/clients/rancher"
 	clusterExtensions "github.com/rancher/shepherd/extensions/clusters"
 	"github.com/rancher/shepherd/extensions/workloads/pods"
@@ -58,6 +59,11 @@ func VerifyCluster(t *testing.T, client *rancher.Client, clusterName string, ter
 
 	podErrors := pods.StatusPods(client, cluster.ID)
 	assert.Empty(t, podErrors)
+
+	if terraformConfig.PrivateRegistries != nil {
+		_, err := registries.CheckAllClusterPodsForRegistryPrefix(client, clusterID, terraformConfig.PrivateRegistries.URL)
+		require.NoError(t, err)
+	}
 }
 
 // VerifyNodeCount validates that a cluster has the expected number of nodes.


### PR DESCRIPTION
### Issue: [Enhance tfp-automation framework to support creating private registries](https://github.com/rancher/qa-tasks/issues/1640)

### Description
Currently, airgap tests require that you bring your own authenticated private registry, prior to running the test. During release testing, this is not ideal. We need to be able to run the test and a private registry is created and then the test is ran. This PR adds support for the following:
- Authenticated private registries
- Non-authenticated private registries

These are written in a modular way so that we can use these for private registry tests down the line. In addition, `VerifyCluster` is enhanced to check if the pods have the registry prefix.