### PR TITLE
Add support for imported clusters for RKE1/RKE2/K3S

### DIFF
--- a/defaults/keypath/keypath.go
+++ b/defaults/keypath/keypath.go
@@ -1,13 +1,14 @@
 package keypath
 
 const (
-	AirgapKeyPath   = "/go/src/github.com/rancher/tfp-automation/modules/airgap"
-	K3sKeyPath      = "/go/src/github.com/rancher/tfp-automation/modules/k3s"
-	ProxyKeyPath    = "/go/src/github.com/rancher/tfp-automation/modules/proxy"
-	RegistryKeyPath = "/go/src/github.com/rancher/tfp-automation/modules/registries"
-	RKEKeyPath      = "/go/src/github.com/rancher/tfp-automation/modules/rke"
-	RKE2KeyPath     = "/go/src/github.com/rancher/tfp-automation/modules/rke2"
-	RancherKeyPath  = "/go/src/github.com/rancher/tfp-automation/modules/rancher2"
-	SanityKeyPath   = "/go/src/github.com/rancher/tfp-automation/modules/sanity"
-	UpgradeKeyPath  = "/go/src/github.com/rancher/tfp-automation/modules/upgrade"
+	AirgapKeyPath     = "/go/src/github.com/rancher/tfp-automation/modules/airgap"
+	AirgapRKE2KeyPath = "/go/src/github.com/rancher/tfp-automation/modules/airgapRKE2"
+	K3sKeyPath        = "/go/src/github.com/rancher/tfp-automation/modules/k3s"
+	ProxyKeyPath      = "/go/src/github.com/rancher/tfp-automation/modules/proxy"
+	RegistryKeyPath   = "/go/src/github.com/rancher/tfp-automation/modules/registries"
+	RKEKeyPath        = "/go/src/github.com/rancher/tfp-automation/modules/rke"
+	RKE2KeyPath       = "/go/src/github.com/rancher/tfp-automation/modules/rke2"
+	RancherKeyPath    = "/go/src/github.com/rancher/tfp-automation/modules/rancher2"
+	SanityKeyPath     = "/go/src/github.com/rancher/tfp-automation/modules/sanity"
+	UpgradeKeyPath    = "/go/src/github.com/rancher/tfp-automation/modules/upgrade"
 )

--- a/defaults/modules/modules.go
+++ b/defaults/modules/modules.go
@@ -23,4 +23,7 @@ const (
 	AirgapRKE1    = "airgap_rke1"
 	AirgapRKE2    = "airgap_rke2"
 	AirgapK3S     = "airgap_k3s"
+	ImportRKE1    = "import_rke1"
+	ImportRKE2    = "import_rke2"
+	ImportK3s     = "import_k3s"
 )

--- a/framework/set/defaults/defaults.go
+++ b/framework/set/defaults/defaults.go
@@ -2,6 +2,7 @@ package defaults
 
 const (
 	Data         = "data"
+	Description  = "description"
 	Resource     = "resource"
 	ResourceKind = "kind"
 	ResourceName = "name"
@@ -16,6 +17,7 @@ const (
 	File         = "file"
 	Airgap       = "airgap"
 	Custom       = "custom"
+	Import       = "import"
 
 	Rancher2Source      = "rancher/rancher2"
 	Rancher2LocalSource = "terraform.local/local/rancher2"
@@ -87,6 +89,7 @@ const (
 	ControlPlaneRoleFlag     = "--controlplane"
 	WorkerRoleFlag           = "--worker"
 	OriginalNodeCommand      = "original_node_command"
+	InsecureCommand          = "insecure_command"
 	InsecureNodeCommand      = "insecure_node_command"
 	ClusterRegistrationToken = "cluster_registration_token"
 	NodeCommand              = "node_command"

--- a/framework/set/provisioning/airgap/setRKE1Config.go
+++ b/framework/set/provisioning/airgap/setRKE1Config.go
@@ -83,7 +83,7 @@ func SetAirgapRKE1(rancherConfig *rancher.Config, terraformConfig *config.Terraf
 
 	_, err = file.Write(newFile.Bytes())
 	if err != nil {
-		logrus.Infof("Failed to write custom RKE2/K3s configurations to main.tf file. Error: %v", err)
+		logrus.Infof("Failed to write airgap RKE2/K3s configurations to main.tf file. Error: %v", err)
 		return nil, err
 	}
 

--- a/framework/set/provisioning/airgap/setRKE2K3SConfig.go
+++ b/framework/set/provisioning/airgap/setRKE2K3SConfig.go
@@ -98,7 +98,7 @@ func SetAirgapRKE2K3s(rancherConfig *rancher.Config, terraformConfig *config.Ter
 
 	_, err = file.Write(newFile.Bytes())
 	if err != nil {
-		logrus.Infof("Failed to write custom RKE2/K3s configurations to main.tf file. Error: %v", err)
+		logrus.Infof("Failed to write airgap RKE2/K3s configurations to main.tf file. Error: %v", err)
 		return nil, err
 	}
 

--- a/framework/set/provisioning/imported/import-nodes.sh
+++ b/framework/set/provisioning/imported/import-nodes.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+PEM_FILE=$1
+USER=$2
+GROUP=$3
+NODE_ONE_PUBLIC_DNS=$4
+IMPORT_COMMAND=$5
+RKE_KUBE_CONFIG_FILE=${6}
+
+set -ex
+
+curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+mkdir -p ~/.kube
+rm kubectl
+
+if [ -n "${RKE_KUBE_CONFIG_FILE}" ]; then
+    echo "${RKE_KUBE_CONFIG_FILE}" > /home/$USER/.kube/config
+fi
+
+echo ${PEM_FILE} | sudo base64 -d > /home/${USER}/key.pem
+echo "${IMPORT_COMMAND}" > /home/${USER}/import_command.txt
+IMPORT_COMMAND=$(cat /home/$USER/import_command.txt)
+
+PEM=/home/${USER}/key.pem
+sudo chmod 600 ${PEM}
+sudo chown ${USER}:${GROUP} ${PEM}
+
+ssh -o ProxyCommand="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $PEM -W %h:%p $USER@$NODE_ONE_PUBLIC_DNS" \
+    -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $PEM $USER@$NODE_ONE_PUBLIC_DNS "$IMPORT_COMMAND"

--- a/framework/set/provisioning/imported/importNodes.go
+++ b/framework/set/provisioning/imported/importNodes.go
@@ -1,0 +1,92 @@
+package imported
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/modules"
+	"github.com/rancher/tfp-automation/framework/set/defaults"
+	"github.com/rancher/tfp-automation/framework/set/resources/imported"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// importNodes is a function that will import the nodes to the cluster
+func importNodes(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, nodeOnePublicDNS, kubeConfig, importCommand,
+	clusterName string) error {
+	userDir, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+
+	scriptPath := filepath.Join(userDir, "go/src/github.com/rancher/tfp-automation/framework/set/provisioning/imported/import-nodes.sh")
+
+	scriptContent, err := os.ReadFile(scriptPath)
+	if err != nil {
+		return err
+	}
+
+	privateKey, err := os.ReadFile(terraformConfig.PrivateKeyPath)
+	if err != nil {
+		return err
+	}
+
+	encodedPEMFile := base64.StdEncoding.EncodeToString([]byte(privateKey))
+
+	kubeConfig = `\"` + kubeConfig + `\"`
+	importCommand = `\"` + importCommand + `\"`
+
+	command := "bash -c '/tmp/import-nodes.sh " + encodedPEMFile + " " + terraformConfig.Standalone.OSUser + " " +
+		terraformConfig.Standalone.OSGroup + " " + nodeOnePublicDNS + " " + importCommand
+
+	if terraformConfig.Module == modules.ImportRKE1 {
+		command += " " + kubeConfig
+	}
+
+	command += "'"
+
+	// Need to first create a null resource block to copy the script to the node.
+	nullResourceBlockBody, provisionerBlockBody := imported.CreateImportedNullResource(rootBody, terraformConfig, nodeOnePublicDNS, clusterName)
+
+	provisionerBlockBody.SetAttributeValue(defaults.Inline, cty.ListVal([]cty.Value{
+		cty.StringVal("echo '" + string(scriptContent) + "' > /tmp/import-nodes.sh"),
+		cty.StringVal("chmod +x /tmp/import-nodes.sh"),
+	}))
+
+	var dependsOnServer string
+
+	if terraformConfig.Module == modules.ImportK3s || terraformConfig.Module == modules.ImportRKE2 {
+		dependsOnServer = `[` + defaults.NullResource + `.` + addServer + serverTwo + `, ` + defaults.NullResource + `.` + addServer + serverThree + `]`
+	} else {
+		dependsOnServer = `[` + defaults.RKECluster + `.` + defaults.RKECluster + `]`
+	}
+
+	server := hclwrite.Tokens{
+		{Type: hclsyntax.TokenIdent, Bytes: []byte(dependsOnServer)},
+	}
+
+	nullResourceBlockBody.SetAttributeRaw(defaults.DependsOn, server)
+
+	// A second null resource block is needed to properly run the script on the node. This is because the cluster registration
+	// token and RKE1 kube config will be not passed correctly as Bash parameters.
+	nullResourceBlockBody, provisionerBlockBody = imported.CreateImportedNullResource(rootBody, terraformConfig, nodeOnePublicDNS, cluster)
+
+	provisionerBlockBody.SetAttributeRaw(defaults.Inline, hclwrite.Tokens{
+		{Type: hclsyntax.TokenOQuote, Bytes: []byte(`["`), SpacesBefore: 1},
+		{Type: hclsyntax.TokenStringLit, Bytes: []byte(command)},
+		{Type: hclsyntax.TokenCQuote, Bytes: []byte(`"]`), SpacesBefore: 1},
+	})
+
+	dependsOnServer = `[` + defaults.NullResource + `.` + clusterName + `]`
+
+	server = hclwrite.Tokens{
+		{Type: hclsyntax.TokenIdent, Bytes: []byte(dependsOnServer)},
+	}
+
+	nullResourceBlockBody.SetAttributeRaw(defaults.DependsOn, server)
+
+	return nil
+}

--- a/framework/set/provisioning/imported/importedRKE1Config.go
+++ b/framework/set/provisioning/imported/importedRKE1Config.go
@@ -1,0 +1,97 @@
+package imported
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/framework/set/defaults"
+	"github.com/rancher/tfp-automation/framework/set/resources/sanity/aws"
+	"github.com/sirupsen/logrus"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// // SetImportedRKE1 is a function that will set the imported RKE1 cluster configurations in the main.tf file.
+func SetImportedRKE1(rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig,
+	clusterName string, newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File) (*os.File, error) {
+	SetImportedCluster(rootBody, clusterName)
+
+	rootBody.AppendNewline()
+
+	createRKE1Cluster(rootBody, terraformConfig, terratestConfig)
+
+	importCommand := getImportCommand(clusterName)
+
+	nodeOnePublicDNS := fmt.Sprintf("${%s.%s.public_dns}", defaults.AwsInstance, serverOne)
+	kubeConfig := fmt.Sprintf("${%s.%s.kube_config_yaml}", defaults.RKECluster, defaults.RKECluster)
+
+	err := importNodes(rootBody, terraformConfig, nodeOnePublicDNS, kubeConfig, importCommand[serverOne], clusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = file.Write(newFile.Bytes())
+	if err != nil {
+		logrus.Infof("Failed to write imported RKE1 configurations to main.tf file. Error: %v", err)
+		return nil, err
+	}
+
+	return file, nil
+}
+
+// createRKE1Cluster is a helper function that will create the RKE1 cluster.
+func createRKE1Cluster(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig) {
+	instances := []string{serverOne, serverTwo, serverThree}
+
+	for _, instance := range instances {
+		aws.CreateAWSInstances(rootBody, terraformConfig, terratestConfig, instance)
+		rootBody.AppendNewline()
+	}
+
+	rkeBlock := rootBody.AppendNewBlock(defaults.Resource, []string{defaults.RKECluster, defaults.RKECluster})
+	rkeBlockBody := rkeBlock.Body()
+
+	for _, instance := range instances {
+		nodesBlock := rkeBlockBody.AppendNewBlock(defaults.Nodes, nil)
+		nodesBlockBody := nodesBlock.Body()
+
+		addressExpression := `"${` + defaults.AwsInstance + "." + instance + ".public_ip" + `}"`
+		values := hclwrite.Tokens{
+			{Type: hclsyntax.TokenIdent, Bytes: []byte(addressExpression)},
+		}
+
+		nodesBlockBody.SetAttributeRaw(address, values)
+		nodesBlockBody.SetAttributeValue(user, cty.StringVal(terraformConfig.Standalone.OSUser))
+
+		rolesExpression := fmt.Sprintf(`["controlplane", "etcd", "worker"]`)
+		values = hclwrite.Tokens{
+			{Type: hclsyntax.TokenIdent, Bytes: []byte(rolesExpression)},
+		}
+
+		nodesBlockBody.SetAttributeRaw(role, values)
+
+		keyPathExpression := defaults.File + `("` + terraformConfig.PrivateKeyPath + `")`
+		keyPath := hclwrite.Tokens{
+			{Type: hclsyntax.TokenIdent, Bytes: []byte(keyPathExpression)},
+		}
+
+		nodesBlockBody.SetAttributeRaw(sshKey, keyPath)
+	}
+
+	rkeBlockBody.SetAttributeValue(enableCriDockerD, cty.BoolVal(true))
+
+	var dependsOnServer string
+
+	dependsOnServer = `[` + defaults.AwsInstance + `.` + serverOne + `, ` + defaults.AwsInstance + `.` + serverTwo + `, ` + defaults.AwsInstance + `.` + serverThree + `]`
+
+	server := hclwrite.Tokens{
+		{Type: hclsyntax.TokenIdent, Bytes: []byte(dependsOnServer)},
+	}
+
+	rkeBlockBody.SetAttributeRaw(defaults.DependsOn, server)
+
+	rootBody.AppendNewline()
+}

--- a/framework/set/provisioning/imported/importedRKE2K3SConfig.go
+++ b/framework/set/provisioning/imported/importedRKE2K3SConfig.go
@@ -1,0 +1,79 @@
+package imported
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/framework/set/defaults"
+	"github.com/rancher/tfp-automation/framework/set/resources/imported"
+	"github.com/rancher/tfp-automation/framework/set/resources/sanity/aws"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	address          = "address"
+	addServer        = "add_server_"
+	cluster          = "import_cluster"
+	enableCriDockerD = "enable_cri_dockerd"
+	role             = "role"
+	serverOne        = "server1"
+	serverTwo        = "server2"
+	serverThree      = "server3"
+	token            = "token"
+	sshKey           = "ssh_key"
+	user             = "user"
+)
+
+// // SetImportedRKE2K3s is a function that will set the imported RKE2/K3s cluster configurations in the main.tf file.
+func SetImportedRKE2K3s(rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig,
+	clusterName string, newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File) (*os.File, error) {
+	SetImportedCluster(rootBody, clusterName)
+
+	rootBody.AppendNewline()
+
+	instances := []string{serverOne, serverTwo, serverThree}
+
+	for _, instance := range instances {
+		aws.CreateAWSInstances(rootBody, terraformConfig, terratestConfig, instance)
+		rootBody.AppendNewline()
+	}
+
+	var nodeOnePublicDNS, nodeOnePrivateIP, nodeTwoPublicDNS, nodeThreePublicDNS string
+
+	nodeOnePrivateIP = fmt.Sprintf("${%s.%s.private_ip}", defaults.AwsInstance, serverOne)
+	nodeOnePublicDNS = fmt.Sprintf("${%s.%s.public_dns}", defaults.AwsInstance, serverOne)
+	nodeTwoPublicDNS = fmt.Sprintf("${%s.%s.public_dns}", defaults.AwsInstance, serverTwo)
+	nodeThreePublicDNS = fmt.Sprintf("${%s.%s.public_dns}", defaults.AwsInstance, serverThree)
+
+	imported.CreateRKE2K3SImportedCluster(rootBody, terraformConfig, nodeOnePublicDNS, nodeOnePrivateIP, nodeTwoPublicDNS, nodeThreePublicDNS)
+
+	rootBody.AppendNewline()
+
+	importCommand := getImportCommand(clusterName)
+
+	err := importNodes(rootBody, terraformConfig, nodeOnePublicDNS, "", importCommand[serverOne], clusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = file.Write(newFile.Bytes())
+	if err != nil {
+		logrus.Infof("Failed to write imported RKE2/K3s configurations to main.tf file. Error: %v", err)
+		return nil, err
+	}
+
+	return file, nil
+}
+
+// getImportCommand is a helper function that will return the import command for the cluster
+func getImportCommand(clusterName string) map[string]string {
+	command := make(map[string]string)
+	importCommand := fmt.Sprintf("${%s.%s.%s[0].%s}", defaults.Cluster, clusterName, defaults.ClusterRegistrationToken, defaults.InsecureCommand)
+
+	command[serverOne] = importCommand
+
+	return command
+}

--- a/framework/set/provisioning/imported/setImportedCluster.go
+++ b/framework/set/provisioning/imported/setImportedCluster.go
@@ -1,0 +1,18 @@
+package imported
+
+import (
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/rancher/tfp-automation/framework/set/defaults"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// SetImportedCluster is a function that will set the imported rancher2_cluster configurations in the main.tf file.
+func SetImportedCluster(rootBody *hclwrite.Body, clusterName string) error {
+	clusterBlock := rootBody.AppendNewBlock(defaults.Resource, []string{defaults.Cluster, clusterName})
+	clusterBlockBody := clusterBlock.Body()
+
+	clusterBlockBody.SetAttributeValue(defaults.ResourceName, cty.StringVal(clusterName))
+	clusterBlockBody.SetAttributeValue(defaults.Description, cty.StringVal("tfp-automation imported cluster"))
+
+	return nil
+}

--- a/framework/set/provisioning/multiclusters/setMultiCluster.go
+++ b/framework/set/provisioning/multiclusters/setMultiCluster.go
@@ -19,6 +19,7 @@ import (
 	custom "github.com/rancher/tfp-automation/framework/set/provisioning/custom/rke1"
 	customV2 "github.com/rancher/tfp-automation/framework/set/provisioning/custom/rke2k3s"
 	"github.com/rancher/tfp-automation/framework/set/provisioning/hosted"
+	"github.com/rancher/tfp-automation/framework/set/provisioning/imported"
 	nodedriver "github.com/rancher/tfp-automation/framework/set/provisioning/nodedriver/rke1"
 	nodedriverV2 "github.com/rancher/tfp-automation/framework/set/provisioning/nodedriver/rke2k3s"
 	"github.com/rancher/tfp-automation/framework/set/resources/rancher2"
@@ -100,6 +101,16 @@ func SetMultiCluster(client *rancher.Client, rancherConfig *rancher.Config, conf
 			}
 		case module == modules.AirgapRKE2 || module == modules.AirgapK3S:
 			file, err = airgap.SetAirgapRKE2K3s(rancherConfig, terraformConfig, terratestConfig, nil, clusterName, newFile, rootBody, file)
+			if err != nil {
+				return clusterNames, err
+			}
+		case module == modules.ImportRKE1:
+			file, err = imported.SetImportedRKE1(rancherConfig, terraformConfig, terratestConfig, clusterName, newFile, rootBody, file)
+			if err != nil {
+				return clusterNames, err
+			}
+		case module == modules.ImportRKE2 || module == modules.ImportK3s:
+			file, err = imported.SetImportedRKE2K3s(rancherConfig, terraformConfig, terratestConfig, clusterName, newFile, rootBody, file)
 			if err != nil {
 				return clusterNames, err
 			}

--- a/framework/set/resources/imported/createRKE2K3SCluster.go
+++ b/framework/set/resources/imported/createRKE2K3SCluster.go
@@ -1,0 +1,189 @@
+package imported
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/modules"
+	"github.com/rancher/tfp-automation/framework/set/defaults"
+	"github.com/zclconf/go-cty/cty"
+)
+
+const (
+	addServer     = "add_server"
+	createCluster = "create_cluster"
+	serverOne     = "server1"
+	serverTwo     = "server2"
+	serverThree   = "server3"
+	token         = "token"
+)
+
+// CreateRKE2K3SImportedCluster is a helper function that will create the RKE2/K3S cluster to be imported into Rancher.
+func CreateRKE2K3SImportedCluster(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, serverOnePublicDNS, serverOnePrivateIP,
+	serverTwoPublicDNS, serverThreePublicDNS string) {
+	userDir, err := os.UserHomeDir()
+	if err != nil {
+		return
+	}
+
+	var serverScriptPath, newServersScriptPath string
+
+	if terraformConfig.Module == modules.ImportK3s {
+		serverScriptPath = filepath.Join(userDir, "go/src/github.com/rancher/tfp-automation/framework/set/resources/k3s/init-server.sh")
+		newServersScriptPath = filepath.Join(userDir, "go/src/github.com/rancher/tfp-automation/framework/set/resources/k3s/add-servers.sh")
+	} else {
+		serverScriptPath = filepath.Join(userDir, "go/src/github.com/rancher/tfp-automation/framework/set/resources/rke2/init-server.sh")
+		newServersScriptPath = filepath.Join(userDir, "go/src/github.com/rancher/tfp-automation/framework/set/resources/rke2/add-servers.sh")
+	}
+
+	serverOneScriptContent, err := os.ReadFile(serverScriptPath)
+	if err != nil {
+		return
+	}
+
+	newServersScriptContent, err := os.ReadFile(newServersScriptPath)
+	if err != nil {
+		return
+	}
+
+	token := namegen.AppendRandomString(token)
+
+	createImportedRKE2K3SServer(rootBody, terraformConfig, serverOnePublicDNS, serverOnePrivateIP, token, serverOneScriptContent)
+	addImportedRKE2K3SServerNodes(rootBody, terraformConfig, serverOnePrivateIP, serverTwoPublicDNS, serverThreePublicDNS, token, newServersScriptContent)
+}
+
+// CreateImportedNullResource is a helper function that will create the null_resource for the cluster.
+func CreateImportedNullResource(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, instance, host string) (*hclwrite.Body, *hclwrite.Body) {
+	nullResourceBlock := rootBody.AppendNewBlock(defaults.Resource, []string{defaults.NullResource, host})
+	nullResourceBlockBody := nullResourceBlock.Body()
+
+	provisionerBlock := nullResourceBlockBody.AppendNewBlock(defaults.Provisioner, []string{defaults.RemoteExec})
+	provisionerBlockBody := provisionerBlock.Body()
+
+	connectionBlock := provisionerBlockBody.AppendNewBlock(defaults.Connection, nil)
+	connectionBlockBody := connectionBlock.Body()
+
+	hostExpression := `"` + instance + `"`
+
+	newHost := hclwrite.Tokens{
+		{Type: hclsyntax.TokenIdent, Bytes: []byte(hostExpression)},
+	}
+
+	connectionBlockBody.SetAttributeRaw(defaults.Host, newHost)
+
+	connectionBlockBody.SetAttributeValue(defaults.Type, cty.StringVal(defaults.Ssh))
+	connectionBlockBody.SetAttributeValue(defaults.User, cty.StringVal(terraformConfig.AWSConfig.AWSUser))
+
+	keyPathExpression := defaults.File + `("` + terraformConfig.PrivateKeyPath + `")`
+	keyPath := hclwrite.Tokens{
+		{Type: hclsyntax.TokenIdent, Bytes: []byte(keyPathExpression)},
+	}
+
+	connectionBlockBody.SetAttributeRaw(defaults.PrivateKey, keyPath)
+
+	dependsOnServer := `[` + defaults.AwsInstance + `.` + serverOne + `, ` + defaults.AwsInstance + `.` + serverTwo + `, ` + defaults.AwsInstance + `.` + serverThree + `]`
+
+	server := hclwrite.Tokens{
+		{Type: hclsyntax.TokenIdent, Bytes: []byte(dependsOnServer)},
+	}
+
+	nullResourceBlockBody.SetAttributeRaw(defaults.DependsOn, server)
+
+	rootBody.AppendNewline()
+
+	return nullResourceBlockBody, provisionerBlockBody
+}
+
+// createImportedRKE2K3SServer is a helper function that will create the server to be imported into Rancher.
+func createImportedRKE2K3SServer(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, serverOnePublicDNS, serverOnePrivateIP,
+	token string, script []byte) {
+	_, provisionerBlockBody := CreateImportedNullResource(rootBody, terraformConfig, serverOnePublicDNS, serverOne)
+
+	var version string
+
+	if terraformConfig.Module == modules.ImportK3s {
+		version = terraformConfig.Standalone.K3SVersion
+	} else {
+		version = terraformConfig.Standalone.RKE2Version
+	}
+
+	command := "bash -c '/tmp/init-server.sh " + terraformConfig.Standalone.OSUser + " " + terraformConfig.Standalone.OSGroup + " " +
+		version + " " + serverOnePrivateIP + " " + token + "'"
+
+	// For imported clusters, need to first put the script on the machine before running it.
+	provisionerBlockBody.SetAttributeValue(defaults.Inline, cty.ListVal([]cty.Value{
+		cty.StringVal("echo '" + string(script) + "' > /tmp/init-server.sh"),
+		cty.StringVal("chmod +x /tmp/init-server.sh"),
+	}))
+
+	nullResourceBlockBody, provisionerBlockBody := CreateImportedNullResource(rootBody, terraformConfig, serverOnePublicDNS, createCluster)
+
+	provisionerBlockBody.SetAttributeRaw(defaults.Inline, hclwrite.Tokens{
+		{Type: hclsyntax.TokenOQuote, Bytes: []byte(`["`), SpacesBefore: 1},
+		{Type: hclsyntax.TokenStringLit, Bytes: []byte(command)},
+		{Type: hclsyntax.TokenCQuote, Bytes: []byte(`"]`), SpacesBefore: 1},
+	})
+
+	dependsOnServer := `[` + defaults.NullResource + `.` + serverOne + `]`
+
+	server := hclwrite.Tokens{
+		{Type: hclsyntax.TokenIdent, Bytes: []byte(dependsOnServer)},
+	}
+
+	nullResourceBlockBody.SetAttributeRaw(defaults.DependsOn, server)
+}
+
+// addImportedServerNodes is a helper function that will add additional server nodes to the initial server.
+func addImportedRKE2K3SServerNodes(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, serverOnePrivateIP, serverTwoPublicDNS,
+	serverThreePublicDNS, token string, script []byte) {
+	instances := []string{serverTwoPublicDNS, serverThreePublicDNS}
+	hosts := []string{serverTwo, serverThree}
+
+	for i, instance := range instances {
+		host := hosts[i]
+		nullResourceBlockBody, provisionerBlockBody := CreateImportedNullResource(rootBody, terraformConfig, instance, host)
+
+		var version string
+
+		if terraformConfig.Module == modules.ImportK3s {
+			version = terraformConfig.Standalone.K3SVersion
+		} else {
+			version = terraformConfig.Standalone.RKE2Version
+		}
+
+		command := "bash -c '/tmp/add-servers.sh " + terraformConfig.Standalone.OSUser + " " + terraformConfig.Standalone.OSGroup + " " +
+			version + " " + serverOnePrivateIP + " " + token + "'"
+
+		provisionerBlockBody.SetAttributeValue(defaults.Inline, cty.ListVal([]cty.Value{
+			cty.StringVal("echo '" + string(script) + "' > /tmp/add-servers.sh"),
+			cty.StringVal("chmod +x /tmp/add-servers.sh"),
+		}))
+
+		dependsOnServer := `[` + defaults.NullResource + `.` + serverOne + `]`
+		server := hclwrite.Tokens{
+			{Type: hclsyntax.TokenIdent, Bytes: []byte(dependsOnServer)},
+		}
+
+		nullResourceBlockBody.SetAttributeRaw(defaults.DependsOn, server)
+
+		nullResourceBlockBody, provisionerBlockBody = CreateImportedNullResource(rootBody, terraformConfig, instance, addServer+"_"+host)
+
+		provisionerBlockBody.SetAttributeRaw(defaults.Inline, hclwrite.Tokens{
+			{Type: hclsyntax.TokenOQuote, Bytes: []byte(`["`), SpacesBefore: 1},
+			{Type: hclsyntax.TokenStringLit, Bytes: []byte(command)},
+			{Type: hclsyntax.TokenCQuote, Bytes: []byte(`"]`), SpacesBefore: 1},
+		})
+
+		dependsOnServer = `[` + defaults.NullResource + `.` + createCluster + `]`
+
+		server = hclwrite.Tokens{
+			{Type: hclsyntax.TokenIdent, Bytes: []byte(dependsOnServer)},
+		}
+
+		nullResourceBlockBody.SetAttributeRaw(defaults.DependsOn, server)
+	}
+}

--- a/framework/set/resources/k3s/createCluster.go
+++ b/framework/set/resources/k3s/createCluster.go
@@ -44,8 +44,8 @@ func CreateK3SCluster(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.
 
 	k3sToken := namegen.AppendRandomString(token)
 
-	createK3SServer(rootBody, terraformConfig, k3sServerOnePublicDNS, k3sServerOnePrivateIP, k3sToken, serverOneScriptContent)
-	addK3SServerNodes(rootBody, terraformConfig, k3sServerOnePrivateIP, k3sServerTwoPublicDNS, k3sServerThreePublicDNS, k3sToken, newServersScriptContent)
+	CreateK3SServer(rootBody, terraformConfig, k3sServerOnePublicDNS, k3sServerOnePrivateIP, k3sToken, serverOneScriptContent)
+	AddK3SServerNodes(rootBody, terraformConfig, k3sServerOnePrivateIP, k3sServerTwoPublicDNS, k3sServerThreePublicDNS, k3sToken, newServersScriptContent)
 
 	_, err = file.Write(newFile.Bytes())
 	if err != nil {
@@ -56,8 +56,8 @@ func CreateK3SCluster(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.
 	return file, nil
 }
 
-// createK3SServer is a helper function that will create the K3S server.
-func createK3SServer(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, k3sServerOnePublicDNS, k3sServerOnePrivateIP,
+// CreateK3SServer is a helper function that will create the K3S server.
+func CreateK3SServer(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, k3sServerOnePublicDNS, k3sServerOnePrivateIP,
 	k3sToken string, script []byte) {
 	_, provisionerBlockBody := rke2.CreateNullResource(rootBody, terraformConfig, k3sServerOnePublicDNS, k3sServerOne)
 
@@ -71,8 +71,8 @@ func createK3SServer(rootBody *hclwrite.Body, terraformConfig *config.TerraformC
 	}))
 }
 
-// addK3SServerNodes is a helper function that will add additional K3s server nodes to the initial K3s server.
-func addK3SServerNodes(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, k3sServerOnePrivateIP, k3sServerTwoPublicDNS,
+// AddK3SServerNodes is a helper function that will add additional K3s server nodes to the initial K3s server.
+func AddK3SServerNodes(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, k3sServerOnePrivateIP, k3sServerTwoPublicDNS,
 	k3sServerThreePublicDNS, k3sToken string, script []byte) {
 	instances := []string{k3sServerTwoPublicDNS, k3sServerThreePublicDNS}
 	hosts := []string{k3sServerTwo, k3sServerThree}

--- a/framework/set/resources/k3s/init-server.sh
+++ b/framework/set/resources/k3s/init-server.sh
@@ -13,3 +13,4 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=${K8S_VERSION} K3S_TOKEN=${K3
 sudo mkdir -p /home/${USER}/.kube
 sudo chown ${USER}:${GROUP} /etc/rancher/k3s/k3s.yaml
 sudo cp /etc/rancher/k3s/k3s.yaml /home/${USER}/.kube/config
+sudo chown ${USER}:${GROUP} /home/${USER}/.kube/config

--- a/framework/set/setConfigTF.go
+++ b/framework/set/setConfigTF.go
@@ -15,6 +15,7 @@ import (
 	custom "github.com/rancher/tfp-automation/framework/set/provisioning/custom/rke1"
 	customV2 "github.com/rancher/tfp-automation/framework/set/provisioning/custom/rke2k3s"
 	"github.com/rancher/tfp-automation/framework/set/provisioning/hosted"
+	"github.com/rancher/tfp-automation/framework/set/provisioning/imported"
 	"github.com/rancher/tfp-automation/framework/set/provisioning/multiclusters"
 	nodedriver "github.com/rancher/tfp-automation/framework/set/provisioning/nodedriver/rke1"
 	nodedriverV2 "github.com/rancher/tfp-automation/framework/set/provisioning/nodedriver/rke2k3s"
@@ -58,11 +59,11 @@ func ConfigTF(client *rancher.Client, rancherConfig *rancher.Config, terraformCo
 		case module == clustertypes.GKE:
 			_, err = hosted.SetGKE(terraformConfig, clusterName, terratestConfig.KubernetesVersion, terratestConfig.Nodepools, newFile, rootBody, file)
 			return clusterNames, err
-		case strings.Contains(module, clustertypes.RKE1) && !strings.Contains(module, defaults.Custom) && !strings.Contains(module, defaults.Airgap):
+		case strings.Contains(module, clustertypes.RKE1) && !strings.Contains(module, defaults.Custom) && !strings.Contains(module, defaults.Airgap) && !strings.Contains(module, defaults.Import):
 			_, err = nodedriver.SetRKE1(terraformConfig, clusterName, poolName, terratestConfig.KubernetesVersion, terratestConfig.PSACT, terratestConfig.Nodepools,
 				terratestConfig.SnapshotInput, newFile, rootBody, file, rbacRole)
 			return clusterNames, err
-		case (strings.Contains(module, clustertypes.RKE2) || strings.Contains(module, clustertypes.K3S)) && !strings.Contains(module, defaults.Custom) && !strings.Contains(module, defaults.Airgap):
+		case (strings.Contains(module, clustertypes.RKE2) || strings.Contains(module, clustertypes.K3S)) && !strings.Contains(module, defaults.Custom) && !strings.Contains(module, defaults.Airgap) && !strings.Contains(module, defaults.Import):
 			_, err = nodedriverV2.SetRKE2K3s(client, terraformConfig, clusterName, poolName, terratestConfig.KubernetesVersion, terratestConfig.PSACT, terratestConfig.Nodepools,
 				terratestConfig.SnapshotInput, newFile, rootBody, file, rbacRole)
 			return clusterNames, err
@@ -78,6 +79,13 @@ func ConfigTF(client *rancher.Client, rancherConfig *rancher.Config, terraformCo
 		case module == modules.AirgapRKE2 || module == modules.AirgapK3S:
 			_, err = airgap.SetAirgapRKE2K3s(rancherConfig, terraformConfig, terratestConfig, nil, clusterName, newFile, rootBody, file)
 			return clusterNames, err
+		case module == modules.ImportRKE1:
+			_, err = imported.SetImportedRKE1(rancherConfig, terraformConfig, terratestConfig, clusterName, newFile, rootBody, file)
+			return clusterNames, err
+		case module == modules.ImportRKE2 || module == modules.ImportK3s:
+			_, err = imported.SetImportedRKE2K3s(rancherConfig, terraformConfig, terratestConfig, clusterName, newFile, rootBody, file)
+			return clusterNames, err
+
 		default:
 			logrus.Errorf("Unsupported module: %v", module)
 		}

--- a/modules/airgapRKE2/main.tf
+++ b/modules/airgapRKE2/main.tf
@@ -1,0 +1,1 @@
+// Leave blank - main.tf will be set during testing

--- a/modules/airgapRKE2/outputs.tf
+++ b/modules/airgapRKE2/outputs.tf
@@ -1,0 +1,19 @@
+output "registry_public_dns" {
+  value = aws_instance.registry.public_dns
+}
+
+output "rke2_bastion_public_dns" {
+    value = aws_instance.rke2_bastion.public_dns
+}
+
+output "rke2_server1_private_ip" {
+  value = aws_instance.rke2_server1.private_ip
+}
+
+output "rke2_server2_private_ip" {
+  value = aws_instance.rke2_server2.private_ip
+}
+
+output "rke2_server3_private_ip" {
+  value = aws_instance.rke2_server3.private_ip
+}

--- a/tests/extensions/provisioning/supportedModules.go
+++ b/tests/extensions/provisioning/supportedModules.go
@@ -34,6 +34,9 @@ func verifyModule(module string) bool {
 		modules.EC2RKE1,
 		modules.EC2RKE2,
 		modules.EC2K3s,
+		modules.HarvesterRKE1,
+		modules.HarvesterRKE2,
+		modules.HarvesterK3s,
 		modules.LinodeRKE1,
 		modules.LinodeRKE2,
 		modules.LinodeK3s,
@@ -46,6 +49,9 @@ func verifyModule(module string) bool {
 		modules.AirgapRKE1,
 		modules.AirgapRKE2,
 		modules.AirgapK3S,
+		modules.ImportRKE1,
+		modules.ImportRKE2,
+		modules.ImportK3s,
 	}
 
 	for _, supportedModule := range supportedModules {

--- a/tests/infrastructure/setup_airgap_rke2_test.go
+++ b/tests/infrastructure/setup_airgap_rke2_test.go
@@ -34,7 +34,7 @@ func (i *CreateAirgappedRKE2ClusterTestSuite) TestCreateAirgappedRKE2Cluster() {
 	i.terratestConfig = new(config.TerratestConfig)
 	ranchFrame.LoadConfig(config.TerratestConfigurationFileKey, i.terratestConfig)
 
-	keyPath := rancher2.SetKeyPath(keypath.RKE2KeyPath)
+	keyPath := rancher2.SetKeyPath(keypath.AirgapRKE2KeyPath)
 	terraformOptions := framework.Setup(i.T(), i.terraformConfig, i.terratestConfig, keyPath)
 	i.terraformOptions = terraformOptions
 

--- a/tests/rancher2/provisioning/README.md
+++ b/tests/rancher2/provisioning/README.md
@@ -72,12 +72,62 @@ terratest:
   nodeCount: 3
 ```
 
+For running the imported clusters, reference the example config block below:
+
+```yaml
+rancher:
+  host: ""
+  adminToken: ""
+  cleanup: true
+terraform:
+  cloudCredentialName: ""
+  cni: ""
+  defaultClusterRoleForProjectMembers: "true"
+  enableNetworkPolicy: false
+  hostnamePrefix: ""
+  machineConfigName: ""
+  networkPlugin: ""
+  nodeTemplateName: ""
+  privateKeyPath: ""
+  awsCredentials:
+    awsAccessKey: ""
+    awsSecretKey: ""
+  awsConfig:
+    ami: ""
+    awsKeyName: ""
+    awsInstanceType: ""
+    region: ""
+    awsSecurityGroupNames: [""]
+    awsSubnetID: ""
+    awsVpcID: ""
+    awsZoneLetter: ""
+    awsRootSize: 100
+    region: ""
+    awsUser: ""
+    standaloneSecurityGroupNames: [""]
+    sshConnectionType: "ssh"
+    timeout: "5m"
+  standalone:
+    k3sVersion: ""                      # Ensure k3s1 suffix is appended (i.e. v1.30.9+k3s1)
+    osGroup: ""
+    osUser: ""
+    rke2Version: ""                     # Ensure rke2r1 suffix is appended (i.e. v1.30.9+rke2r1)
+terratest:
+  tfLogging: true
+```
+
+In addition, when running locally, you will need to ensure that you have `export RKE_PROVIDER_VERSION=x.xx.x` defined for the RKE1 portion of the test.
+
 See the below examples on how to run the tests:
 
 ### RKE1/RKE2/K3S
 
 `gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/rancher2/provisioning --junitfile results.xml --jsonfile results.json -- -timeout=60m -v -run "TestTfpProvisionTestSuite/TestTfpProvision$"` \
 `gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/rancher2/provisioning --junitfile results.xml --jsonfile results.json -- -timeout=60m -v -run "TestTfpProvisionTestSuite/TestTfpProvisionDynamicInput$"`
+
+### Imported
+
+`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/rancher2/provisioning --junitfile results.xml --jsonfile results.json -- -timeout=60m -v -run "TestTfpProvisionImportTestSuite/TestTfpProvisionImport$"`
 
 ### Hosted
 

--- a/tests/rancher2/provisioning/provision_hosted_test.go
+++ b/tests/rancher2/provisioning/provision_hosted_test.go
@@ -1,4 +1,4 @@
-package tests
+package provisioning
 
 import (
 	"testing"

--- a/tests/rancher2/provisioning/provision_import_test.go
+++ b/tests/rancher2/provisioning/provision_import_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/rancher/tfp-automation/defaults/configs"
 	"github.com/rancher/tfp-automation/defaults/keypath"
 	"github.com/rancher/tfp-automation/framework"
-	cleanup "github.com/rancher/tfp-automation/framework/cleanup"
+	"github.com/rancher/tfp-automation/framework/cleanup"
 	"github.com/rancher/tfp-automation/framework/set/resources/rancher2"
 	qase "github.com/rancher/tfp-automation/pipeline/qase/results"
 	"github.com/rancher/tfp-automation/tests/extensions/provisioning"
@@ -19,7 +19,7 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-type ProvisionTestSuite struct {
+type ProvisionImportTestSuite struct {
 	suite.Suite
 	client           *rancher.Client
 	session          *session.Session
@@ -29,7 +29,7 @@ type ProvisionTestSuite struct {
 	terraformOptions *terraform.Options
 }
 
-func (p *ProvisionTestSuite) SetupSuite() {
+func (p *ProvisionImportTestSuite) SetupSuite() {
 	testSession := session.NewSession()
 	p.session = testSession
 
@@ -56,55 +56,22 @@ func (p *ProvisionTestSuite) SetupSuite() {
 	keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath)
 	terraformOptions := framework.Setup(p.T(), p.terraformConfig, p.terratestConfig, keyPath)
 	p.terraformOptions = terraformOptions
-
-	provisioning.GetK8sVersion(p.T(), p.client, p.terratestConfig, p.terraformConfig, configs.DefaultK8sVersion)
 }
 
-func (p *ProvisionTestSuite) TestTfpProvision() {
-	nodeRolesDedicated := []config.Nodepool{config.EtcdNodePool, config.ControlPlaneNodePool, config.WorkerNodePool}
-
+func (p *ProvisionImportTestSuite) TestTfpProvisionImport() {
 	tests := []struct {
-		name      string
-		nodeRoles []config.Nodepool
+		name   string
+		module string
 	}{
-		{"3 nodes - 1 role per node " + config.StandardClientName.String(), nodeRolesDedicated},
+		{"RKE1", "import_rke1"},
+		{"RKE2", "import_rke2"},
+		{"K3S", "import_k3s"},
 	}
 
 	for _, tt := range tests {
 		terratestConfig := *p.terratestConfig
-		terratestConfig.Nodepools = tt.nodeRoles
-
-		tt.name = tt.name + " Module: " + p.terraformConfig.Module + " Kubernetes version: " + p.terratestConfig.KubernetesVersion
-
-		testUser, testPassword, clusterName, poolName := configs.CreateTestCredentials()
-
-		p.Run((tt.name), func() {
-			keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath)
-			defer cleanup.Cleanup(p.T(), p.terraformOptions, keyPath)
-
-			adminClient, err := provisioning.FetchAdminClient(p.T(), p.client)
-			require.NoError(p.T(), err)
-
-			clusterIDs := provisioning.Provision(p.T(), p.client, p.rancherConfig, p.terraformConfig, &terratestConfig, testUser, testPassword, clusterName, poolName, p.terraformOptions, nil)
-			provisioning.VerifyClustersState(p.T(), adminClient, clusterIDs)
-			provisioning.VerifyWorkloads(p.T(), adminClient, clusterIDs)
-		})
-	}
-
-	if p.terratestConfig.LocalQaseReporting {
-		qase.ReportTest()
-	}
-}
-
-func (p *ProvisionTestSuite) TestTfpProvisionDynamicInput() {
-	tests := []struct {
-		name string
-	}{
-		{config.StandardClientName.String()},
-	}
-
-	for _, tt := range tests {
-		tt.name = tt.name + " Module: " + p.terraformConfig.Module + " Kubernetes version: " + p.terratestConfig.KubernetesVersion
+		terraformConfig := *p.terraformConfig
+		terraformConfig.Module = tt.module
 
 		testUser, testPassword, clusterName, poolName := configs.CreateTestCredentials()
 
@@ -115,7 +82,7 @@ func (p *ProvisionTestSuite) TestTfpProvisionDynamicInput() {
 			adminClient, err := provisioning.FetchAdminClient(p.T(), p.client)
 			require.NoError(p.T(), err)
 
-			clusterIDs := provisioning.Provision(p.T(), p.client, p.rancherConfig, p.terraformConfig, p.terratestConfig, testUser, testPassword, clusterName, poolName, p.terraformOptions, nil)
+			clusterIDs := provisioning.Provision(p.T(), p.client, p.rancherConfig, &terraformConfig, &terratestConfig, testUser, testPassword, clusterName, poolName, p.terraformOptions, nil)
 			provisioning.VerifyClustersState(p.T(), adminClient, clusterIDs)
 			provisioning.VerifyWorkloads(p.T(), adminClient, clusterIDs)
 		})
@@ -126,6 +93,6 @@ func (p *ProvisionTestSuite) TestTfpProvisionDynamicInput() {
 	}
 }
 
-func TestTfpProvisionTestSuite(t *testing.T) {
-	suite.Run(t, new(ProvisionTestSuite))
+func TestTfpProvisionImportTestSuite(t *testing.T) {
+	suite.Run(t, new(ProvisionImportTestSuite))
 }

--- a/tests/rancher2/upgrading/kubernetes_hosted_test.go
+++ b/tests/rancher2/upgrading/kubernetes_hosted_test.go
@@ -1,4 +1,4 @@
-package tests
+package upgrading
 
 import (
 	"testing"

--- a/tests/rancher2/upgrading/kubernetes_upgrade_test.go
+++ b/tests/rancher2/upgrading/kubernetes_upgrade_test.go
@@ -1,4 +1,4 @@
-package tests
+package upgrading
 
 import (
 	"testing"


### PR DESCRIPTION
### Issue: [Add imported cluster tests to tfp-automation framework](https://github.com/rancher/qa-tasks/issues/1629)

### Description
Out of the broader effort to fully move away from Corral, one of the release test tasks is importing clusters. Not only is it using Corral, it is limited in only doing K3s. This PR goes and adds support for importing RKE1, RKE2 and K3s HA clusters.