### PR TITLE
Fix s3 cloud credential

### DIFF
--- a/framework/set/provisioning/nodedriver/rke2k3s/setConfig.go
+++ b/framework/set/provisioning/nodedriver/rke2k3s/setConfig.go
@@ -148,7 +148,7 @@ func SetRKE2K3s(client *rancher.Client, terraformConfig *config.TerraformConfig,
 	upgradeStrategyBlockBody.SetAttributeValue(workerConcurrency, cty.StringVal(("10%")))
 
 	if terraformConfig.ETCD != nil {
-		setEtcdConfig(rkeConfigBlockBody, terraformConfig)
+		setEtcdConfig(rkeConfigBlockBody, terraformConfig, clusterName)
 	}
 
 	if snapshots.CreateSnapshot {

--- a/framework/set/provisioning/nodedriver/rke2k3s/setEtcdConfig.go
+++ b/framework/set/provisioning/nodedriver/rke2k3s/setEtcdConfig.go
@@ -12,7 +12,7 @@ import (
 )
 
 // setEtcdConfig is a function that will set the etcd configurations in the main.tf file.
-func setEtcdConfig(rkeConfigBlockBody *hclwrite.Body, terraformConfig *config.TerraformConfig) error {
+func setEtcdConfig(rkeConfigBlockBody *hclwrite.Body, terraformConfig *config.TerraformConfig, clusterName string) error {
 	snapshotBlock := rkeConfigBlockBody.AppendNewBlock(defaults.Etcd, nil)
 	snapshotBlockBody := snapshotBlock.Body()
 
@@ -25,7 +25,7 @@ func setEtcdConfig(rkeConfigBlockBody *hclwrite.Body, terraformConfig *config.Te
 		s3ConfigBlockBody := s3ConfigBlock.Body()
 
 		cloudCredSecretName := hclwrite.Tokens{
-			{Type: hclsyntax.TokenIdent, Bytes: []byte(defaults.CloudCredential + "." + defaults.CloudCredential + ".id")},
+			{Type: hclsyntax.TokenIdent, Bytes: []byte(defaults.CloudCredential + "." + clusterName + ".id")},
 		}
 
 		s3ConfigBlockBody.SetAttributeValue(bucket, cty.StringVal(terraformConfig.ETCD.S3.Bucket))

--- a/framework/set/provisioning/providers/aws/awsProviders.go
+++ b/framework/set/provisioning/providers/aws/awsProviders.go
@@ -53,7 +53,7 @@ func SetAWSRKE2K3SProvider(rootBody *hclwrite.Body, terraformConfig *config.Terr
 	cloudCredBlock := rootBody.AppendNewBlock(resource, []string{cloudCredential, clusterName})
 	cloudCredBlockBody := cloudCredBlock.Body()
 
-	cloudCredBlockBody.SetAttributeValue(resourceName, cty.StringVal(terraformConfig.CloudCredentialName))
+	cloudCredBlockBody.SetAttributeValue(resourceName, cty.StringVal(clusterName))
 
 	awsCredBlock := cloudCredBlockBody.AppendNewBlock(amazon.EC2CredentialConfig, nil)
 	awsCredBlockBody := awsCredBlock.Body()


### PR DESCRIPTION
During on of our reworks/updates to cluster provisioning we inadvertently broke s3 by generating the cloud credential name during the creation process. 

Note: at some point in the future we should separate the config build stage from the creation logic so things don't get out of sync like this.