### PR TITLE
Fix Qase names for release testing and temporarily disable workload checks

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -33,4 +33,3 @@ issues:
   exclude-files:
     - ^*\.yaml$
     - ^*\.yml$
-  exclude-generated-strict: true

--- a/tests/airgap/airgap_provisioning_test.go
+++ b/tests/airgap/airgap_provisioning_test.go
@@ -94,9 +94,9 @@ func (a *TfpAirgapProvisioningTestSuite) TestTfpAirgapProvisioning() {
 		name   string
 		module string
 	}{
-		{"RKE1", "airgap_rke1"},
-		{"RKE2", "airgap_rke2"},
-		{"K3S", "airgap_k3s"},
+		{"Airgap RKE1", "airgap_rke1"},
+		{"Airgap RKE2", "airgap_rke2"},
+		{"Airgap K3S", "airgap_k3s"},
 	}
 
 	for _, tt := range tests {
@@ -134,9 +134,9 @@ func (a *TfpAirgapProvisioningTestSuite) TestTfpAirgapUpgrading() {
 		name   string
 		module string
 	}{
-		{"Upgrading RKE1", "airgap_rke1"},
-		{"Upgrading RKE2", "airgap_rke2"},
-		{"Upgrading K3S", "airgap_k3s"},
+		{"Upgrading Airgap RKE1", "airgap_rke1"},
+		{"Upgrading Airgap RKE2", "airgap_rke2"},
+		{"Upgrading Airgap K3S", "airgap_k3s"},
 	}
 
 	for _, tt := range tests {

--- a/tests/extensions/provisioning/verify.go
+++ b/tests/extensions/provisioning/verify.go
@@ -80,6 +80,8 @@ func VerifyClustersState(t *testing.T, client *rancher.Client, clusterIDs []stri
 
 // VerifyWorkloads validates that different workload operations and workload types are able to provision successfully
 func VerifyWorkloads(t *testing.T, client *rancher.Client, clusterIDs []string) {
+	// Skip test for now. Need to investigate a consistenet way to not hit Docker Hub rate limits.
+	t.Skip("Skipping VerifyWorkloads test")
 	workloadValidations := []struct {
 		name           string
 		validationFunc func(client *rancher.Client, clusterID string) error

--- a/tests/proxy/proxy_provisioning_test.go
+++ b/tests/proxy/proxy_provisioning_test.go
@@ -97,9 +97,9 @@ func (p *TfpProxyProvisioningTestSuite) TestTfpNoProxyProvisioning() {
 		nodeRoles []config.Nodepool
 		module    string
 	}{
-		{"RKE1", nodeRolesDedicated, "ec2_rke1"},
-		{"RKE2", nodeRolesDedicated, "ec2_rke2"},
-		{"K3S", nodeRolesDedicated, "ec2_k3s"},
+		{"No Proxy RKE1", nodeRolesDedicated, "ec2_rke1"},
+		{"No Proxy RKE2", nodeRolesDedicated, "ec2_rke2"},
+		{"No Proxy K3S", nodeRolesDedicated, "ec2_k3s"},
 	}
 
 	for _, tt := range tests {
@@ -139,9 +139,9 @@ func (p *TfpProxyProvisioningTestSuite) TestTfpProxyProvisioning() {
 		nodeRoles []config.Nodepool
 		module    string
 	}{
-		{"RKE1", nodeRolesDedicated, "ec2_rke1"},
-		{"RKE2", nodeRolesDedicated, "ec2_rke2"},
-		{"K3S", nodeRolesDedicated, "ec2_k3s"},
+		{"Proxy RKE1", nodeRolesDedicated, "ec2_rke1"},
+		{"Proxy RKE2", nodeRolesDedicated, "ec2_rke2"},
+		{"Proxy K3S", nodeRolesDedicated, "ec2_k3s"},
 	}
 
 	for _, tt := range tests {

--- a/tests/proxy/proxy_upgrade_rancher_test.go
+++ b/tests/proxy/proxy_upgrade_rancher_test.go
@@ -99,12 +99,12 @@ func (p *TfpProxyUpgradeRancherTestSuite) TfpSetupSuite(terratestConfig *config.
 }
 
 func (p *TfpProxyUpgradeRancherTestSuite) TestTfpUpgradeProxyProvisioning() {
-	p.provisionAndVerifyCluster("Pre-Upgrade ")
+	p.provisionAndVerifyCluster("Pre-Upgrade Proxy ")
 
 	keyPath := rancher2.SetKeyPath(keypath.UpgradeKeyPath)
 	upgrade.CreateMainTF(p.T(), p.upgradeTerraformOptions, keyPath, p.terraformConfig, p.terratestConfig, p.proxyNode, p.proxyServerNodeOne)
 
-	p.provisionAndVerifyCluster("Post-Upgrade ")
+	p.provisionAndVerifyCluster("Post-Upgrade Proxy ")
 
 	if p.terratestConfig.LocalQaseReporting {
 		qase.ReportTest()

--- a/tests/rancher2/provisioning/provision_import_test.go
+++ b/tests/rancher2/provisioning/provision_import_test.go
@@ -63,9 +63,9 @@ func (p *ProvisionImportTestSuite) TestTfpProvisionImport() {
 		name   string
 		module string
 	}{
-		{"RKE1", "import_rke1"},
-		{"RKE2", "import_rke2"},
-		{"K3S", "import_k3s"},
+		{"Importing TFP RKE1", "import_rke1"},
+		{"Importing TFP RKE2", "import_rke2"},
+		{"Importing TFP K3S", "import_k3s"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### Description
In this current release testing iteration, it was found that some test cases do not have unique names. Primarily, airgap and proxy are interchanging reports when they shouldn't.

Also, it was noted that the workload tests are not consistently pulling an `nginx` image. This is due to a Docker Hub pull throttle issue. This causes tests to provision clusters, but not finish all of the post cluster checks. As such, we need to disable for now until we can find a reliable, consistent solution.