### PR TITLE
Fix rke1 SSH user and add volumeType

### DIFF
--- a/config/nodeproviders/aws/awsConfig.go
+++ b/config/nodeproviders/aws/awsConfig.go
@@ -4,6 +4,7 @@ type Config struct {
 	AMI                          string   `json:"ami,omitempty" yaml:"ami,omitempty"`
 	AWSInstanceType              string   `json:"awsInstanceType,omitempty" yaml:"awsInstanceType,omitempty"`
 	AWSKeyName                   string   `json:"awsKeyName,omitempty" yaml:"awsKeyName,omitempty"`
+	AWSVolumeType                string   `json:"awsVolumeType,omitempty" yaml:"awsVolumeType,omitempty"`
 	AWSRootSize                  int64    `json:"awsRootSize,omitempty" yaml:"awsRootSize,omitempty"`
 	AWSSecurityGroupNames        []string `json:"awsSecurityGroupNames,omitempty" yaml:"awsSecurityGroupNames,omitempty"`
 	AWSSecurityGroups            []string `json:"awsSecurityGroups,omitempty" yaml:"awsSecurityGroups,omitempty"`

--- a/defaults/resourceblocks/nodeproviders/amazon/amazonBlocks.go
+++ b/defaults/resourceblocks/nodeproviders/amazon/amazonBlocks.go
@@ -21,6 +21,8 @@ const (
 
 	NodeGroups   = "node_groups"
 	InstanceType = "instance_type"
+	VolumeType   = "volume_type"
+	SSHUser      = "ssh_user"
 	DesiredSize  = "desired_size"
 	MaxSize      = "max_size"
 	MinSize      = "min_size"

--- a/framework/set/provisioning/nodedriver/rke1/setConfig.go
+++ b/framework/set/provisioning/nodedriver/rke1/setConfig.go
@@ -114,7 +114,7 @@ func SetRKE1(terraformConfig *config.TerraformConfig, clusterName, poolName, k8s
 	networkBlock := rkeConfigBlockBody.AppendNewBlock(defaults.Network, nil)
 	networkBlockBody := networkBlock.Body()
 
-	networkBlockBody.SetAttributeValue(defaults.Plugin, cty.StringVal(terraformConfig.NetworkPlugin))
+	networkBlockBody.SetAttributeValue(defaults.Plugin, cty.StringVal(terraformConfig.CNI))
 
 	rootBody.AppendNewline()
 

--- a/framework/set/provisioning/providers/aws/awsMachineConfig.go
+++ b/framework/set/provisioning/providers/aws/awsMachineConfig.go
@@ -17,8 +17,12 @@ func SetAWSRKE2K3SMachineConfig(machineConfigBlockBody *hclwrite.Body, terraform
 	awsConfigBlock := machineConfigBlockBody.AppendNewBlock(amazon.EC2Config, nil)
 	awsConfigBlockBody := awsConfigBlock.Body()
 
-	awsConfigBlockBody.SetAttributeValue(amazon.AMI, cty.StringVal(terraformConfig.AWSConfig.AMI))
 	awsConfigBlockBody.SetAttributeValue(defaults.Region, cty.StringVal(terraformConfig.AWSConfig.Region))
+	awsConfigBlockBody.SetAttributeValue(amazon.AMI, cty.StringVal(terraformConfig.AWSConfig.AMI))
+	awsConfigBlockBody.SetAttributeValue(amazon.InstanceType, cty.StringVal(terraformConfig.AWSConfig.AWSInstanceType))
+	awsConfigBlockBody.SetAttributeValue(amazon.SSHUser, cty.StringVal(terraformConfig.AWSConfig.AWSUser))
+	awsConfigBlockBody.SetAttributeValue(amazon.VolumeType, cty.StringVal(terraformConfig.AWSConfig.AWSVolumeType))
+	awsConfigBlockBody.SetAttributeValue(amazon.RootSize, cty.NumberIntVal(terraformConfig.AWSConfig.AWSRootSize))
 
 	awsSecGroupsExpression := fmt.Sprintf(`["%s"]`, terraformConfig.AWSConfig.AWSSecurityGroupNames[0])
 	awsSecGroupsList := hclwrite.Tokens{
@@ -29,6 +33,4 @@ func SetAWSRKE2K3SMachineConfig(machineConfigBlockBody *hclwrite.Body, terraform
 	awsConfigBlockBody.SetAttributeValue(amazon.SubnetID, cty.StringVal(terraformConfig.AWSConfig.AWSSubnetID))
 	awsConfigBlockBody.SetAttributeValue(amazon.VPCID, cty.StringVal(terraformConfig.AWSConfig.AWSVpcID))
 	awsConfigBlockBody.SetAttributeValue(amazon.Zone, cty.StringVal(terraformConfig.AWSConfig.AWSZoneLetter))
-	awsConfigBlockBody.SetAttributeValue(amazon.RootSize, cty.NumberIntVal(terraformConfig.AWSConfig.AWSRootSize))
-	awsConfigBlockBody.SetAttributeValue(amazon.InstanceType, cty.StringVal(terraformConfig.AWSConfig.AWSInstanceType))
 }

--- a/framework/set/provisioning/providers/aws/awsProviders.go
+++ b/framework/set/provisioning/providers/aws/awsProviders.go
@@ -19,11 +19,13 @@ func SetAWSRKE1Provider(nodeTemplateBlockBody *hclwrite.Body, terraformConfig *c
 
 	awsConfigBlockBody.SetAttributeValue(defaults.AccessKey, cty.StringVal(terraformConfig.AWSCredentials.AWSAccessKey))
 	awsConfigBlockBody.SetAttributeValue(defaults.SecretKey, cty.StringVal(terraformConfig.AWSCredentials.AWSSecretKey))
-
-	awsConfigBlockBody.SetAttributeValue(defaults.AccessKey, cty.StringVal(terraformConfig.AWSCredentials.AWSAccessKey))
-	awsConfigBlockBody.SetAttributeValue(defaults.SecretKey, cty.StringVal(terraformConfig.AWSCredentials.AWSSecretKey))
-	awsConfigBlockBody.SetAttributeValue(amazon.AMI, cty.StringVal(terraformConfig.AWSConfig.AMI))
 	awsConfigBlockBody.SetAttributeValue(defaults.Region, cty.StringVal(terraformConfig.AWSConfig.Region))
+
+	awsConfigBlockBody.SetAttributeValue(amazon.AMI, cty.StringVal(terraformConfig.AWSConfig.AMI))
+	awsConfigBlockBody.SetAttributeValue(amazon.InstanceType, cty.StringVal(terraformConfig.AWSConfig.AWSInstanceType))
+	awsConfigBlockBody.SetAttributeValue(amazon.SSHUser, cty.StringVal(terraformConfig.AWSConfig.AWSUser))
+	awsConfigBlockBody.SetAttributeValue(amazon.VolumeType, cty.StringVal(terraformConfig.AWSConfig.AWSVolumeType))
+	awsConfigBlockBody.SetAttributeValue(amazon.RootSize, cty.NumberIntVal(terraformConfig.AWSConfig.AWSRootSize))
 
 	awsSecGroupsExpression := fmt.Sprintf(`["%s"]`, terraformConfig.AWSConfig.AWSSecurityGroupNames[0])
 	awsSecGroupsList := hclwrite.Tokens{
@@ -34,8 +36,6 @@ func SetAWSRKE1Provider(nodeTemplateBlockBody *hclwrite.Body, terraformConfig *c
 	awsConfigBlockBody.SetAttributeValue(amazon.SubnetID, cty.StringVal(terraformConfig.AWSConfig.AWSSubnetID))
 	awsConfigBlockBody.SetAttributeValue(amazon.VPCID, cty.StringVal(terraformConfig.AWSConfig.AWSVpcID))
 	awsConfigBlockBody.SetAttributeValue(amazon.Zone, cty.StringVal(terraformConfig.AWSConfig.AWSZoneLetter))
-	awsConfigBlockBody.SetAttributeValue(amazon.RootSize, cty.NumberIntVal(terraformConfig.AWSConfig.AWSRootSize))
-	awsConfigBlockBody.SetAttributeValue(amazon.InstanceType, cty.StringVal(terraformConfig.AWSConfig.AWSInstanceType))
 }
 
 // SetAWSRKE2K3SProvider is a helper function that will set the AWS RKE2/K3S

--- a/tests/airgap/README.md
+++ b/tests/airgap/README.md
@@ -41,7 +41,7 @@ terraform:
   hostnamePrefix: ""                              # REQUIRED - fill with desired value
   machineConfigName: ""                           # REQUIRED - fill with desired value
   module: ""                                      # REQUIRED - leave this field empty as shown
-  networkPlugin: ""                               # REQUIRED - fill with desired value
+  cni: ""                                         # REQUIRED - fill with desired value
   nodeTemplateName: ""                            # REQUIRED - fill with desired value
   privateKeyPath: ""                              # REQUIRED - specify private key that will be used to access created instances
   privateRegistries:

--- a/tests/proxy/README.md
+++ b/tests/proxy/README.md
@@ -41,7 +41,7 @@ terraform:
   hostnamePrefix: ""                              # REQUIRED - fill with desired value
   machineConfigName: ""                           # REQUIRED - fill with desired value
   module: ""                                      # REQUIRED - leave this field empty as shown
-  networkPlugin: ""                               # REQUIRED - fill with desired value
+  cni: ""                                         # REQUIRED - fill with desired value
   nodeTemplateName: ""                            # REQUIRED - fill with desired value
   privateKeyPath: ""                              # REQUIRED - specify private key that will be used to access created instances
   proxy:

--- a/tests/rancher2/provisioning/README.md
+++ b/tests/rancher2/provisioning/README.md
@@ -86,7 +86,6 @@ terraform:
   enableNetworkPolicy: false
   hostnamePrefix: ""
   machineConfigName: ""
-  networkPlugin: ""
   nodeTemplateName: ""
   privateKeyPath: ""
   awsCredentials:

--- a/tests/rancher2/rbac/README.md
+++ b/tests/rancher2/rbac/README.md
@@ -29,7 +29,7 @@ terraform:
     hostnamePrefix: ""
     machineConfigName: ""
     module: "linode_k3s"
-    networkPlugin: "canal"
+    cni: "canal"
     nodeTemplateName: ""                # Needed for RKE1 clusters
     linodeCredentials:
         linodeToken: ""

--- a/tests/registries/README.md
+++ b/tests/registries/README.md
@@ -41,7 +41,7 @@ terraform:
   hostnamePrefix: ""                              # REQUIRED - fill with desired value
   machineConfigName: ""                           # REQUIRED - fill with desired value
   module: ""                                      # REQUIRED - leave this field empty as shown
-  networkPlugin: ""                               # REQUIRED - fill with desired value
+  cni: ""                                         # REQUIRED - fill with desired value
   nodeTemplateName: ""                            # REQUIRED - fill with desired value
   privateKeyPath: ""                              # REQUIRED - specify private key that will be used to access created instances
   privateRegistries:

--- a/tests/sanity/README.md
+++ b/tests/sanity/README.md
@@ -40,7 +40,7 @@ terraform:
   hostnamePrefix: ""                              # REQUIRED - fill with desired value
   machineConfigName: ""                           # REQUIRED - fill with desired value
   module: ""                                      # REQUIRED - leave this field empty as shown
-  networkPlugin: ""                               # REQUIRED - fill with desired value
+  cni: ""                                         # REQUIRED - fill with desired value
   nodeTemplateName: ""                            # REQUIRED - fill with desired value
   privateKeyPath: ""                              # REQUIRED - specify private key that will be used to access created instances
   ###########################


### PR DESCRIPTION
Found a bug with rke1 not setting the SSH user which causes node drivers to error out on all non-ubuntu images. 
Added a field for volumeType to allow gp3 ami's to function