### PR TITLE
Remove the workloads function from each test

### DIFF
--- a/tests/airgap/airgap_provisioning_test.go
+++ b/tests/airgap/airgap_provisioning_test.go
@@ -120,7 +120,6 @@ func (a *TfpAirgapProvisioningTestSuite) TestTfpAirgapProvisioning() {
 
 			clusterIDs := provisioning.Provision(a.T(), a.client, a.rancherConfig, &terraformConfig, &terratestConfig, testUser, testPassword, clusterName, poolName, a.terraformOptions, nil)
 			provisioning.VerifyClustersState(a.T(), a.client, clusterIDs)
-			provisioning.VerifyWorkloads(a.T(), a.client, clusterIDs)
 		})
 	}
 
@@ -160,11 +159,9 @@ func (a *TfpAirgapProvisioningTestSuite) TestTfpAirgapUpgrading() {
 
 			clusterIDs := provisioning.Provision(a.T(), a.client, a.rancherConfig, &terraformConfig, &terratestConfig, testUser, testPassword, clusterName, poolName, a.terraformOptions, nil)
 			provisioning.VerifyClustersState(a.T(), a.client, clusterIDs)
-			provisioning.VerifyWorkloads(a.T(), a.client, clusterIDs)
 
 			provisioning.KubernetesUpgrade(a.T(), a.client, a.rancherConfig, &terraformConfig, &terratestConfig, testUser, testPassword, clusterName, poolName, a.terraformOptions)
 			provisioning.VerifyClustersState(a.T(), a.client, clusterIDs)
-			provisioning.VerifyWorkloads(a.T(), a.client, clusterIDs)
 		})
 	}
 

--- a/tests/extensions/provisioning/verify.go
+++ b/tests/extensions/provisioning/verify.go
@@ -80,8 +80,6 @@ func VerifyClustersState(t *testing.T, client *rancher.Client, clusterIDs []stri
 
 // VerifyWorkloads validates that different workload operations and workload types are able to provision successfully
 func VerifyWorkloads(t *testing.T, client *rancher.Client, clusterIDs []string) {
-	// Skip test for now. Need to investigate a consistenet way to not hit Docker Hub rate limits.
-	t.Skip("Skipping VerifyWorkloads test")
 	workloadValidations := []struct {
 		name           string
 		validationFunc func(client *rancher.Client, clusterID string) error

--- a/tests/proxy/proxy_provisioning_test.go
+++ b/tests/proxy/proxy_provisioning_test.go
@@ -122,7 +122,6 @@ func (p *TfpProxyProvisioningTestSuite) TestTfpNoProxyProvisioning() {
 
 			clusterIDs := provisioning.Provision(p.T(), p.client, p.rancherConfig, &terraformConfig, &terratestConfig, testUser, testPassword, clusterName, poolName, p.terraformOptions, nil)
 			provisioning.VerifyClustersState(p.T(), p.client, clusterIDs)
-			provisioning.VerifyWorkloads(p.T(), p.client, clusterIDs)
 		})
 	}
 
@@ -164,7 +163,6 @@ func (p *TfpProxyProvisioningTestSuite) TestTfpProxyProvisioning() {
 
 			clusterIDs := provisioning.Provision(p.T(), p.client, p.rancherConfig, &terraformConfig, &terratestConfig, testUser, testPassword, clusterName, poolName, p.terraformOptions, nil)
 			provisioning.VerifyClustersState(p.T(), p.client, clusterIDs)
-			provisioning.VerifyWorkloads(p.T(), p.client, clusterIDs)
 		})
 	}
 

--- a/tests/proxy/proxy_upgrade_rancher_test.go
+++ b/tests/proxy/proxy_upgrade_rancher_test.go
@@ -144,7 +144,6 @@ func (p *TfpProxyUpgradeRancherTestSuite) provisionAndVerifyCluster(name string)
 
 			clusterIDs := provisioning.Provision(p.T(), p.client, p.rancherConfig, &terraformConfig, &terratestConfig, testUser, testPassword, clusterName, poolName, p.terraformOptions, nil)
 			provisioning.VerifyClustersState(p.T(), p.client, clusterIDs)
-			provisioning.VerifyWorkloads(p.T(), p.client, clusterIDs)
 		})
 	}
 }

--- a/tests/rancher2/nodescaling/scale_test.go
+++ b/tests/rancher2/nodescaling/scale_test.go
@@ -102,7 +102,6 @@ func (s *ScaleTestSuite) TestTfpScale() {
 
 			clusterIDs := provisioning.Provision(s.T(), s.client, s.rancherConfig, s.terraformConfig, &terratestConfig, testUser, testPassword, clusterName, poolName, s.terraformOptions, nil)
 			provisioning.VerifyClustersState(s.T(), adminClient, clusterIDs)
-			provisioning.VerifyWorkloads(s.T(), adminClient, clusterIDs)
 
 			terratestConfig.Nodepools = tt.scaleUpNodeRoles
 
@@ -150,7 +149,6 @@ func (s *ScaleTestSuite) TestTfpScaleDynamicInput() {
 
 			clusterIDs := provisioning.Provision(s.T(), s.client, s.rancherConfig, s.terraformConfig, s.terratestConfig, testUser, testPassword, clusterName, poolName, s.terraformOptions, nil)
 			provisioning.VerifyClustersState(s.T(), adminClient, clusterIDs)
-			provisioning.VerifyWorkloads(s.T(), adminClient, clusterIDs)
 
 			s.terratestConfig.Nodepools = s.terratestConfig.ScalingInput.ScaledUpNodepools
 

--- a/tests/rancher2/provisioning/provision_import_test.go
+++ b/tests/rancher2/provisioning/provision_import_test.go
@@ -84,7 +84,6 @@ func (p *ProvisionImportTestSuite) TestTfpProvisionImport() {
 
 			clusterIDs := provisioning.Provision(p.T(), p.client, p.rancherConfig, &terraformConfig, &terratestConfig, testUser, testPassword, clusterName, poolName, p.terraformOptions, nil)
 			provisioning.VerifyClustersState(p.T(), adminClient, clusterIDs)
-			provisioning.VerifyWorkloads(p.T(), adminClient, clusterIDs)
 		})
 	}
 

--- a/tests/rancher2/rbac/rbac_test.go
+++ b/tests/rancher2/rbac/rbac_test.go
@@ -89,7 +89,6 @@ func (r *RBACTestSuite) TestTfpRBAC() {
 
 			clusterIDs := provisioning.Provision(r.T(), r.client, r.rancherConfig, r.terraformConfig, &terratestConfig, testUser, testPassword, clusterName, poolName, r.terraformOptions, nil)
 			provisioning.VerifyClustersState(r.T(), adminClient, clusterIDs)
-			provisioning.VerifyWorkloads(r.T(), adminClient, clusterIDs)
 
 			rb.RBAC(r.T(), r.client, r.rancherConfig, r.terraformConfig, &terratestConfig, testUser, testPassword, clusterName, poolName, r.terraformOptions, tt.rbacRole)
 			provisioning.VerifyClustersState(r.T(), adminClient, clusterIDs)

--- a/tests/rancher2/snapshot/snapshot_restore_test.go
+++ b/tests/rancher2/snapshot/snapshot_restore_test.go
@@ -100,7 +100,6 @@ func (s *SnapshotRestoreTestSuite) TestTfpSnapshotRestore() {
 
 			clusterIDs := provisioning.Provision(s.T(), s.client, s.rancherConfig, s.terraformConfig, &terratestConfig, testUser, testPassword, clusterName, poolName, s.terraformOptions, nil)
 			provisioning.VerifyClustersState(s.T(), adminClient, clusterIDs)
-			provisioning.VerifyWorkloads(s.T(), adminClient, clusterIDs)
 
 			snapshotRestore(s.T(), s.client, s.rancherConfig, s.terraformConfig, &terratestConfig, testUser, testPassword, clusterName, poolName, s.terraformOptions)
 			provisioning.VerifyClustersState(s.T(), adminClient, clusterIDs)
@@ -137,7 +136,6 @@ func (s *SnapshotRestoreTestSuite) TestTfpSnapshotRestoreDynamicInput() {
 
 			clusterIDs := provisioning.Provision(s.T(), s.client, s.rancherConfig, s.terraformConfig, s.terratestConfig, testUser, testPassword, clusterName, poolName, s.terraformOptions, nil)
 			provisioning.VerifyClustersState(s.T(), adminClient, clusterIDs)
-			provisioning.VerifyWorkloads(s.T(), adminClient, clusterIDs)
 
 			snapshotRestore(s.T(), s.client, s.rancherConfig, s.terraformConfig, s.terratestConfig, testUser, testPassword, clusterName, poolName, s.terraformOptions)
 			provisioning.VerifyClustersState(s.T(), adminClient, clusterIDs)

--- a/tests/rancher2/upgrading/kubernetes_upgrade_test.go
+++ b/tests/rancher2/upgrading/kubernetes_upgrade_test.go
@@ -87,7 +87,6 @@ func (k *KubernetesUpgradeTestSuite) TestTfpKubernetesUpgrade() {
 
 			clusterIDs := provisioning.Provision(k.T(), k.client, k.rancherConfig, k.terraformConfig, &terratestConfig, testUser, testPassword, clusterName, poolName, k.terraformOptions, nil)
 			provisioning.VerifyClustersState(k.T(), adminClient, clusterIDs)
-			provisioning.VerifyWorkloads(k.T(), adminClient, clusterIDs)
 
 			provisioning.KubernetesUpgrade(k.T(), k.client, k.rancherConfig, k.terraformConfig, &terratestConfig, testUser, testPassword, clusterName, poolName, k.terraformOptions)
 			provisioning.VerifyClustersState(k.T(), adminClient, clusterIDs)
@@ -121,7 +120,6 @@ func (k *KubernetesUpgradeTestSuite) TestTfpKubernetesUpgradeDynamicInput() {
 
 			clusterIDs := provisioning.Provision(k.T(), k.client, k.rancherConfig, k.terraformConfig, k.terratestConfig, testUser, testPassword, clusterName, poolName, k.terraformOptions, nil)
 			provisioning.VerifyClustersState(k.T(), adminClient, clusterIDs)
-			provisioning.VerifyWorkloads(k.T(), adminClient, clusterIDs)
 
 			provisioning.KubernetesUpgrade(k.T(), k.client, k.rancherConfig, k.terraformConfig, k.terratestConfig, testUser, testPassword, clusterName, poolName, k.terraformOptions)
 			provisioning.VerifyClustersState(k.T(), adminClient, clusterIDs)

--- a/tests/registries/registries_test.go
+++ b/tests/registries/registries_test.go
@@ -133,7 +133,6 @@ func (r *TfpRegistriesTestSuite) TestTfpGlobalRegistry() {
 			clusterIDs := provisioning.Provision(r.T(), r.client, r.rancherConfig, &terraformConfig, &terratestConfig, testUser, testPassword, clusterName, poolName, r.terraformOptions, nil)
 			provisioning.VerifyClustersState(r.T(), r.client, clusterIDs)
 			provisioning.VerifyRegistry(r.T(), r.client, clusterIDs[0], &terraformConfig)
-			provisioning.VerifyWorkloads(r.T(), r.client, clusterIDs)
 		})
 	}
 
@@ -180,7 +179,6 @@ func (r *TfpRegistriesTestSuite) TestTfpAuthenticatedRegistry() {
 			clusterIDs := provisioning.Provision(r.T(), r.client, r.rancherConfig, &terraformConfig, &terratestConfig, testUser, testPassword, clusterName, poolName, r.terraformOptions, nil)
 			provisioning.VerifyClustersState(r.T(), r.client, clusterIDs)
 			provisioning.VerifyRegistry(r.T(), r.client, clusterIDs[0], &terraformConfig)
-			provisioning.VerifyWorkloads(r.T(), r.client, clusterIDs)
 		})
 	}
 
@@ -229,7 +227,6 @@ func (r *TfpRegistriesTestSuite) TestTfpNonAuthenticatedRegistry() {
 			clusterIDs := provisioning.Provision(r.T(), r.client, r.rancherConfig, &terraformConfig, &terratestConfig, testUser, testPassword, clusterName, poolName, r.terraformOptions, nil)
 			provisioning.VerifyClustersState(r.T(), r.client, clusterIDs)
 			provisioning.VerifyRegistry(r.T(), r.client, clusterIDs[0], &terraformConfig)
-			provisioning.VerifyWorkloads(r.T(), r.client, clusterIDs)
 		})
 	}
 


### PR DESCRIPTION
### Description
The previous PR that aimed to skip the workload tests was actually marking the whole test as skipped. To get around this, we're just going to remove the call from the relevant release testing based tests.