### PR TITLE
Add RKE1 support to airgap test and speed up private registries

### DIFF
--- a/defaults/modules/modules.go
+++ b/defaults/modules/modules.go
@@ -20,6 +20,7 @@ const (
 	VsphereRKE1   = "vsphere_rke1"
 	VsphereRKE2   = "vsphere_rke2"
 	VsphereK3s    = "vsphere_k3s"
+	AirgapRKE1    = "airgap_rke1"
 	AirgapRKE2    = "airgap_rke2"
 	AirgapK3S     = "airgap_k3s"
 )

--- a/framework/set/provisioning/airgap/register-nodes.sh
+++ b/framework/set/provisioning/airgap/register-nodes.sh
@@ -6,6 +6,7 @@ GROUP=$3
 BASTION_IP=$4
 NODE_PRIVATE_IP=$5
 REGISTRATION_COMMAND=$6
+REGISTRY=$7
 
 set -e
 
@@ -17,4 +18,16 @@ PEM=/home/${USER}/airgap.pem
 sudo chmod 600 ${PEM}
 sudo chown ${USER}:${GROUP} ${PEM}
 
-ssh -o ProxyCommand="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $PEM -W %h:%p $USER@$BASTION_IP" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $PEM $USER@$NODE_PRIVATE_IP "$REGISTRATION_COMMAND; sleep 10"
+ssh -o ProxyCommand="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $PEM -W %h:%p $USER@$BASTION_IP" \
+    -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $PEM $USER@$NODE_PRIVATE_IP "sudo tee /etc/docker/daemon.json > /dev/null << EOF
+{
+    \"insecure-registries\" : [ \"${REGISTRY}\" ]
+    }
+EOF"
+
+ssh -o ProxyCommand="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $PEM -W %h:%p $USER@$BASTION_IP" \
+    -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $PEM $USER@$NODE_PRIVATE_IP \
+    "sudo systemctl restart docker && sudo systemctl daemon-reload"
+
+ssh -o ProxyCommand="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $PEM -W %h:%p $USER@$BASTION_IP" \
+    -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $PEM $USER@$NODE_PRIVATE_IP "$REGISTRATION_COMMAND"

--- a/framework/set/provisioning/airgap/registerPrivateNodes.go
+++ b/framework/set/provisioning/airgap/registerPrivateNodes.go
@@ -26,7 +26,7 @@ func registerPrivateNodes(provisionerBlockBody *hclwrite.Body, terraformConfig *
 		{Type: hclsyntax.TokenOQuote, Bytes: []byte(`["`), SpacesBefore: 1},
 		{Type: hclsyntax.TokenStringLit, Bytes: []byte("/tmp/register-nodes.sh " + encodedPEMFile + " " +
 			terraformConfig.Standalone.OSUser + " " + terraformConfig.Standalone.OSGroup + " " + bastionPublicIP + " " +
-			nodePrivateIP + " " + newCommand)},
+			nodePrivateIP + " " + newCommand + " " + terraformConfig.PrivateRegistries.SystemDefaultRegistry)},
 		{Type: hclsyntax.TokenCQuote, Bytes: []byte(`"]`), SpacesBefore: 1},
 	})
 

--- a/framework/set/provisioning/airgap/setRKE2K3SConfig.go
+++ b/framework/set/provisioning/airgap/setRKE2K3SConfig.go
@@ -1,0 +1,136 @@
+package airgap
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/modules"
+	"github.com/rancher/tfp-automation/framework/set/defaults"
+	"github.com/rancher/tfp-automation/framework/set/provisioning/airgap/nullresource"
+	"github.com/rancher/tfp-automation/framework/set/provisioning/custom/locals"
+	v2 "github.com/rancher/tfp-automation/framework/set/provisioning/custom/rke2k3s"
+	airgap "github.com/rancher/tfp-automation/framework/set/resources/airgap/aws"
+	"github.com/rancher/tfp-automation/framework/set/resources/sanity/aws"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	airgapNodeOne       = "airgap_node1"
+	airgapNodeTwo       = "airgap_node2"
+	airgapNodeThree     = "airgap_node3"
+	bastion             = "bastion"
+	copyScriptToBastion = "copy_script_to_bastion"
+)
+
+// // SetAirgapRKE2K3s is a function that will set the airgap RKE2/K3s cluster configurations in the main.tf file.
+func SetAirgapRKE2K3s(rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig,
+	configMap []map[string]any, clusterName string, newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File) (*os.File, error) {
+	v2.SetRancher2ClusterV2(rootBody, terraformConfig, terratestConfig, clusterName)
+	rootBody.AppendNewline()
+
+	aws.CreateAWSInstances(rootBody, terraformConfig, terratestConfig, bastion)
+	rootBody.AppendNewline()
+
+	// Based on GH issue https://github.com/rancher/rancher/issues/45607, K3s clusters will only have one node.
+	instances := []string{}
+	if terraformConfig.Module == modules.AirgapRKE2 {
+		instances = []string{airgapNodeOne, airgapNodeTwo, airgapNodeThree}
+	} else if terraformConfig.Module == modules.AirgapK3S {
+		instances = []string{airgapNodeOne}
+	}
+
+	for _, instance := range instances {
+		airgap.CreateAirgappedAWSInstances(rootBody, terraformConfig, instance)
+		rootBody.AppendNewline()
+	}
+
+	provisionerBlockBody, err := nullresource.SetAirgapNullResource(rootBody, terraformConfig, copyScriptToBastion, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	rootBody.AppendNewline()
+
+	file, _ = locals.SetLocals(rootBody, terraformConfig, configMap, clusterName, newFile, file, nil)
+
+	rootBody.AppendNewline()
+
+	err = copyScript(provisionerBlockBody)
+	if err != nil {
+		return nil, err
+	}
+
+	registrationCommands, nodePrivateIPs := getRKE2K3sRegistrationCommands(terraformConfig, clusterName)
+
+	for _, instance := range instances {
+		var dependsOn []string
+
+		// Depending on the airgapped node, add the specific dependsOn expression.
+		bastionScriptExpression := "[" + defaults.NullResource + `.copy_script_to_bastion` + "]"
+		nodeOneExpression := "[" + defaults.NullResource + `.register_` + airgapNodeOne + "]"
+		nodeTwoExpression := "[" + defaults.NullResource + `.register_` + airgapNodeTwo + "]"
+
+		bastionPublicIP := fmt.Sprintf("${%s.%s.%s}", defaults.AwsInstance, bastion, defaults.PublicIp)
+
+		if instance == airgapNodeOne {
+			dependsOn = append(dependsOn, bastionScriptExpression)
+		} else if instance == airgapNodeTwo {
+			dependsOn = append(dependsOn, nodeOneExpression)
+		} else if instance == airgapNodeThree {
+			dependsOn = append(dependsOn, nodeTwoExpression)
+		}
+
+		provisionerBlockBody, err = nullresource.SetAirgapNullResource(rootBody, terraformConfig, "register_"+instance, dependsOn)
+		if err != nil {
+			return nil, err
+		}
+
+		err = registerPrivateNodes(provisionerBlockBody, terraformConfig, bastionPublicIP, nodePrivateIPs[instance], registrationCommands[instance])
+		if err != nil {
+			return nil, err
+		}
+
+		rootBody.AppendNewline()
+	}
+
+	_, err = file.Write(newFile.Bytes())
+	if err != nil {
+		logrus.Infof("Failed to write custom RKE2/K3s configurations to main.tf file. Error: %v", err)
+		return nil, err
+	}
+
+	return file, nil
+}
+
+// getRKE2K3sRegistrationCommands is a helper function that will return the registration commands for the airgap nodes.
+func getRKE2K3sRegistrationCommands(terraformConfig *config.TerraformConfig, clusterName string) (map[string]string, map[string]string) {
+	commands := make(map[string]string)
+	nodePrivateIPs := make(map[string]string)
+
+	etcdRegistrationCommand := fmt.Sprintf("${%s.%s_%s} %s", defaults.Local, clusterName, defaults.InsecureNodeCommand, defaults.EtcdRoleFlag)
+	controlPlaneRegistrationCommand := fmt.Sprintf("${%s.%s_%s} %s", defaults.Local, clusterName, defaults.InsecureNodeCommand, defaults.ControlPlaneRoleFlag)
+	workerRegistrationCommand := fmt.Sprintf("${%s.%s_%s} %s", defaults.Local, clusterName, defaults.InsecureNodeCommand, defaults.WorkerRoleFlag)
+	allRolesRegistrationCommand := fmt.Sprintf("${%s.%s_%s} %s", defaults.Local, clusterName, defaults.InsecureNodeCommand, defaults.AllFlags)
+
+	airgapNodeOnePrivateIP := fmt.Sprintf("${%s.%s.%s}", defaults.AwsInstance, airgapNodeOne, defaults.PrivateIp)
+	airgapNodeTwoPrivateIP := fmt.Sprintf("${%s.%s.%s}", defaults.AwsInstance, airgapNodeTwo, defaults.PrivateIp)
+	airgapNodeThreePrivateIP := fmt.Sprintf("${%s.%s.%s}", defaults.AwsInstance, airgapNodeThree, defaults.PrivateIp)
+
+	if terraformConfig.Module == modules.AirgapRKE2 {
+		commands[airgapNodeOne] = etcdRegistrationCommand
+		commands[airgapNodeTwo] = controlPlaneRegistrationCommand
+		commands[airgapNodeThree] = workerRegistrationCommand
+
+		nodePrivateIPs[airgapNodeOne] = airgapNodeOnePrivateIP
+		nodePrivateIPs[airgapNodeTwo] = airgapNodeTwoPrivateIP
+		nodePrivateIPs[airgapNodeThree] = airgapNodeThreePrivateIP
+	} else if terraformConfig.Module == modules.AirgapK3S {
+		commands[airgapNodeOne] = allRolesRegistrationCommand
+		nodePrivateIPs[airgapNodeOne] = airgapNodeOnePrivateIP
+	}
+
+	return commands, nodePrivateIPs
+}

--- a/framework/set/provisioning/custom/rke1/setConfig.go
+++ b/framework/set/provisioning/custom/rke1/setConfig.go
@@ -19,7 +19,7 @@ func SetCustomRKE1(rancherConfig *rancher.Config, terraformConfig *config.Terraf
 	if terraformConfig.MultiCluster {
 		aws.CreateAWSInstances(rootBody, terraformConfig, terratestConfig, clusterName)
 
-		setRancher2Cluster(rootBody, terraformConfig, clusterName)
+		SetRancher2Cluster(rootBody, terraformConfig, clusterName)
 
 		nullresource.SetNullResource(rootBody, terraformConfig, clusterName)
 	} else {
@@ -27,7 +27,7 @@ func SetCustomRKE1(rancherConfig *rancher.Config, terraformConfig *config.Terraf
 
 		aws.CreateAWSInstances(rootBody, terraformConfig, terratestConfig, clusterName)
 
-		setRancher2Cluster(rootBody, terraformConfig, clusterName)
+		SetRancher2Cluster(rootBody, terraformConfig, clusterName)
 
 		nullresource.SetNullResource(rootBody, terraformConfig, clusterName)
 

--- a/framework/set/provisioning/custom/rke1/setRancher2Cluster.go
+++ b/framework/set/provisioning/custom/rke1/setRancher2Cluster.go
@@ -7,8 +7,8 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-// setRancher2ClusterV2 is a function that will set the rancher2_cluster_v2 configurations in the main.tf file.
-func setRancher2Cluster(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, clusterName string) error {
+// SetRancher2Cluster is a function that will set the rancher2_cluster configurations in the main.tf file.
+func SetRancher2Cluster(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, clusterName string) error {
 	clusterBlock := rootBody.AppendNewBlock(defaults.Resource, []string{defaults.Cluster, clusterName})
 	clusterBlockBody := clusterBlock.Body()
 

--- a/framework/set/provisioning/multiclusters/setMultiCluster.go
+++ b/framework/set/provisioning/multiclusters/setMultiCluster.go
@@ -70,13 +70,13 @@ func SetMultiCluster(client *rancher.Client, rancherConfig *rancher.Config, conf
 			if err != nil {
 				return clusterNames, err
 			}
-		case strings.Contains(module, clustertypes.RKE1) && !strings.Contains(module, defaults.Custom):
+		case strings.Contains(module, clustertypes.RKE1) && !strings.Contains(module, defaults.Custom) && !strings.Contains(module, defaults.Airgap):
 			file, err = nodedriver.SetRKE1(terraformConfig, clusterName, poolName, kubernetesVersion, psact, nodePools,
 				snapshotInput, newFile, rootBody, file, rbacRole)
 			if err != nil {
 				return clusterNames, err
 			}
-		case (strings.Contains(module, clustertypes.RKE2) || strings.Contains(module, clustertypes.K3S)) && !strings.Contains(module, defaults.Custom):
+		case (strings.Contains(module, clustertypes.RKE2) || strings.Contains(module, clustertypes.K3S)) && !strings.Contains(module, defaults.Custom) && !strings.Contains(module, defaults.Airgap):
 			file, err = nodedriverV2.SetRKE2K3s(client, terraformConfig, clusterName, poolName, kubernetesVersion, psact, nodePools,
 				snapshotInput, newFile, rootBody, file, rbacRole)
 			if err != nil {
@@ -89,6 +89,11 @@ func SetMultiCluster(client *rancher.Client, rancherConfig *rancher.Config, conf
 			}
 		case module == modules.CustomEC2RKE2 || module == modules.CustomEC2K3s:
 			file, err = customV2.SetCustomRKE2K3s(rancherConfig, terraformConfig, terratestConfig, configMap, clusterName, newFile, rootBody, file)
+			if err != nil {
+				return clusterNames, err
+			}
+		case module == modules.AirgapRKE1:
+			file, err = airgap.SetAirgapRKE1(rancherConfig, terraformConfig, terratestConfig, nil, clusterName, newFile, rootBody, file)
 			if err != nil {
 				return clusterNames, err
 			}

--- a/framework/set/resources/airgap/rancher/setupAirgapRancher.go
+++ b/framework/set/resources/airgap/rancher/setupAirgapRancher.go
@@ -37,10 +37,14 @@ func CreateAirgapRancher(file *os.File, newFile *hclwrite.File, rootBody *hclwri
 		terraformConfig.Standalone.Repo + " " + terraformConfig.Standalone.CertManagerVersion + " " +
 		terraformConfig.Standalone.RancherHostname + " " + " " + terraformConfig.Standalone.AirgapInternalFQDN + " " +
 		terraformConfig.Standalone.RancherTagVersion + " " + terraformConfig.Standalone.BootstrapPassword + " " +
-		terraformConfig.Standalone.RancherImage
+		terraformConfig.Standalone.RancherImage + " " + registryPublicDNS
 
 	if terraformConfig.Standalone.StagingRancherAgentImage != "" {
-		command += " " + terraformConfig.Standalone.StagingRancherAgentImage + " " + registryPublicDNS
+		command += " " + terraformConfig.Standalone.StagingRancherAgentImage
+	}
+
+	if terraformConfig.Standalone.PrimeRancherAgentImage != "" {
+		command += " " + terraformConfig.Standalone.PrimeRancherAgentImage
 	}
 
 	command += "'"

--- a/framework/set/resources/registries/createRegistry/non-auth-registry.sh
+++ b/framework/set/resources/registries/createRegistry/non-auth-registry.sh
@@ -11,6 +11,35 @@ PRIME_RANCHER_AGENT_IMAGE=${8}
 
 set -e
 
+manageImages() {
+    ACTION=$1
+    mapfile -t IMAGES < /home/${USER}/rancher-images.txt
+    PARALLEL_ACTIONS=10
+
+    COUNTER=0
+    for IMAGE in "${IMAGES[@]}"; do
+        action "${ACTION}" "${IMAGE}"
+        COUNTER=$((COUNTER+1))
+        
+        if (( $COUNTER % $PARALLEL_ACTIONS == 0 )); then
+            wait
+        fi
+    done
+
+    wait
+}
+
+action() {
+    ACTION=$1
+    IMAGE=$2
+    
+    if [ "$ACTION" == "pull" ]; then
+        sudo docker pull ${IMAGE} && sudo docker tag ${IMAGE} ${HOST}/${IMAGE} &
+    elif [ "$ACTION" == "push" ]; then
+        sudo docker push ${HOST}/${IMAGE} &
+    fi
+}
+
 echo "Creating a self-signed certificate..."
 sudo mkdir -p /home/${USER}/certs
 sudo openssl req -newkey rsa:4096 -nodes -sha256 -keyout /home/${USER}/certs/domain.key -addext "subjectAltName = DNS:${HOST}" -x509 -days 365 -out /home/${USER}/certs/domain.crt -subj "/C=US/ST=CA/L=SUSE/O=Dis/CN=${HOST}"
@@ -46,15 +75,8 @@ if [[ ! -z "${PRIME_RANCHER_AGENT_IMAGE}" ]]; then
     sudo sed -i "s|rancher/rancher-agent:|${PRIME_RANCHER_AGENT_IMAGE}:|g" /home/${USER}/rancher-images.txt
 fi
     
-echo "Saving the images..."
-sudo /home/${USER}/rancher-save-images.sh --image-list /home/${USER}/rancher-images.txt
-
-echo "Tagging the images..."
-for IMAGE in $(cat /home/$USER/rancher-images.txt); do
-    sudo docker tag ${IMAGE} ${HOST}/${IMAGE}
-done
+echo "Pulling the images..."
+manageImages "pull"
 
 echo "Pushing the newly tagged images..."
-for IMAGE in $(cat /home/$USER/rancher-images.txt); do
-    sudo docker push ${HOST}/${IMAGE}
-done
+manageImages "push"

--- a/framework/set/resources/registries/rancher/createRancher.go
+++ b/framework/set/resources/registries/rancher/createRancher.go
@@ -42,6 +42,10 @@ func CreateRancher(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Bod
 		command += " " + terraformConfig.Standalone.StagingRancherAgentImage
 	}
 
+	if terraformConfig.Standalone.PrimeRancherAgentImage != "" {
+		command += " " + terraformConfig.Standalone.PrimeRancherAgentImage
+	}
+
 	command += "'"
 
 	provisionerBlockBody.SetAttributeValue(defaults.Inline, cty.ListVal([]cty.Value{

--- a/framework/set/resources/registries/rancher/setup.sh
+++ b/framework/set/resources/registries/rancher/setup.sh
@@ -8,7 +8,8 @@ RANCHER_TAG_VERSION=$5
 BOOTSTRAP_PASSWORD=$6
 RANCHER_IMAGE=$7
 REGISTRY=$8
-STAGING_RANCHER_AGENT_IMAGE=${9}
+STAGING_RANCHER_AGENT_IMAGE=${9:-""}
+PRIME_RANCHER_AGENT_IMAGE=${10}
 
 set -ex
 
@@ -48,6 +49,15 @@ if [ -n "$STAGING_RANCHER_AGENT_IMAGE" ]; then
                                                                                  --set "extraEnv[0].value=${STAGING_RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}" \
                                                                                  --set systemDefaultRegistry=${REGISTRY} \
                                                                                  --set bootstrapPassword=${BOOTSTRAP_PASSWORD} --devel
+
+elif [ -n "$PRIME_RANCHER_AGENT_IMAGE" ]; then
+    helm upgrade --install rancher rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
+                                                                                 --set hostname=${HOSTNAME} \
+                                                                                 --set rancherImage=${REGISTRY}/${PRIME_RANCHER_IMAGE} \
+                                                                                 --set rancherImageTag=${RANCHER_TAG_VERSION} \
+                                                                                 --set 'extraEnv[0].name=CATTLE_AGENT_IMAGE' \
+                                                                                 --set "extraEnv[0].value=${REGISTRY}/${PRIME_RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}" \
+                                                                                 --set bootstrapPassword=${BOOTSTRAP_PASSWORD}
 
 else
     helm upgrade --install rancher rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \

--- a/framework/set/setConfigTF.go
+++ b/framework/set/setConfigTF.go
@@ -56,7 +56,7 @@ func ConfigTF(client *rancher.Client, rancherConfig *rancher.Config, terraformCo
 		case module == clustertypes.GKE:
 			_, err = hosted.SetGKE(terraformConfig, clusterName, terratestConfig.KubernetesVersion, terratestConfig.Nodepools, newFile, rootBody, file)
 			return clusterNames, err
-		case strings.Contains(module, clustertypes.RKE1) && !strings.Contains(module, defaults.Custom):
+		case strings.Contains(module, clustertypes.RKE1) && !strings.Contains(module, defaults.Custom) && !strings.Contains(module, defaults.Airgap):
 			_, err = nodedriver.SetRKE1(terraformConfig, clusterName, poolName, terratestConfig.KubernetesVersion, terratestConfig.PSACT, terratestConfig.Nodepools,
 				terratestConfig.SnapshotInput, newFile, rootBody, file, rbacRole)
 			return clusterNames, err
@@ -69,6 +69,9 @@ func ConfigTF(client *rancher.Client, rancherConfig *rancher.Config, terraformCo
 			return clusterNames, err
 		case module == modules.CustomEC2RKE2 || module == modules.CustomEC2K3s:
 			_, err = customV2.SetCustomRKE2K3s(rancherConfig, terraformConfig, terratestConfig, nil, clusterName, newFile, rootBody, file)
+			return clusterNames, err
+		case module == modules.AirgapRKE1:
+			_, err = airgap.SetAirgapRKE1(rancherConfig, terraformConfig, terratestConfig, nil, clusterName, newFile, rootBody, file)
 			return clusterNames, err
 		case module == modules.AirgapRKE2 || module == modules.AirgapK3S:
 			_, err = airgap.SetAirgapRKE2K3s(rancherConfig, terraformConfig, terratestConfig, nil, clusterName, newFile, rootBody, file)

--- a/tests/airgap/airgap_provisioning_test.go
+++ b/tests/airgap/airgap_provisioning_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/rancher/tfp-automation/framework"
 	"github.com/rancher/tfp-automation/framework/cleanup"
 	"github.com/rancher/tfp-automation/framework/set/resources/airgap"
-	resources "github.com/rancher/tfp-automation/framework/set/resources/airgap"
 	"github.com/rancher/tfp-automation/framework/set/resources/rancher2"
 	qase "github.com/rancher/tfp-automation/pipeline/qase/results"
 	"github.com/rancher/tfp-automation/tests/extensions/provisioning"
@@ -51,7 +50,7 @@ func (a *TfpAirgapProvisioningTestSuite) SetupSuite() {
 	standaloneTerraformOptions := framework.Setup(a.T(), a.terraformConfig, a.terratestConfig, keyPath)
 	a.standaloneTerraformOptions = standaloneTerraformOptions
 
-	registry, err := resources.CreateMainTF(a.T(), a.standaloneTerraformOptions, keyPath, a.terraformConfig, a.terratestConfig)
+	registry, err := airgap.CreateMainTF(a.T(), a.standaloneTerraformOptions, keyPath, a.terraformConfig, a.terratestConfig)
 	require.NoError(a.T(), err)
 
 	a.registry = registry
@@ -94,6 +93,7 @@ func (a *TfpAirgapProvisioningTestSuite) TestTfpAirgapProvisioning() {
 		name   string
 		module string
 	}{
+		{"RKE1", "airgap_rke1"},
 		{"RKE2", "airgap_rke2"},
 		{"K3S", "airgap_k3s"},
 	}
@@ -133,6 +133,7 @@ func (a *TfpAirgapProvisioningTestSuite) TestTfpAirgapUpgrading() {
 		name   string
 		module string
 	}{
+		{"Upgrading RKE1", "airgap_rke1"},
 		{"Upgrading RKE2", "airgap_rke2"},
 		{"Upgrading K3S", "airgap_k3s"},
 	}

--- a/tests/extensions/provisioning/supportedModules.go
+++ b/tests/extensions/provisioning/supportedModules.go
@@ -46,6 +46,7 @@ func verifyModule(module string) bool {
 		modules.CustomEC2RKE1,
 		modules.CustomEC2RKE2,
 		modules.CustomEC2K3s,
+		modules.AirgapRKE1,
 		modules.AirgapRKE2,
 		modules.AirgapK3S,
 	}

--- a/tests/infrastructure/README.md
+++ b/tests/infrastructure/README.md
@@ -199,7 +199,7 @@ export AWS_PROVIDER_VERSION=""
 
 See the below examples on how to run the tests:
 
-`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/infrastructure --junitfile results.xml --jsonfile results.json -- -timeout=3h -v -run "TestTfpProxyProvisioningTestSuite$"`
+`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/infrastructure --junitfile results.xml --jsonfile results.json -- -timeout=3h -v -run "TestProxyRancherTestSuite$"`
 
 ## Setup RKE1 Cluster
 


### PR DESCRIPTION
### Issue: N/A

### Description
For the airgap tests, we currently only support RKE2/K3s. While RKE1 is slated to be deprecated soon, we should still it for release testing purposes mainly in the meantime. This PR adds support for RKE1 to the airgap tests.

Additionally, this PR supports pulling and pushing images to private registries in parallel. We're starting off with 10 images at a time. If we see issues, we will decrease the number, but this help to speed up relevant tests.