### PR TITLE
Add infrastructure folder and Prime support for registries

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -123,6 +123,7 @@ type Standalone struct {
 	Repo                           string `json:"repo,omitempty" yaml:"repo,omitempty"`
 	OSUser                         string `json:"osUser,omitempty" yaml:"osUser,omitempty"`
 	OSGroup                        string `json:"osGroup,omitempty" yaml:"osGroup,omitempty"`
+	PrimeRancherAgentImage         string `json:"primeRancherAgentImage,omitempty" yaml:"primeRancherAgentImage,omitempty"`
 	RKE2Version                    string `json:"rke2Version,omitempty" yaml:"rke2Version,omitempty"`
 	StagingRancherAgentImage       string `json:"stagingRancherAgentImage,omitempty" yaml:"stagingRancherAgentImage,omitempty"`
 	UpgradedRancherChartRepository string `json:"upgradedRancherChartRepository,omitempty" yaml:"upgradedRancherChartRepository,omitempty"`

--- a/framework/set/resources/airgap/createMainTF.go
+++ b/framework/set/resources/airgap/createMainTF.go
@@ -33,7 +33,7 @@ const (
 
 // CreateMainTF is a helper function that will create the main.tf file for creating an Airgapped-Rancher server.
 func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath string, terraformConfig *config.TerraformConfig,
-	terratest *config.TerratestConfig) (string, error) {
+	terratestConfig *config.TerratestConfig) (string, error) {
 	var file *os.File
 	file = OpenFile(file, keyPath)
 	defer file.Close()
@@ -44,7 +44,7 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 	tfBlock := rootBody.AppendNewBlock(terraformConst, nil)
 	tfBlockBody := tfBlock.Body()
 
-	file, err := aws.CreateAWSResources(file, newFile, tfBlockBody, rootBody, terraformConfig, terratest)
+	file, err := aws.CreateAWSResources(file, newFile, tfBlockBody, rootBody, terraformConfig, terratestConfig)
 	if err != nil {
 		return "", err
 	}
@@ -58,16 +58,9 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 	rke2ServerThreePrivateIP := terraform.Output(t, terraformOptions, rke2ServerThreePrivateIP)
 
 	file = OpenFile(file, keyPath)
-	if terraformConfig.StandaloneRegistry.Authenticated {
-		file, err = registry.CreateAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, registryPublicDNS)
-		if err != nil {
-			return "", err
-		}
-	} else {
-		file, err = registry.CreateNonAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, registryPublicDNS, nonAuthRegistry)
-		if err != nil {
-			return "", err
-		}
+	file, err = registry.CreateNonAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, registryPublicDNS, nonAuthRegistry)
+	if err != nil {
+		return "", err
 	}
 
 	terraform.InitAndApply(t, terraformOptions)

--- a/framework/set/resources/airgap/rke2/add-servers.sh
+++ b/framework/set/resources/airgap/rke2/add-servers.sh
@@ -8,9 +8,8 @@ RKE2_TOKEN=$5
 REGISTRY=$6
 RANCHER_IMAGE=$7
 RANCHER_TAG_VERSION=$8
-REGISTRY_USERNAME=${9:-}
-REGISTRY_PASSWORD=${10:-}
-STAGING_RANCHER_AGENT_IMAGE=${11}
+STAGING_RANCHER_AGENT_IMAGE=${9:-""}
+PRIME_RANCHER_AGENT_IMAGE=${10}
 PEM_FILE=/home/$USER/airgap.pem
 
 set -e
@@ -41,23 +40,7 @@ EOF
 
 setupRegistry() {
   sudo mkdir -p /etc/rancher/rke2
-
-  if [ -n "${REGISTRY_USERNAME}" ]; then
-    sudo tee -a /etc/rancher/rke2/registries.yaml > /dev/null << EOF
-mirrors:
-  docker.io:
-    endpoint:
-      - "https://${REGISTRY}"
-configs:
-  "${REGISTRY}":
-    auth:
-      username: "${REGISTRY_USERNAME}"
-      password: "${REGISTRY_PASSWORD}"
-    tls:
-      insecure_skip_verify: true
-EOF
-  else
-    sudo tee -a /etc/rancher/rke2/registries.yaml > /dev/null << EOF
+  sudo tee -a /etc/rancher/rke2/registries.yaml > /dev/null << EOF
 mirrors:
   docker.io:
     endpoint:
@@ -67,7 +50,6 @@ configs:
     tls:
       insecure_skip_verify: true
 EOF
-  fi
 }
 
 setupDockerDaemon() {
@@ -88,17 +70,21 @@ runSSH "${RKE2_NEW_SERVER_IP}" "sudo INSTALL_RKE2_ARTIFACT_PATH=/home/${USER} sh
 runSSH "${RKE2_NEW_SERVER_IP}" "sudo systemctl enable rke2-server"
 runSSH "${RKE2_NEW_SERVER_IP}" "sudo systemctl start rke2-server"
 
-if [ -n "$STAGING_RANCHER_AGENT_IMAGE" ]; then
+if [ -n "$STAGING_RANCHER_AGENT_IMAGE" ] || [ -n "$PRIME_RANCHER_AGENT_IMAGE" ]; then
   setupDaemonFunction=$(declare -f setupDockerDaemon)
   runSSH "${RKE2_NEW_SERVER_IP}" "${setupDaemonFunction}; setupDockerDaemon"
   runSSH "${RKE2_NEW_SERVER_IP}" "sudo systemctl restart docker && sudo systemctl daemon-reload"
 
-  if [ -n "$REGISTRY_USERNAME" ]; then
-    runSSH "${RKE2_NEW_SERVER_IP}" "sudo docker login https://${REGISTRY} -u ${REGISTRY_USERNAME} -p ${REGISTRY_PASSWORD}"
+  runSSH "${RKE2_NEW_SERVER_IP}" "sudo docker pull ${REGISTRY}/${RANCHER_IMAGE}:${RANCHER_TAG_VERSION}"
+
+  if [ -n "$STAGING_RANCHER_AGENT_IMAGE" ]; then
+    runSSH "${RKE2_NEW_SERVER_IP}" "sudo docker pull ${REGISTRY}/${STAGING_RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}"
+  fi
+
+  if [ -n "$PRIME_RANCHER_AGENT_IMAGE" ]; then
+    runSSH "${RKE2_NEW_SERVER_IP}" "sudo docker pull ${REGISTRY}/${PRIME_RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}"
   fi
   
-  runSSH "${RKE2_NEW_SERVER_IP}" "sudo docker pull ${REGISTRY}/${RANCHER_IMAGE}:${RANCHER_TAG_VERSION}"
-  runSSH "${RKE2_NEW_SERVER_IP}" "sudo docker pull ${REGISTRY}/${STAGING_RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}"
   runSSH "${RKE2_NEW_SERVER_IP}" "sudo systemctl restart rke2-server"
 fi
 

--- a/framework/set/resources/airgap/rke2/createAirgapCluster.go
+++ b/framework/set/resources/airgap/rke2/createAirgapCluster.go
@@ -90,12 +90,12 @@ func createAirgappedRKE2Server(rootBody *hclwrite.Body, terraformConfig *config.
 		rke2ServerOnePrivateIP + " " + rke2Token + " " + registryPublicDNS + " " + terraformConfig.Standalone.RancherImage + " " +
 		terraformConfig.Standalone.RancherTagVersion
 
-	if terraformConfig.PrivateRegistries.Username != "" {
-		command += " " + terraformConfig.PrivateRegistries.Username + " " + terraformConfig.PrivateRegistries.Password
-	}
-
 	if terraformConfig.Standalone.StagingRancherAgentImage != "" {
 		command += " " + terraformConfig.Standalone.StagingRancherAgentImage
+	}
+
+	if terraformConfig.Standalone.PrimeRancherAgentImage != "" {
+		command += " " + terraformConfig.Standalone.PrimeRancherAgentImage
 	}
 
 	command += "'"
@@ -128,12 +128,12 @@ func addAirgappedRKE2ServerNodes(rootBody *hclwrite.Body, terraformConfig *confi
 			rke2ServerOnePrivateIP + " " + instance + " " + rke2Token + " " + registryPublicDNS + " " +
 			terraformConfig.Standalone.RancherImage + " " + terraformConfig.Standalone.RancherTagVersion
 
-		if terraformConfig.PrivateRegistries.Username != "" {
-			command += " " + terraformConfig.PrivateRegistries.Username + " " + terraformConfig.PrivateRegistries.Password
-		}
-
 		if terraformConfig.Standalone.StagingRancherAgentImage != "" {
 			command += " " + terraformConfig.Standalone.StagingRancherAgentImage
+		}
+
+		if terraformConfig.Standalone.PrimeRancherAgentImage != "" {
+			command += " " + terraformConfig.Standalone.PrimeRancherAgentImage
 		}
 
 		command += "'"

--- a/framework/set/resources/registries/createRegistry/auth-registry.sh
+++ b/framework/set/resources/registries/createRegistry/auth-registry.sh
@@ -8,7 +8,8 @@ RANCHER_VERSION=$5
 ASSET_DIR=$6
 USER=$7
 RANCHER_IMAGE=$8
-STAGING_RANCHER_AGENT_IMAGE=${9}
+STAGING_RANCHER_AGENT_IMAGE=${9:-""}
+PRIME_RANCHER_AGENT_IMAGE=${10}
 
 set -e
 
@@ -57,6 +58,11 @@ sudo sed -i '/mirrored-prometheus-windows-exporter/d' /home/${USER}/rancher-imag
 if [ ! -z "${STAGING_RANCHER_AGENT_IMAGE}" ]; then
     sudo sed -i "s|rancher/rancher:|${RANCHER_IMAGE}:|g" /home/${USER}/rancher-images.txt
     sudo sed -i "s|rancher/rancher-agent:|${STAGING_RANCHER_AGENT_IMAGE}:|g" /home/${USER}/rancher-images.txt
+fi
+
+if [[ ! -z "${PRIME_RANCHER_AGENT_IMAGE}" ]]; then
+    sudo sed -i "s|rancher/rancher:|${RANCHER_IMAGE}:|g" /home/${USER}/rancher-images.txt
+    sudo sed -i "s|rancher/rancher-agent:|${PRIME_RANCHER_AGENT_IMAGE}:|g" /home/${USER}/rancher-images.txt
 fi
     
 echo "Saving the images..."

--- a/framework/set/resources/registries/createRegistry/createRegistry.go
+++ b/framework/set/resources/registries/createRegistry/createRegistry.go
@@ -44,6 +44,10 @@ func CreateAuthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootBody
 		command += " " + terraformConfig.Standalone.StagingRancherAgentImage
 	}
 
+	if terraformConfig.Standalone.PrimeRancherAgentImage != "" {
+		command += " " + terraformConfig.Standalone.PrimeRancherAgentImage
+	}
+
 	command += "'"
 
 	provisionerBlockBody.SetAttributeValue(defaults.Inline, cty.ListVal([]cty.Value{
@@ -85,6 +89,10 @@ func CreateNonAuthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootB
 
 	if terraformConfig.Standalone.StagingRancherAgentImage != "" {
 		command += " " + terraformConfig.Standalone.StagingRancherAgentImage
+	}
+
+	if terraformConfig.Standalone.PrimeRancherAgentImage != "" {
+		command += " " + terraformConfig.Standalone.PrimeRancherAgentImage
 	}
 
 	command += "'"

--- a/framework/set/resources/registries/createRegistry/non-auth-registry.sh
+++ b/framework/set/resources/registries/createRegistry/non-auth-registry.sh
@@ -6,7 +6,8 @@ RANCHER_VERSION=$3
 ASSET_DIR=$4
 USER=$5
 RANCHER_IMAGE=$6
-STAGING_RANCHER_AGENT_IMAGE=${7}
+STAGING_RANCHER_AGENT_IMAGE=${7:-""}
+PRIME_RANCHER_AGENT_IMAGE=${8}
 
 set -e
 
@@ -38,6 +39,11 @@ sudo sed -i '/mirrored-prometheus-windows-exporter/d' /home/${USER}/rancher-imag
 if [ ! -z "${STAGING_RANCHER_AGENT_IMAGE}" ]; then
     sudo sed -i "s|rancher/rancher:|${RANCHER_IMAGE}:|g" /home/${USER}/rancher-images.txt
     sudo sed -i "s|rancher/rancher-agent:|${STAGING_RANCHER_AGENT_IMAGE}:|g" /home/${USER}/rancher-images.txt
+fi
+
+if [[ ! -z "${PRIME_RANCHER_AGENT_IMAGE}" ]]; then
+    sudo sed -i "s|rancher/rancher:|${RANCHER_IMAGE}:|g" /home/${USER}/rancher-images.txt
+    sudo sed -i "s|rancher/rancher-agent:|${PRIME_RANCHER_AGENT_IMAGE}:|g" /home/${USER}/rancher-images.txt
 fi
     
 echo "Saving the images..."

--- a/framework/set/resources/registries/rancher/setup.sh
+++ b/framework/set/resources/registries/rancher/setup.sh
@@ -48,6 +48,7 @@ if [ -n "$STAGING_RANCHER_AGENT_IMAGE" ]; then
                                                                                  --set "extraEnv[0].value=${STAGING_RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}" \
                                                                                  --set systemDefaultRegistry=${REGISTRY} \
                                                                                  --set bootstrapPassword=${BOOTSTRAP_PASSWORD} --devel
+
 else
     helm upgrade --install rancher rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
                                                                                  --set hostname=${HOSTNAME} \

--- a/framework/set/resources/registries/rke2/add-servers.sh
+++ b/framework/set/resources/registries/rke2/add-servers.sh
@@ -8,7 +8,8 @@ RKE2_TOKEN=$5
 RANCHER_IMAGE=$6
 RANCHER_TAG_VERSION=$7
 REGISTRY=$8
-STAGING_RANCHER_AGENT_IMAGE=${9}
+STAGING_RANCHER_AGENT_IMAGE=${9:-}
+PRIME_RANCHER_AGENT_IMAGE=${10:-}
 
 set -e
 
@@ -46,9 +47,16 @@ EOF
 
 sudo systemctl restart docker && sudo systemctl daemon-reload
 
-if [ -n "$STAGING_RANCHER_AGENT_IMAGE" ]; then
+if [ -n "$STAGING_RANCHER_AGENT_IMAGE" ] || [ -n "$PRIME_RANCHER_AGENT_IMAGE" ]; then
   sudo docker pull ${REGISTRY}/${RANCHER_IMAGE}:${RANCHER_TAG_VERSION}
-  sudo docker pull ${REGISTRY}/${STAGING_RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}
+
+  if [ -n "$STAGING_RANCHER_AGENT_IMAGE" ]; then
+    sudo docker pull ${REGISTRY}/${STAGING_RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}
+  fi
+
+  if [ -n "$PRIME_RANCHER_AGENT_IMAGE" ]; then
+    sudo docker pull ${REGISTRY}/${PRIME_RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}
+  fi
 
   sudo systemctl restart rke2-server
 fi

--- a/framework/set/resources/registries/rke2/createCluster.go
+++ b/framework/set/resources/registries/rke2/createCluster.go
@@ -70,6 +70,10 @@ func createRKE2Server(rootBody *hclwrite.Body, terraformConfig *config.Terraform
 		command += " " + terraformConfig.Standalone.StagingRancherAgentImage
 	}
 
+	if terraformConfig.Standalone.PrimeRancherAgentImage != "" {
+		command += " " + terraformConfig.Standalone.PrimeRancherAgentImage
+	}
+
 	command += "'"
 
 	provisionerBlockBody.SetAttributeValue(defaults.Inline, cty.ListVal([]cty.Value{
@@ -95,6 +99,10 @@ func addRKE2ServerNodes(rootBody *hclwrite.Body, terraformConfig *config.Terrafo
 
 		if terraformConfig.Standalone.StagingRancherAgentImage != "" {
 			command += " " + terraformConfig.Standalone.StagingRancherAgentImage
+		}
+
+		if terraformConfig.Standalone.PrimeRancherAgentImage != "" {
+			command += " " + terraformConfig.Standalone.PrimeRancherAgentImage
 		}
 
 		command += "'"

--- a/framework/set/resources/registries/rke2/init-server.sh
+++ b/framework/set/resources/registries/rke2/init-server.sh
@@ -8,7 +8,8 @@ RKE2_TOKEN=$5
 RANCHER_IMAGE=$6
 RANCHER_TAG_VERSION=$7
 REGISTRY=$8
-STAGING_RANCHER_AGENT_IMAGE=${9}
+STAGING_RANCHER_AGENT_IMAGE=${9:-}
+PRIME_RANCHER_AGENT_IMAGE=${10:-}
 
 set -e
 
@@ -45,9 +46,16 @@ EOF
 
 sudo systemctl restart docker && sudo systemctl daemon-reload
 
-if [ -n "$STAGING_RANCHER_AGENT_IMAGE" ]; then
+if [ -n "$STAGING_RANCHER_AGENT_IMAGE" ] || [ -n "$PRIME_RANCHER_AGENT_IMAGE" ]; then
   sudo docker pull ${REGISTRY}/${RANCHER_IMAGE}:${RANCHER_TAG_VERSION}
-  sudo docker pull ${REGISTRY}/${STAGING_RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}
+
+  if [ -n "$STAGING_RANCHER_AGENT_IMAGE" ]; then
+    sudo docker pull ${REGISTRY}/${STAGING_RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}
+  fi
+
+  if [ -n "$PRIME_RANCHER_AGENT_IMAGE" ]; then
+    sudo docker pull ${REGISTRY}/${PRIME_RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}
+  fi
 
   sudo systemctl restart rke2-server
 fi

--- a/tests/airgap/README.md
+++ b/tests/airgap/README.md
@@ -45,12 +45,9 @@ terraform:
   nodeTemplateName: ""                            # REQUIRED - fill with desired value
   privateKeyPath: ""                              # REQUIRED - specify private key that will be used to access created instances
   privateRegistries:
-    authConfigSecretName: ""                      # REQUIRED (authenticated registry only) - specify the name of the secret you wanted created
     insecure: true
     url: ""                                       # LEAVE BLANK - will be set during the test
     systemDefaultRegistry: ""                     # LEAVE BLANK - will be set during the test
-    username: ""                                  # REQUIRED (authenticated registry only) - username of the private registry
-    password: ""                                  # REQUIRED (authenticated registry only) - password of the private registry
   ##########################################
   # INFRASTRUCTURE / CUSTOM CLUSTER SETUP
   ##########################################
@@ -82,6 +79,7 @@ terraform:
     certManagerVersion: ""                        # REQUIRED - (e.g. v1.15.3)
     osGroup: ""                                   # REQUIRED - fill with group of the instance created
     osUser: ""                                    # REQUIRED - fill with username of the instance created
+    primeRancherAgentImage: ""                    # OPTIONAL - fill out only if you are using Rancher Prime
     rancherChartRepository: ""                    # REQUIRED - fill with desired value. Must end with a trailing /
     rancherHostname: ""                           # REQUIRED - fill with desired value
     rancherImage: ""                              # REQUIRED - fill with desired value
@@ -94,19 +92,23 @@ terraform:
   ####################################
   standaloneRegistry:
     assetsPath: ""                                # REQUIRED - ensure that you end with a trailing `/`
-    authenticated: true                           # REQUIRED - true if you want an authenticated registry, false for a non-authenticated registry
-    registryName: ""                              # REQUIRED (authenticated registry only)
-    registryPassword: ""                          # REQUIRED (authenticated registry only)
-    registryUsername: ""                          # REQUIRED (authenticated registry only)
+    registryName: ""                              # REQUIRED - fill with desired value
 ```
 
 Before running, be sure to run the following commands:
 
-`export RANCHER2_KEY_PATH="/<path>/<to>/go/src/github.com/rancher/tfp-automation/modules/rancher2"; export AIRGAP_KEY_PATH="/<path>/<to>/go/src/github.com/rancher/tfp-automation/modules/airgap"; export RANCHER2_PROVIDER_VERSION=""; export CATTLE_TEST_CONFIG=<path/to/yaml>; export LOCALS_PROVIDER_VERSION=""; export AWS_PROVIDER_VERSION=""`
+```yaml
+export RANCHER2_KEY_PATH="/<path>/<to>/go/src/github.com/rancher/tfp-automation/modules/rancher2"
+export AIRGAP_KEY_PATH="/<path>/<to>/go/src/github.com/rancher/tfp-automation/modules/airgap"
+export RANCHER2_PROVIDER_VERSION=""
+export CATTLE_TEST_CONFIG=<path/to/yaml>
+export LOCALS_PROVIDER_VERSION=""
+export AWS_PROVIDER_VERSION=""
+```
 
 See the below examples on how to run the tests:
 
-`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/airgap --junitfile results.xml --jsonfile results.json -- -timeout=120m -v -run "TestTfpAirgapProvisioningTestSuite$"`
+`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/airgap --junitfile results.xml --jsonfile results.json -- -timeout=9h -v -run "TestTfpAirgapProvisioningTestSuite$"`
 
 If the specified test passes immediately without warning, try adding the -count=1 flag to get around this issue. This will avoid previous results from interfering with the new test run.
 
@@ -117,4 +119,4 @@ If you are planning to report to Qase locally, then you will need to have the fo
      - `QASE_AUTOMATION_TOKEN=""`
      - `QASE_TEST_RUN_ID=""`
 3. Append `./reporter` to the end of the `gotestsum` command. See an example below::
-     - `gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/airgap  --junitfile results.xml --jsonfile results.json -- -timeout=120m -v -run TestTfpAirgapProvisioningTestSuite$";/path/to/tfp-automation/reporter`
+     - `gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/airgap  --junitfile results.xml --jsonfile results.json -- -timeout=9h -v -run TestTfpAirgapProvisioningTestSuite$";/path/to/tfp-automation/reporter`

--- a/tests/infrastructure/README.md
+++ b/tests/infrastructure/README.md
@@ -1,0 +1,337 @@
+# Setup Infrastructure
+
+The `infrastructure` directory aims to be a hub to create various environments for testing needs. These include standalone clusters as well as various types of Rancher setups (i.e. airgap or proxy). These are written in the forms of tests, but they are strictly meant to get you going with an environment in a stable, reliable manner.
+
+Please see below for more details for your config. Please note that the config can be in either JSON or YAML (all examples are illustrated in YAML).
+
+## Table of Contents
+1. [Setup Rancher](#Setup-Rancher)
+2. [Setup Airgap Rancher](#Setup-Airgap-Rancher)
+3. [Setup Proxy Rancher](#Setup-Proxy-Rancher)
+4. [Setup RKE1 Cluster](#Setup-RKE1-Cluster)
+5. [Setup RKE2 Cluster](#Setup-RKE2-Cluster)
+6. [Setup Airgap RKE2 Cluster](#Setup-Airgap-RKE2-Cluster)
+
+## Setup Rancher
+
+See below an example config on setting up a Rancher server powered by a RKE2 HA cluster:
+
+```yaml
+#######################
+# RANCHER CONFIG
+#######################
+rancher:
+  host: ""                                        # REQUIRED - fill out with the expected Rancher server URL
+  insecure: true                                  # REQUIRED - leave this as true
+#######################
+# TERRAFORM CONFIG
+#######################
+terraform:
+  privateKeyPath: ""                              # REQUIRED - specify private key that will be used to access created instances
+  ##########################################
+  # STANDALONE CONFIG - INFRASTRUCTURE SETUP
+  ##########################################
+  awsCredentials:
+    awsAccessKey: ""
+    awsSecretKey: ""
+  awsConfig:
+    ami: ""
+    awsKeyName: ""
+    awsInstanceType: ""
+    awsSubnetID: ""
+    awsVpcID: ""
+    awsZoneLetter: ""
+    awsRootSize: 100
+    awsRoute53Zone: ""
+    region: ""
+    prefix: ""
+    awsUser: ""
+    sshConnectionType: "ssh"
+    standaloneSecurityGroupNames: [""]
+    timeout: "5m"
+  ###################################
+  # STANDALONE CONFIG - RANCHER SETUP
+  ###################################
+  standalone:
+    bootstrapPassword: ""                         # REQUIRED - this is the same as the adminPassword above, make sure they match
+    certManagerVersion: ""                        # REQUIRED - (e.g. v1.15.3)
+    rancherChartVersion: ""                       # REQUIRED - fill with desired value
+    rancherChartRepository: ""                    # REQUIRED - fill with desired value. Must end with a trailing /
+    rancherHostname: ""                           # REQUIRED - fill with desired value
+    rancherImage: ""                              # REQUIRED - fill with desired value
+    rancherTagVersion: ""                         # REQUIRED - fill with desired value
+    repo: ""                                      # REQUIRED - fill with desired value
+    rke2Group: ""                                 # REQUIRED - fill with group of the instance created
+    rke2User: ""                                  # REQUIRED - fill with username of the instance created
+    stagingRancherAgentImage: ""                  # OPTIONAL - fill out only if you are using staging registry
+    rke2Version: ""                               # REQUIRED - fill with desired RKE2 k8s value (i.e. v1.30.6+rke2r1)
+```
+
+Before running locally, be sure to run the following commands:
+
+```yaml
+export RANCHER2_KEY_PATH="/<path>/<to>/go/src/github.com/rancher/tfp-automation/modules/rancher2"
+export SANITY_KEY_PATH="/<path>/<to>/go/src/github.com/rancher/tfp-automation/modules/sanity"
+export RANCHER2_PROVIDER_VERSION=""
+export CATTLE_TEST_CONFIG=<path/to/yaml>
+export LOCALS_PROVIDER_VERSION=""
+export AWS_PROVIDER_VERSION=""
+```
+
+See the below examples on how to run the test:
+
+`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/infrastructure --junitfile results.xml --jsonfile results.json -- -timeout=2h -v -run "TestRancherTestSuite$"`
+
+If the specified test passes immediately without warning, try adding the -count=1 flag to get around this issue. This will avoid previous results from interfering with the new test run.
+
+## Setup Airgap Rancher
+
+See below an example config on setting up an air-gapped Rancher server powered by an air-gapped RKE2 HA cluster:
+
+```yaml
+terraform:
+  privateKeyPath: ""                              # REQUIRED - specify private key that will be used to access created instances
+  awsCredentials:
+    awsAccessKey: ""
+    awsSecretKey: ""
+  awsConfig:
+    ami: ""
+    awsKeyName: ""
+    awsInstanceType: ""
+    awsSubnetID: ""
+    awsVpcID: ""
+    awsZoneLetter: ""
+    awsRootSize: 100
+    awsRoute53Zone: ""
+    awsSecurityGroupNames: [""]
+    awsUser: ""
+    region: ""
+    registryRootSize: 500
+    sshConnectionType: "ssh"
+    standaloneSecurityGroupNames: [""]
+    timeout: "5m"
+  standalone:
+    airgapInternalFQDN: ""                        # REQUIRED - Have the same name as the rancherHostname but it must end with `-internal`
+    bootstrapPassword: ""                         # REQUIRED - this is the same as the adminPassword above, make sure they match
+    certManagerVersion: ""                        # REQUIRED - (e.g. v1.15.3)
+    osGroup: ""                                   # REQUIRED - fill with group of the instance created
+    osUser: ""                                    # REQUIRED - fill with username of the instance created
+    primeRancherAgentImage: ""                    # OPTIONAL - fill out only if you are using Rancher Prime
+    rancherChartRepository: ""                    # REQUIRED - fill with desired value. Must end with a trailing /
+    rancherHostname: ""                           # REQUIRED - fill with desired value
+    rancherImage: ""                              # REQUIRED - fill with desired value
+    rancherTagVersion: ""                         # REQUIRED - fill with desired value
+    repo: ""                                      # REQUIRED - fill with desired value
+    stagingRancherAgentImage: ""                  # OPTIONAL - fill out only if you are using staging registry
+    rke2Version: ""                               # REQUIRED - the format MUST be in `v1.xx.x` (i.e. v1.31.3)
+  standaloneRegistry:
+    assetsPath: ""                                # REQUIRED - ensure that you end with a trailing `/`
+    authenticated: true                           # REQUIRED - true if you want an authenticated registry, false for a non-authenticated registry
+    registryName: ""                              # REQUIRED (authenticated registry only)
+    registryPassword: ""                          # REQUIRED (authenticated registry only)
+    registryUsername: ""                          # REQUIRED (authenticated registry only)
+```
+
+Before running, be sure to run the following commands:
+
+```yaml
+export RANCHER2_KEY_PATH="/<path>/<to>/go/src/github.com/rancher/tfp-automation/modules/rancher2"
+export AIRGAP_KEY_PATH="/<path>/<to>/go/src/github.com/rancher/tfp-automation/modules/airgap"
+export RANCHER2_PROVIDER_VERSION=""
+export CATTLE_TEST_CONFIG=<path/to/yaml>
+export LOCALS_PROVIDER_VERSION=""
+export AWS_PROVIDER_VERSION=""
+```
+
+See the below examples on how to run the test:
+
+`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/infrastructure --junitfile results.xml --jsonfile results.json -- -timeout=7h -v -run "TestAirgapRancherTestSuite$"`
+
+## Setup Proxy Rancher
+
+See below an example config on setting up a Rancher server behind a proxy, powered by an RKE2 HA cluster:
+
+```yaml
+terraform:
+  privateKeyPath: ""                              # REQUIRED - specify private key that will be used to access created instances
+  awsCredentials:
+    awsAccessKey: ""
+    awsSecretKey: ""
+  awsConfig:
+    ami: ""
+    awsKeyName: ""
+    awsInstanceType: ""
+    awsSubnetID: ""
+    awsVpcID: ""
+    awsZoneLetter: ""
+    awsRootSize: 100
+    awsRoute53Zone: ""
+    region: ""
+    awsUser: ""
+    sshConnectionType: "ssh"
+    standaloneSecurityGroupNames: [""]
+    timeout: "5m"
+  standalone:
+    bootstrapPassword: ""                         # REQUIRED - this is the same as the adminPassword above, make sure they match
+    certManagerVersion: ""                        # REQUIRED - (e.g. v1.15.3)
+    rancherChartVersion: ""                       # REQUIRED - fill with desired value
+    rancherChartRepository: ""                    # REQUIRED - fill with desired value. Must end with a trailing /
+    rancherHostname: ""                           # REQUIRED - fill with desired value
+    rancherImage: ""                              # REQUIRED - fill with desired value
+    rancherTagVersion: ""                         # REQUIRED - fill with desired value
+    repo: ""                                      # REQUIRED - fill with desired value
+    rke2Group: ""                                 # REQUIRED - fill with group of the instance created
+    rke2User: ""                                  # REQUIRED - fill with username of the instance created
+    stagingRancherAgentImage: ""                  # OPTIONAL - fill out only if you are using staging registry
+    rke2Version: ""                               # REQUIRED - fill with desired RKE2 k8s value (i.e. v1.30.6+rke2r1)
+```
+
+Before running, be sure to run the following commands:
+
+```yaml
+export RANCHER2_KEY_PATH="/<path>/<to>/go/src/github.com/rancher/tfp-automation/modules/rancher2"
+export PROXY_KEY_PATH="/<path>/<to>/go/src/github.com/rancher/tfp-automation/modules/proxy"
+export RANCHER2_PROVIDER_VERSION=""
+export CATTLE_TEST_CONFIG=<path/to/yaml>
+export LOCALS_PROVIDER_VERSION=""
+export AWS_PROVIDER_VERSION=""
+```
+
+See the below examples on how to run the tests:
+
+`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/infrastructure --junitfile results.xml --jsonfile results.json -- -timeout=3h -v -run "TestTfpProxyProvisioningTestSuite$"`
+
+## Setup RKE1 Cluster
+
+See below an example config on setting up a standalone RKE1 cluster:
+
+```yaml
+terraform:
+  hostnamePrefix: ""
+  privateKeyPath: ""
+  awsCredentials:
+    awsAccessKey: ""
+    awsSecretKey: ""
+  awsConfig:
+    ami: ""
+    awsKeyName: ""
+    awsInstanceType: ""
+    region: ""
+    awsSubnetID: ""
+    awsVpcID: ""
+    awsZoneLetter: ""
+    awsRootSize: 100
+    region: ""
+    awsUser: ""
+    sshConnectionType: ""
+    standaloneSecurityGroupNames: [""]
+    timeout: ""
+  standalone:
+    osUser: ""
+```
+
+Before running, be sure to run the following commands:
+
+```yaml
+export RKE_KEY_PATH="/<path>/<to>/go/src/github.com/rancher/tfp-automation/modules/rke"
+export RKE_PROVIDER_VERSION=""
+export CATTLE_TEST_CONFIG=<path/to/yaml>
+export AWS_PROVIDER_VERSION=""
+```
+
+See the below examples on how to run the tests:
+
+`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/infrastructure --junitfile results.xml --jsonfile results.json -- -timeout=60m -v -run "TestRKEProviderTestSuite$"`
+
+## Setup RKE2 Cluster
+
+See below an example config on setting up a standalone RKE2 cluster:
+
+```yaml
+terraform:
+  hostnamePrefix: ""
+  privateKeyPath: ""
+  awsCredentials:
+    awsAccessKey: ""
+    awsSecretKey: ""
+  awsConfig:
+    ami: ""
+    awsKeyName: ""
+    awsInstanceType: ""
+    region: ""
+    awsSubnetID: ""
+    awsVpcID: ""
+    awsZoneLetter: ""
+    awsRootSize: 100
+    awsRoute53Zone: ""
+    awsUser: ""
+    registryRootSize: 500
+    sshConnectionType: "ssh"
+    standaloneSecurityGroupNames: [""]
+    timeout: ""
+  standalone:
+    osGroup: ""                                   # REQUIRED - fill with group of the instance created
+    osUser: ""                                    # REQUIRED - fill with username of the instance created
+    primeRancherAgentImage: ""                    # OPTIONAL - fill out only if you are using Rancher Prime
+    rancherChartRepository: ""                    # REQUIRED - fill with desired value. Must end with a trailing /
+    rancherHostname: ""                           # REQUIRED - fill with desired value
+    rancherImage: ""                              # REQUIRED - fill with desired value
+    rancherTagVersion: ""                         # REQUIRED - fill with desired value
+    repo: ""                                      # REQUIRED - fill with desired value
+    stagingRancherAgentImage: ""                  # OPTIONAL - fill out only if you are using staging registry
+    rke2Version: ""                               # REQUIRED - the format MUST be in `v1.xx.x` (i.e. v1.31.3)
+  standaloneRegistry:
+    assetsPath: ""                                # REQUIRED - ensure that you end with a trailing `/`
+    registryName: ""                              # REQUIRED - fill with desired value
+```
+
+See the below examples on how to run the tests:
+
+`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/infrastructure --junitfile results.xml --jsonfile results.json -- -timeout=60m -v -run "TestCreateRKE2ClusterTestSuite$"`
+
+## Setup Airgap RKE2 Cluster
+
+See below an example config on setting up a standalone airgapped RKE2 cluster:
+
+```yaml
+terraform:
+  hostnamePrefix: ""
+  privateKeyPath: ""
+  awsCredentials:
+    awsAccessKey: ""
+    awsSecretKey: ""
+  awsConfig:
+    ami: ""
+    awsKeyName: ""
+    awsInstanceType: ""
+    region: ""
+    awsSubnetID: ""
+    awsVpcID: ""
+    awsZoneLetter: ""
+    awsRootSize: 100
+    awsRoute53Zone: ""
+    awsUser: ""
+    registryRootSize: 500
+    sshConnectionType: "ssh"
+    standaloneSecurityGroupNames: [""]
+    timeout: ""
+  standalone:
+    airgapInternalFQDN: ""                        # REQUIRED - Have the same name as the rancherHostname but it must end with `-internal`
+    osGroup: ""                                   # REQUIRED - fill with group of the instance created
+    osUser: ""                                    # REQUIRED - fill with username of the instance created
+    primeRancherAgentImage: ""                    # OPTIONAL - fill out only if you are using Rancher Prime
+    rancherChartRepository: ""                    # REQUIRED - fill with desired value. Must end with a trailing /
+    rancherHostname: ""                           # REQUIRED - fill with desired value
+    rancherImage: ""                              # REQUIRED - fill with desired value
+    rancherTagVersion: ""                         # REQUIRED - fill with desired value
+    repo: ""                                      # REQUIRED - fill with desired value
+    stagingRancherAgentImage: ""                  # OPTIONAL - fill out only if you are using staging registry
+    rke2Version: ""                               # REQUIRED - the format MUST be in `v1.xx.x` (i.e. v1.31.3)
+  standaloneRegistry:
+    assetsPath: ""                                # REQUIRED - ensure that you end with a trailing `/`
+    registryName: ""                              # REQUIRED - fill with desired value
+```
+
+See the below examples on how to run the tests:
+
+`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/infrastructure --junitfile results.xml --jsonfile results.json -- -timeout=5h -v -run "TestCreateAirgappedRKE2ClusterTestSuite$"`

--- a/tests/infrastructure/setup_airgap_rancher_test.go
+++ b/tests/infrastructure/setup_airgap_rancher_test.go
@@ -1,0 +1,45 @@
+package infrastructure
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	ranchFrame "github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/framework"
+	"github.com/rancher/tfp-automation/framework/set/resources/airgap"
+	resources "github.com/rancher/tfp-automation/framework/set/resources/airgap"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type AirgapRancherTestSuite struct {
+	suite.Suite
+	terraformConfig  *config.TerraformConfig
+	terratestConfig  *config.TerratestConfig
+	terraformOptions *terraform.Options
+}
+
+func (i *AirgapRancherTestSuite) TestCreateAirgapRancher() {
+	i.terraformConfig = new(config.TerraformConfig)
+	ranchFrame.LoadConfig(config.TerraformConfigurationFileKey, i.terraformConfig)
+
+	i.terratestConfig = new(config.TerratestConfig)
+	ranchFrame.LoadConfig(config.TerratestConfigurationFileKey, i.terratestConfig)
+
+	keyPath := airgap.KeyPath()
+	terraformOptions := framework.Setup(i.T(), i.terraformConfig, i.terratestConfig, keyPath)
+	i.terraformOptions = terraformOptions
+
+	registry, err := resources.CreateMainTF(i.T(), i.terraformOptions, keyPath, i.terraformConfig, i.terratestConfig)
+	require.NoError(i.T(), err)
+
+	logrus.Infof("Rancher server URL: %s", i.terraformConfig.Standalone.RancherHostname)
+	logrus.Infof("Booststrap password: %s", i.terraformConfig.Standalone.BootstrapPassword)
+	logrus.Infof("Private registry: %s", registry)
+}
+
+func TestAirgapRancherTestSuite(t *testing.T) {
+	suite.Run(t, new(AirgapRancherTestSuite))
+}

--- a/tests/infrastructure/setup_airgap_rke2_test.go
+++ b/tests/infrastructure/setup_airgap_rke2_test.go
@@ -1,0 +1,77 @@
+package infrastructure
+
+import (
+	"os"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	ranchFrame "github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/framework"
+	"github.com/rancher/tfp-automation/framework/set/resources/airgap/aws"
+	"github.com/rancher/tfp-automation/framework/set/resources/airgap/rke2"
+	registry "github.com/rancher/tfp-automation/framework/set/resources/registries/createRegistry"
+	"github.com/rancher/tfp-automation/framework/set/resources/sanity"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type CreateAirgappedRKE2ClusterTestSuite struct {
+	suite.Suite
+	terraformConfig  *config.TerraformConfig
+	terratestConfig  *config.TerratestConfig
+	terraformOptions *terraform.Options
+}
+
+func (i *CreateAirgappedRKE2ClusterTestSuite) TestCreateAirgappedRKE2Cluster() {
+	i.terraformConfig = new(config.TerraformConfig)
+	ranchFrame.LoadConfig(config.TerraformConfigurationFileKey, i.terraformConfig)
+
+	i.terratestConfig = new(config.TerratestConfig)
+	ranchFrame.LoadConfig(config.TerratestConfigurationFileKey, i.terratestConfig)
+
+	keyPath := sanity.KeyPath()
+	terraformOptions := framework.Setup(i.T(), i.terraformConfig, i.terratestConfig, keyPath)
+	i.terraformOptions = terraformOptions
+
+	var file *os.File
+	file = sanity.OpenFile(file, keyPath)
+	defer file.Close()
+
+	newFile := hclwrite.NewEmptyFile()
+	rootBody := newFile.Body()
+
+	tfBlock := rootBody.AppendNewBlock(terraformConst, nil)
+	tfBlockBody := tfBlock.Body()
+
+	file, err := aws.CreateAWSResources(file, newFile, tfBlockBody, rootBody, i.terraformConfig, i.terratestConfig)
+	require.NoError(i.T(), err)
+
+	terraform.InitAndApply(i.T(), terraformOptions)
+
+	registryPublicDNS := terraform.Output(i.T(), terraformOptions, registryPublicDNS)
+	rke2BastionPublicDNS := terraform.Output(i.T(), terraformOptions, rke2BastionPublicDNS)
+	rke2ServerOnePrivateIP := terraform.Output(i.T(), terraformOptions, rke2ServerOnePrivateIP)
+	rke2ServerTwoPrivateIP := terraform.Output(i.T(), terraformOptions, rke2ServerTwoPrivateIP)
+	rke2ServerThreePrivateIP := terraform.Output(i.T(), terraformOptions, rke2ServerThreePrivateIP)
+
+	file = sanity.OpenFile(file, keyPath)
+	file, err = registry.CreateNonAuthenticatedRegistry(file, newFile, rootBody, i.terraformConfig, registryPublicDNS, nonAuthRegistry)
+	require.NoError(i.T(), err)
+
+	terraform.InitAndApply(i.T(), terraformOptions)
+
+	file = sanity.OpenFile(file, keyPath)
+	file, err = rke2.CreateAirgapRKE2Cluster(file, newFile, rootBody, i.terraformConfig, rke2BastionPublicDNS, registryPublicDNS, rke2ServerOnePrivateIP, rke2ServerTwoPrivateIP, rke2ServerThreePrivateIP)
+	require.NoError(i.T(), err)
+
+	terraform.InitAndApply(i.T(), terraformOptions)
+
+	logrus.Infof("Kubeconfig file is located in /home/%s/.kube in the bastion node: %s", i.terraformConfig.Standalone.OSUser, rke2BastionPublicDNS)
+}
+
+func TestCreateAirgappedRKE2ClusterTestSuite(t *testing.T) {
+	suite.Run(t, new(CreateAirgappedRKE2ClusterTestSuite))
+}

--- a/tests/infrastructure/setup_proxy_rancher_test.go
+++ b/tests/infrastructure/setup_proxy_rancher_test.go
@@ -1,0 +1,44 @@
+package infrastructure
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	ranchFrame "github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/framework"
+	"github.com/rancher/tfp-automation/framework/set/resources/proxy"
+	resources "github.com/rancher/tfp-automation/framework/set/resources/proxy"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type ProxyRancherTestSuite struct {
+	suite.Suite
+	terraformConfig  *config.TerraformConfig
+	terratestConfig  *config.TerratestConfig
+	terraformOptions *terraform.Options
+}
+
+func (i *ProxyRancherTestSuite) TestCreateProxyRancher() {
+	i.terraformConfig = new(config.TerraformConfig)
+	ranchFrame.LoadConfig(config.TerraformConfigurationFileKey, i.terraformConfig)
+
+	i.terratestConfig = new(config.TerratestConfig)
+	ranchFrame.LoadConfig(config.TerratestConfigurationFileKey, i.terratestConfig)
+
+	keyPath := proxy.KeyPath()
+	terraformOptions := framework.Setup(i.T(), i.terraformConfig, i.terratestConfig, keyPath)
+	i.terraformOptions = terraformOptions
+
+	_, _, err := resources.CreateMainTF(i.T(), i.terraformOptions, keyPath, i.terraformConfig, i.terratestConfig)
+	require.NoError(i.T(), err)
+
+	logrus.Infof("Rancher server URL: %s", i.terraformConfig.Standalone.RancherHostname)
+	logrus.Infof("Booststrap password: %s", i.terraformConfig.Standalone.BootstrapPassword)
+}
+
+func TestProxyRancherTestSuite(t *testing.T) {
+	suite.Run(t, new(ProxyRancherTestSuite))
+}

--- a/tests/infrastructure/setup_rancher_test.go
+++ b/tests/infrastructure/setup_rancher_test.go
@@ -1,0 +1,42 @@
+package infrastructure
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	ranchFrame "github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/framework"
+	"github.com/rancher/tfp-automation/framework/set/resources/sanity"
+	resources "github.com/rancher/tfp-automation/framework/set/resources/sanity"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/suite"
+)
+
+type RancherTestSuite struct {
+	suite.Suite
+	terraformConfig  *config.TerraformConfig
+	terratestConfig  *config.TerratestConfig
+	terraformOptions *terraform.Options
+}
+
+func (i *RancherTestSuite) TestCreateRancher() {
+	i.terraformConfig = new(config.TerraformConfig)
+	ranchFrame.LoadConfig(config.TerraformConfigurationFileKey, i.terraformConfig)
+
+	i.terratestConfig = new(config.TerratestConfig)
+	ranchFrame.LoadConfig(config.TerratestConfigurationFileKey, i.terratestConfig)
+
+	keyPath := sanity.KeyPath()
+	terraformOptions := framework.Setup(i.T(), i.terraformConfig, i.terratestConfig, keyPath)
+	i.terraformOptions = terraformOptions
+
+	resources.CreateMainTF(i.T(), i.terraformOptions, keyPath, i.terraformConfig, i.terratestConfig)
+
+	logrus.Infof("Rancher server URL: %s", i.terraformConfig.Standalone.RancherHostname)
+	logrus.Infof("Booststrap password: %s", i.terraformConfig.Standalone.BootstrapPassword)
+}
+
+func TestRancherTestSuite(t *testing.T) {
+	suite.Run(t, new(RancherTestSuite))
+}

--- a/tests/infrastructure/setup_rke1_test.go
+++ b/tests/infrastructure/setup_rke1_test.go
@@ -1,0 +1,42 @@
+package infrastructure
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	ranchFrame "github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/framework"
+	rke "github.com/rancher/tfp-automation/framework/set/resources/rke"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type CreateRKE1ClusterTestSuite struct {
+	suite.Suite
+	terraformConfig  *config.TerraformConfig
+	terratestConfig  *config.TerratestConfig
+	terraformOptions *terraform.Options
+}
+
+func (i *CreateRKE1ClusterTestSuite) TestCreateRKE1Cluster() {
+	i.terraformConfig = new(config.TerraformConfig)
+	ranchFrame.LoadConfig(config.TerraformConfigurationFileKey, i.terraformConfig)
+
+	i.terratestConfig = new(config.TerratestConfig)
+	ranchFrame.LoadConfig(config.TerratestConfigurationFileKey, i.terratestConfig)
+
+	keyPath := rke.KeyPath()
+	terraformOptions := framework.Setup(i.T(), i.terraformConfig, i.terratestConfig, keyPath)
+	i.terraformOptions = terraformOptions
+
+	rkeNodeOne, err := rke.CreateRKEMainTF(i.T(), i.terraformOptions, keyPath, i.terraformConfig, i.terratestConfig)
+	require.NoError(i.T(), err)
+
+	logrus.Infof("Kubeconfig file is located in /home/%s/.kube in the node: %s", i.terraformConfig.Standalone.OSUser, rkeNodeOne)
+}
+
+func TestCreateRKE1ClusterTestSuite(t *testing.T) {
+	suite.Run(t, new(CreateRKE1ClusterTestSuite))
+}

--- a/tests/infrastructure/setup_rke2_test.go
+++ b/tests/infrastructure/setup_rke2_test.go
@@ -1,0 +1,90 @@
+package infrastructure
+
+import (
+	"os"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	ranchFrame "github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/framework"
+	"github.com/rancher/tfp-automation/framework/set/resources/sanity"
+	"github.com/rancher/tfp-automation/framework/set/resources/sanity/aws"
+	"github.com/rancher/tfp-automation/framework/set/resources/sanity/rke2"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type CreateRKE2ClusterTestSuite struct {
+	suite.Suite
+	terraformConfig  *config.TerraformConfig
+	terratestConfig  *config.TerratestConfig
+	terraformOptions *terraform.Options
+}
+
+const (
+	rke2ServerOne   = "rke2_server1"
+	rke2ServerTwo   = "rke2_server2"
+	rke2ServerThree = "rke2_server3"
+
+	rke2ServerOnePublicDNS = "rke2_server1_public_dns"
+	registryPublicDNS      = "registry_public_dns"
+
+	nonAuthRegistry = "non_auth_registry"
+
+	rke2ServerOnePrivateIP   = "rke2_server1_private_ip"
+	rke2ServerTwoPublicDNS   = "rke2_server2_public_dns"
+	rke2ServerThreePublicDNS = "rke2_server3_public_dns"
+	rke2BastionPublicDNS     = "rke2_bastion_public_dns"
+	rke2ServerTwoPrivateIP   = "rke2_server2_private_ip"
+	rke2ServerThreePrivateIP = "rke2_server3_private_ip"
+
+	terraformConst = "terraform"
+)
+
+func (i *CreateRKE2ClusterTestSuite) TestCreateRKE2Cluster() {
+	i.terraformConfig = new(config.TerraformConfig)
+	ranchFrame.LoadConfig(config.TerraformConfigurationFileKey, i.terraformConfig)
+
+	i.terratestConfig = new(config.TerratestConfig)
+	ranchFrame.LoadConfig(config.TerratestConfigurationFileKey, i.terratestConfig)
+
+	keyPath := sanity.KeyPath()
+	terraformOptions := framework.Setup(i.T(), i.terraformConfig, i.terratestConfig, keyPath)
+	i.terraformOptions = terraformOptions
+
+	var file *os.File
+	file = sanity.OpenFile(file, keyPath)
+	defer file.Close()
+
+	newFile := hclwrite.NewEmptyFile()
+	rootBody := newFile.Body()
+
+	tfBlock := rootBody.AppendNewBlock(terraformConst, nil)
+	tfBlockBody := tfBlock.Body()
+
+	instances := []string{rke2ServerOne, rke2ServerTwo, rke2ServerThree}
+	file, err := aws.CreateAWSResources(file, newFile, tfBlockBody, rootBody, i.terraformConfig, i.terratestConfig, instances)
+	require.NoError(i.T(), err)
+
+	terraform.InitAndApply(i.T(), terraformOptions)
+
+	rke2ServerOnePublicDNS := terraform.Output(i.T(), terraformOptions, rke2ServerOnePublicDNS)
+	rke2ServerOnePrivateIP := terraform.Output(i.T(), terraformOptions, rke2ServerOnePrivateIP)
+	rke2ServerTwoPublicDNS := terraform.Output(i.T(), terraformOptions, rke2ServerTwoPublicDNS)
+	rke2ServerThreePublicDNS := terraform.Output(i.T(), terraformOptions, rke2ServerThreePublicDNS)
+
+	file = sanity.OpenFile(file, keyPath)
+	file, err = rke2.CreateRKE2Cluster(file, newFile, rootBody, i.terraformConfig, rke2ServerOnePublicDNS, rke2ServerOnePrivateIP, rke2ServerTwoPublicDNS, rke2ServerThreePublicDNS)
+	require.NoError(i.T(), err)
+
+	terraform.InitAndApply(i.T(), terraformOptions)
+
+	logrus.Infof("Kubeconfig file is located in /home/%s/.kube in the node: %s", i.terraformConfig.Standalone.OSUser, rke2ServerOnePublicDNS)
+}
+
+func TestCreateRKE2ClusterTestSuite(t *testing.T) {
+	suite.Run(t, new(CreateRKE2ClusterTestSuite))
+}

--- a/tests/proxy/README.md
+++ b/tests/proxy/README.md
@@ -64,7 +64,6 @@ terraform:
     awsRoute53Zone: ""
     region: ""
     awsUser: ""
-    registryRootSize: 500
     sshConnectionType: "ssh"
     standaloneSecurityGroupNames: [""]
     timeout: "5m"
@@ -88,12 +87,20 @@ terraform:
 
 Before running, be sure to run the following commands:
 
-`export RANCHER2_KEY_PATH="/<path>/<to>/go/src/github.com/rancher/tfp-automation/modules/rancher2"; export PROXY_KEY_PATH="/<path>/<to>/go/src/github.com/rancher/tfp-automation/modules/proxy"; export RANCHER2_PROVIDER_VERSION=""; export CATTLE_TEST_CONFIG=<path/to/yaml>; export LOCALS_PROVIDER_VERSION=""; export AWS_PROVIDER_VERSION=""`
+```yaml
+export RANCHER2_KEY_PATH="/<path>/<to>/go/src/github.com/rancher/tfp-automation/modules/rancher2"
+export PROXY_KEY_PATH="/<path>/<to>/go/src/github.com/rancher/tfp-automation/modules/proxy"
+export UPGRADE_KEY_PATH="/<path>/<to>/go/src/github.com/rancher/tfp-automation/modules/upgrade"
+export RANCHER2_PROVIDER_VERSION=""
+export CATTLE_TEST_CONFIG=<path/to/yaml>
+export LOCALS_PROVIDER_VERSION=""
+export AWS_PROVIDER_VERSION=""
+```
 
 See the below examples on how to run the tests:
 
-`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/proxy --junitfile results.xml --jsonfile results.json -- -timeout=120m -v -run "TestTfpProxyProvisioningTestSuite$"` \
-`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/proxy --junitfile results.xml --jsonfile results.json -- -timeout=120m -v -run "TestTfpProxyUpgradeRancherTestSuite$"`
+`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/proxy --junitfile results.xml --jsonfile results.json -- -timeout=3h -v -run "TestTfpProxyProvisioningTestSuite$"` \
+`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/proxy --junitfile results.xml --jsonfile results.json -- -timeout=3h -v -run "TestTfpProxyUpgradeRancherTestSuite$"`
 
 If the specified test passes immediately without warning, try adding the -count=1 flag to get around this issue. This will avoid previous results from interfering with the new test run.
 
@@ -104,4 +111,4 @@ If you are planning to report to Qase locally, then you will need to have the fo
      - `QASE_AUTOMATION_TOKEN=""`
      - `QASE_TEST_RUN_ID=""`
 3. Append `./reporter` to the end of the `gotestsum` command. See an example below::
-     - `gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/proxy  --junitfile results.xml --jsonfile results.json -- -timeout=120m -v -run TestTfpProxyProvisioningTestSuite$";/path/to/tfp-automation/reporter`
+     - `gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/proxy  --junitfile results.xml --jsonfile results.json -- -timeout=3h -v -run TestTfpProxyProvisioningTestSuite$";/path/to/tfp-automation/reporter`

--- a/tests/registries/README.md
+++ b/tests/registries/README.md
@@ -81,6 +81,7 @@ terraform:
     certManagerVersion: ""                        # REQUIRED - (e.g. v1.15.3)
     osGroup: ""                                   # REQUIRED - fill with group of the instance created
     osUser: ""                                    # REQUIRED - fill with username of the instance created
+    primeRancherAgentImage: ""                    # OPTIONAL - fill out only if you are using Rancher Prime
     rancherChartRepository: ""                    # REQUIRED - fill with desired value. Must end with a trailing /
     rancherHostname: ""                           # REQUIRED - fill with desired value
     rancherImage: ""                              # REQUIRED - fill with desired value
@@ -104,7 +105,7 @@ Before running, be sure to run the following commands:
 
 See the below examples on how to run the tests:
 
-`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/registries --junitfile results.xml --jsonfile results.json -- -timeout=600m -v -run "TestTfpRegistriesTestSuite$"`
+`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/registries --junitfile results.xml --jsonfile results.json -- -timeout=8h -v -run "TestTfpRegistriesTestSuite$"`
 
 If the specified test passes immediately without warning, try adding the -count=1 flag to get around this issue. This will avoid previous results from interfering with the new test run.
 
@@ -115,4 +116,4 @@ If you are planning to report to Qase locally, then you will need to have the fo
      - `QASE_AUTOMATION_TOKEN=""`
      - `QASE_TEST_RUN_ID=""`
 3. Append `./reporter` to the end of the `gotestsum` command. See an example below::
-     - `gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/airgap  --junitfile results.xml --jsonfile results.json -- -timeout=120m -v -run TestTfpAirgapProvisioningTestSuite$";/path/to/tfp-automation/reporter`
+     - `gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/airgap  --junitfile results.xml --jsonfile results.json -- -timeout=8h -v -run TestTfpAirgapProvisioningTestSuite$";/path/to/tfp-automation/reporter`

--- a/tests/rke/README.md
+++ b/tests/rke/README.md
@@ -59,7 +59,12 @@ terraform:
 
 Before running, be sure to run the following commands:
 
-`export RKE_KEY_PATH="/<path>/<to>/go/src/github.com/rancher/tfp-automation/modules/rke": export RKE_PROVIDER_VERSION=""; export CATTLE_TEST_CONFIG=<path/to/yaml>; export AWS_PROVIDER_VERSION=""`
+```yaml
+export RKE_KEY_PATH="/<path>/<to>/go/src/github.com/rancher/tfp-automation/modules/rke"
+export RKE_PROVIDER_VERSION=""
+export CATTLE_TEST_CONFIG=<path/to/yaml>
+export AWS_PROVIDER_VERSION=""
+```
 
 See the below examples on how to run the tests:
 

--- a/tests/rke/rke_provider_test.go
+++ b/tests/rke/rke_provider_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rancher/tfp-automation/framework/cleanup"
 	rke "github.com/rancher/tfp-automation/framework/set/resources/rke"
 	qase "github.com/rancher/tfp-automation/pipeline/qase/results"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -19,7 +20,6 @@ type RKEProviderTestSuite struct {
 	suite.Suite
 	client           *rancher.Client
 	session          *session.Session
-	rancherConfig    *rancher.Config
 	terraformConfig  *config.TerraformConfig
 	terratestConfig  *config.TerratestConfig
 	terraformOptions *terraform.Options
@@ -41,7 +41,8 @@ func (t *RKEProviderTestSuite) TestCreateRKECluster() {
 	terraformOptions := framework.Setup(t.T(), t.terraformConfig, t.terratestConfig, keyPath)
 	t.terraformOptions = terraformOptions
 
-	rke.CreateRKEMainTF(t.T(), t.terraformOptions, keyPath, t.terraformConfig, t.terratestConfig)
+	_, err := rke.CreateRKEMainTF(t.T(), t.terraformOptions, keyPath, t.terraformConfig, t.terratestConfig)
+	require.NoError(t.T(), err)
 
 	if t.terratestConfig.LocalQaseReporting {
 		qase.ReportTest()

--- a/tests/sanity/README.md
+++ b/tests/sanity/README.md
@@ -67,8 +67,8 @@ terraform:
     awsZoneLetter: ""
     awsRootSize: 100
     awsRoute53Zone: ""
+    awsSecurityGroupNames: [""]
     region: ""
-    prefix: ""
     awsUser: ""
     sshConnectionType: "ssh"
     standaloneSecurityGroupNames: [""]
@@ -93,11 +93,18 @@ terraform:
 
 Before running, be sure to run the following commands:
 
-`export RANCHER2_KEY_PATH="/<path>/<to>/go/src/github.com/rancher/tfp-automation/modules/rancher2"; export SANITY_KEY_PATH="/<path>/<to>/go/src/github.com/rancher/tfp-automation/modules/sanity"; export RANCHER2_PROVIDER_VERSION=""; export CATTLE_TEST_CONFIG=<path/to/yaml>; export LOCALS_PROVIDER_VERSION=""; export AWS_PROVIDER_VERSION=""`
+```yaml
+export RANCHER2_KEY_PATH="/<path>/<to>/go/src/github.com/rancher/tfp-automation/modules/rancher2"
+export SANITY_KEY_PATH="/<path>/<to>/go/src/github.com/rancher/tfp-automation/modules/sanity"
+export RANCHER2_PROVIDER_VERSION=""
+export CATTLE_TEST_CONFIG=<path/to/yaml>
+export LOCALS_PROVIDER_VERSION=""
+export AWS_PROVIDER_VERSION=""
+```
 
 See the below examples on how to run the tests:
 
-`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/sanity --junitfile results.xml --jsonfile results.json -- -timeout=120m -v -run "TestTfpSanityTestSuite$"`
+`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/sanity --junitfile results.xml --jsonfile results.json -- -timeout=2h -v -run "TestTfpSanityTestSuite$"`
 
 If the specified test passes immediately without warning, try adding the -count=1 flag to get around this issue. This will avoid previous results from interfering with the new test run.
 
@@ -108,4 +115,4 @@ If you are planning to report to Qase locally, then you will need to have the fo
      - `QASE_AUTOMATION_TOKEN=""`
      - `QASE_TEST_RUN_ID=""`
 3. Append `./reporter` to the end of the `gotestsum` command. See an example below::
-     - `gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/sanity  --junitfile results.xml --jsonfile results.json -- -timeout=120m -v -run TestTfpSanityTestSuite$";/path/to/tfp-automation/reporter`
+     - `gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/sanity  --junitfile results.xml --jsonfile results.json -- -timeout=2h -v -run TestTfpSanityTestSuite$";/path/to/tfp-automation/reporter`


### PR DESCRIPTION
### Issue: [Enhance tfp-automation to create standalone environments that we already support](https://github.com/rancher/qa-tasks/issues/1669)

### Description
A talking point on the team for quite some time has been a desire to have side "tests" that will various types of infrastructure. These can be standalone clusters or just different permutations of Rancher. As this framework has evolved over time, this increasingly has been more of a need to have.

This PR creates an `infrastructure` folder that does just that. This helps to keep the overall objective of the repo to testing the Rancher2 Terraform provider, while also having a dedicated location for creating infrastructure.

In addition, enhanced the following:
- Prime support for airgap and private registries tests
- Removed authenticated registry for airgap tests - Rancher officially only supports unauthenticated registry for the system default registry