### PR TITLE
QOL updates and overall enhancements

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -121,6 +121,7 @@ type Standalone struct {
 	CertManagerVersion             string `json:"certManagerVersion,omitempty" yaml:"certManagerVersion,omitempty"`
 	K3SVersion                     string `json:"k3sVersion,omitempty" yaml:"k3sVersion,omitempty"`
 	ProxyRancher                   bool   `json:"proxyRancher,omitempty" yaml:"proxyRancher,omitempty"`
+	RancherAgentImage              string `json:"rancherAgentImage,omitempty" yaml:"rancherAgentImage,omitempty"`
 	RancherChartRepository         string `json:"rancherChartRepository,omitempty" yaml:"rancherChartRepository,omitempty"`
 	RancherHostname                string `json:"rancherHostname,omitempty" yaml:"rancherHostname,omitempty"`
 	RancherImage                   string `json:"rancherImage,omitempty" yaml:"rancherImage,omitempty"`
@@ -128,12 +129,10 @@ type Standalone struct {
 	Repo                           string `json:"repo,omitempty" yaml:"repo,omitempty"`
 	OSUser                         string `json:"osUser,omitempty" yaml:"osUser,omitempty"`
 	OSGroup                        string `json:"osGroup,omitempty" yaml:"osGroup,omitempty"`
-	PrimeRancherAgentImage         string `json:"primeRancherAgentImage,omitempty" yaml:"primeRancherAgentImage,omitempty"`
 	RKE2Version                    string `json:"rke2Version,omitempty" yaml:"rke2Version,omitempty"`
-	StagingRancherAgentImage       string `json:"stagingRancherAgentImage,omitempty" yaml:"stagingRancherAgentImage,omitempty"`
 	UpgradedRancherChartRepository string `json:"upgradedRancherChartRepository,omitempty" yaml:"upgradedRancherChartRepository,omitempty"`
 	UpgradedRancherImage           string `json:"upgradedRancherImage,omitempty" yaml:"upgradedRancherImage,omitempty"`
-	UpgradedRancherStagingImage    string `json:"upgradedRancherStagingImage,omitempty" yaml:"upgradedRancherStagingImage,omitempty"`
+	UpgradedRancherAgentImage      string `json:"upgradedRancherAgentImage,omitempty" yaml:"upgradedRancherAgentImage,omitempty"`
 	UpgradedRancherRepo            string `json:"upgradedRancherRepo,omitempty" yaml:"upgradedRancherRepo,omitempty"`
 	UpgradedRancherTagVersion      string `json:"upgradedRancherTagVersion,omitempty" yaml:"upgradedRancherTagVersion,omitempty"`
 }
@@ -212,6 +211,7 @@ type TerratestConfig struct {
 	ScalingInput              Scaling    `json:"scalingInput,omitempty" yaml:"scalingInput,omitempty"`
 	PSACT                     string     `json:"psact,omitempty" yaml:"psact,omitempty"`
 	SnapshotInput             Snapshots  `json:"snapshotInput,omitempty" yaml:"snapshotInput,omitempty"`
+	StandaloneLogging         bool       `json:"standaloneLogging,omitempty" yaml:"standaloneLogging,omitempty"`
 	TFLogging                 bool       `json:"tfLogging,omitempty" yaml:"tfLogging,omitempty"`
 }
 

--- a/framework/cleanup/cleanup.go
+++ b/framework/cleanup/cleanup.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/tfp-automation/defaults/configs"
+	"github.com/sirupsen/logrus"
 )
 
 // Cleanup is a function that will run terraform destroy and cleanup Terraform resources.
@@ -15,6 +16,7 @@ func Cleanup(t *testing.T, terraformOptions *terraform.Options, keyPath string) 
 	config.LoadConfig(configs.Rancher, rancherConfig)
 
 	if *rancherConfig.Cleanup {
+		logrus.Infof("Cleaning up Terraform resources...")
 		terraform.Destroy(t, terraformOptions)
 		TFFilesCleanup(keyPath)
 	}

--- a/framework/set/provisioning/airgap/setRKE1Config.go
+++ b/framework/set/provisioning/airgap/setRKE1Config.go
@@ -83,7 +83,7 @@ func SetAirgapRKE1(rancherConfig *rancher.Config, terraformConfig *config.Terraf
 
 	_, err = file.Write(newFile.Bytes())
 	if err != nil {
-		logrus.Infof("Failed to write airgap RKE2/K3s configurations to main.tf file. Error: %v", err)
+		logrus.Infof("Failed to write airgap RKE1 configurations to main.tf file. Error: %v", err)
 		return nil, err
 	}
 

--- a/framework/set/resources/airgap/createMainTF.go
+++ b/framework/set/resources/airgap/createMainTF.go
@@ -44,6 +44,7 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 	tfBlock := rootBody.AppendNewBlock(terraformConst, nil)
 	tfBlockBody := tfBlock.Body()
 
+	logrus.Infof("Creating AWS resources...")
 	file, err := aws.CreateAWSResources(file, newFile, tfBlockBody, rootBody, terraformConfig, terratestConfig)
 	if err != nil {
 		return "", err
@@ -57,6 +58,7 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 	rke2ServerTwoPrivateIP := terraform.Output(t, terraformOptions, rke2ServerTwoPrivateIP)
 	rke2ServerThreePrivateIP := terraform.Output(t, terraformOptions, rke2ServerThreePrivateIP)
 
+	logrus.Infof("Creating registry...")
 	file = OpenFile(file, keyPath)
 	file, err = registry.CreateNonAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, registryPublicDNS, nonAuthRegistry)
 	if err != nil {
@@ -66,6 +68,7 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 	terraform.InitAndApply(t, terraformOptions)
 
 	file = OpenFile(file, keyPath)
+	logrus.Infof("Creating RKE2 cluster...")
 	file, err = rke2.CreateAirgapRKE2Cluster(file, newFile, rootBody, terraformConfig, rke2BastionPublicDNS, registryPublicDNS, rke2ServerOnePrivateIP, rke2ServerTwoPrivateIP, rke2ServerThreePrivateIP)
 	if err != nil {
 		return "", err
@@ -74,6 +77,7 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 	terraform.InitAndApply(t, terraformOptions)
 
 	file = OpenFile(file, keyPath)
+	logrus.Infof("Creating Rancher server...")
 	file, err = rancher.CreateAirgapRancher(file, newFile, rootBody, terraformConfig, rke2BastionPublicDNS, registryPublicDNS)
 	if err != nil {
 		return "", err

--- a/framework/set/resources/airgap/rancher/setup.sh
+++ b/framework/set/resources/airgap/rancher/setup.sh
@@ -9,8 +9,7 @@ RANCHER_TAG_VERSION=$6
 BOOTSTRAP_PASSWORD=$7
 RANCHER_IMAGE=$8
 REGISTRY=$9
-STAGING_RANCHER_AGENT_IMAGE=${10:-""}
-PRIME_RANCHER_AGENT_IMAGE=${11}
+RANCHER_AGENT_IMAGE=${10}
 
 set -ex
 
@@ -35,25 +34,15 @@ echo "Waiting 1 minute for Rancher"
 sleep 60
 
 echo "Installing Rancher"
-if [ -n "$STAGING_RANCHER_AGENT_IMAGE" ]; then
+if [ -n "$RANCHER_AGENT_IMAGE" ]; then
     helm upgrade --install rancher rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
                                                                                  --set hostname=${HOSTNAME} \
                                                                                  --set rancherImageTag=${RANCHER_TAG_VERSION} \
                                                                                  --set rancherImage=${REGISTRY}/${RANCHER_IMAGE} \
                                                                                  --set systemDefaultRegistry=${REGISTRY} \
                                                                                  --set 'extraEnv[0].name=CATTLE_AGENT_IMAGE' \
-                                                                                 --set "extraEnv[0].value=${REGISTRY}/${STAGING_RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}" \
+                                                                                 --set "extraEnv[0].value=${REGISTRY}/${RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}" \
                                                                                  --set bootstrapPassword=${BOOTSTRAP_PASSWORD} --devel
-
-elif [ -n "$PRIME_RANCHER_AGENT_IMAGE" ]; then
-    helm upgrade --install rancher rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
-                                                                                 --set hostname=${HOSTNAME} \
-                                                                                 --set rancherImage=${REGISTRY}/${PRIME_RANCHER_IMAGE} \
-                                                                                 --set rancherImageTag=${RANCHER_TAG_VERSION} \
-                                                                                 --set systemDefaultRegistry=${REGISTRY} \
-                                                                                 --set 'extraEnv[0].name=CATTLE_AGENT_IMAGE' \
-                                                                                 --set "extraEnv[0].value=${REGISTRY}/${PRIME_RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}" \
-                                                                                 --set bootstrapPassword=${BOOTSTRAP_PASSWORD}
 
 else
     helm upgrade --install rancher rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \

--- a/framework/set/resources/airgap/rancher/setupAirgapRancher.go
+++ b/framework/set/resources/airgap/rancher/setupAirgapRancher.go
@@ -35,19 +35,15 @@ func CreateAirgapRancher(file *os.File, newFile *hclwrite.File, rootBody *hclwri
 
 	command := "bash -c '/tmp/setup.sh " + terraformConfig.Standalone.RancherChartRepository + " " +
 		terraformConfig.Standalone.Repo + " " + terraformConfig.Standalone.CertManagerVersion + " " +
-		terraformConfig.Standalone.RancherHostname + " " + " " + terraformConfig.Standalone.AirgapInternalFQDN + " " +
+		terraformConfig.Standalone.RancherHostname + " " + terraformConfig.Standalone.AirgapInternalFQDN + " " +
 		terraformConfig.Standalone.RancherTagVersion + " " + terraformConfig.Standalone.BootstrapPassword + " " +
 		terraformConfig.Standalone.RancherImage + " " + registryPublicDNS
 
-	if terraformConfig.Standalone.StagingRancherAgentImage != "" {
-		command += " " + terraformConfig.Standalone.StagingRancherAgentImage
+	if terraformConfig.Standalone.RancherAgentImage != "" {
+		command += " " + terraformConfig.Standalone.RancherAgentImage
 	}
 
-	if terraformConfig.Standalone.PrimeRancherAgentImage != "" {
-		command += " " + terraformConfig.Standalone.PrimeRancherAgentImage
-	}
-
-	command += "'"
+	command += " || true'"
 
 	provisionerBlockBody.SetAttributeValue(defaults.Inline, cty.ListVal([]cty.Value{
 		cty.StringVal("printf '" + string(scriptContent) + "' > /tmp/setup.sh"),

--- a/framework/set/resources/airgap/rke2/add-servers.sh
+++ b/framework/set/resources/airgap/rke2/add-servers.sh
@@ -8,8 +8,7 @@ RKE2_TOKEN=$5
 REGISTRY=$6
 RANCHER_IMAGE=$7
 RANCHER_TAG_VERSION=$8
-STAGING_RANCHER_AGENT_IMAGE=${9:-""}
-PRIME_RANCHER_AGENT_IMAGE=${10}
+RANCHER_AGENT_IMAGE=${9}
 PEM_FILE=/home/$USER/airgap.pem
 
 set -e
@@ -70,21 +69,13 @@ runSSH "${RKE2_NEW_SERVER_IP}" "sudo INSTALL_RKE2_ARTIFACT_PATH=/home/${USER} sh
 runSSH "${RKE2_NEW_SERVER_IP}" "sudo systemctl enable rke2-server"
 runSSH "${RKE2_NEW_SERVER_IP}" "sudo systemctl start rke2-server"
 
-if [ -n "$STAGING_RANCHER_AGENT_IMAGE" ] || [ -n "$PRIME_RANCHER_AGENT_IMAGE" ]; then
+if [ -n "$RANCHER_AGENT_IMAGE" ]; then
   setupDaemonFunction=$(declare -f setupDockerDaemon)
   runSSH "${RKE2_NEW_SERVER_IP}" "${setupDaemonFunction}; setupDockerDaemon"
   runSSH "${RKE2_NEW_SERVER_IP}" "sudo systemctl restart docker && sudo systemctl daemon-reload"
 
   runSSH "${RKE2_NEW_SERVER_IP}" "sudo docker pull ${REGISTRY}/${RANCHER_IMAGE}:${RANCHER_TAG_VERSION}"
-
-  if [ -n "$STAGING_RANCHER_AGENT_IMAGE" ]; then
-    runSSH "${RKE2_NEW_SERVER_IP}" "sudo docker pull ${REGISTRY}/${STAGING_RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}"
-  fi
-
-  if [ -n "$PRIME_RANCHER_AGENT_IMAGE" ]; then
-    runSSH "${RKE2_NEW_SERVER_IP}" "sudo docker pull ${REGISTRY}/${PRIME_RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}"
-  fi
-  
+  runSSH "${RKE2_NEW_SERVER_IP}" "sudo docker pull ${REGISTRY}/${RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}"
   runSSH "${RKE2_NEW_SERVER_IP}" "sudo systemctl restart rke2-server"
 fi
 

--- a/framework/set/resources/airgap/rke2/createAirgapCluster.go
+++ b/framework/set/resources/airgap/rke2/createAirgapCluster.go
@@ -89,15 +89,11 @@ func createAirgappedRKE2Server(rootBody *hclwrite.Body, terraformConfig *config.
 		rke2ServerOnePrivateIP + " " + rke2Token + " " + registryPublicDNS + " " + terraformConfig.Standalone.RancherImage + " " +
 		terraformConfig.Standalone.RancherTagVersion
 
-	if terraformConfig.Standalone.StagingRancherAgentImage != "" {
-		command += " " + terraformConfig.Standalone.StagingRancherAgentImage
+	if terraformConfig.Standalone.RancherAgentImage != "" {
+		command += " " + terraformConfig.Standalone.RancherAgentImage
 	}
 
-	if terraformConfig.Standalone.PrimeRancherAgentImage != "" {
-		command += " " + terraformConfig.Standalone.PrimeRancherAgentImage
-	}
-
-	command += "'"
+	command += " || true'"
 
 	provisionerBlockBody.SetAttributeValue(defaults.Inline, cty.ListVal([]cty.Value{
 		cty.StringVal("printf '" + string(script) + "' > /tmp/init-server.sh"),
@@ -127,15 +123,11 @@ func addAirgappedRKE2ServerNodes(rootBody *hclwrite.Body, terraformConfig *confi
 			rke2ServerOnePrivateIP + " " + instance + " " + rke2Token + " " + registryPublicDNS + " " +
 			terraformConfig.Standalone.RancherImage + " " + terraformConfig.Standalone.RancherTagVersion
 
-		if terraformConfig.Standalone.StagingRancherAgentImage != "" {
-			command += " " + terraformConfig.Standalone.StagingRancherAgentImage
+		if terraformConfig.Standalone.RancherAgentImage != "" {
+			command += " " + terraformConfig.Standalone.RancherAgentImage
 		}
 
-		if terraformConfig.Standalone.PrimeRancherAgentImage != "" {
-			command += " " + terraformConfig.Standalone.PrimeRancherAgentImage
-		}
-
-		command += "'"
+		command += " || true'"
 
 		provisionerBlockBody.SetAttributeValue(defaults.Inline, cty.ListVal([]cty.Value{
 			cty.StringVal("printf '" + string(script) + "' > /tmp/add-servers.sh"),

--- a/framework/set/resources/airgap/rke2/init-server.sh
+++ b/framework/set/resources/airgap/rke2/init-server.sh
@@ -7,8 +7,7 @@ RKE2_TOKEN=$4
 REGISTRY=$5
 RANCHER_IMAGE=$6
 RANCHER_TAG_VERSION=$7
-STAGING_RANCHER_AGENT_IMAGE=${8:-""}
-PRIME_RANCHER_AGENT_IMAGE=${9}
+RANCHER_AGENT_IMAGE=${8}
 PEM_FILE=/home/$USER/airgap.pem
 
 set -e
@@ -70,21 +69,13 @@ runSSH "${RKE2_SERVER_ONE_IP}" "sudo INSTALL_RKE2_ARTIFACT_PATH=/home/${USER} sh
 runSSH "${RKE2_SERVER_ONE_IP}" "sudo systemctl enable rke2-server"
 runSSH "${RKE2_SERVER_ONE_IP}" "sudo systemctl start rke2-server"
 
-if [ -n "$STAGING_RANCHER_AGENT_IMAGE" ] || [ -n "$PRIME_RANCHER_AGENT_IMAGE" ]; then
+if [ -n "$RANCHER_AGENT_IMAGE" ]; then
   setupDaemonFunction=$(declare -f setupDockerDaemon)
   runSSH "${RKE2_SERVER_ONE_IP}" "${setupDaemonFunction}; setupDockerDaemon"
   runSSH "${RKE2_SERVER_ONE_IP}" "sudo systemctl restart docker && sudo systemctl daemon-reload"
 
   runSSH "${RKE2_SERVER_ONE_IP}" "sudo docker pull ${REGISTRY}/${RANCHER_IMAGE}:${RANCHER_TAG_VERSION}"
-
-  if [ -n "$STAGING_RANCHER_AGENT_IMAGE" ]; then
-    runSSH "${RKE2_SERVER_ONE_IP}" "sudo docker pull ${REGISTRY}/${STAGING_RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}"
-  fi
-
-  if [ -n "$PRIME_RANCHER_AGENT_IMAGE" ]; then
-    runSSH "${RKE2_SERVER_ONE_IP}" "sudo docker pull ${REGISTRY}/${PRIME_RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}"
-  fi
-  
+  runSSH "${RKE2_SERVER_ONE_IP}" "sudo docker pull ${REGISTRY}/${RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}"
   runSSH "${RKE2_SERVER_ONE_IP}" "sudo systemctl restart rke2-server"
 fi
 

--- a/framework/set/resources/proxy/rancher/createRancher.go
+++ b/framework/set/resources/proxy/rancher/createRancher.go
@@ -40,11 +40,11 @@ func CreateProxiedRancher(file *os.File, newFile *hclwrite.File, rootBody *hclwr
 		terraformConfig.Standalone.BootstrapPassword + " " + terraformConfig.Standalone.RancherImage + " " +
 		rke2BastionPublicDNS
 
-	if terraformConfig.Standalone.StagingRancherAgentImage != "" {
-		command += " " + terraformConfig.Standalone.StagingRancherAgentImage
+	if terraformConfig.Standalone.RancherAgentImage != "" {
+		command += " " + terraformConfig.Standalone.RancherAgentImage
 	}
 
-	command += "'"
+	command += " || true'"
 
 	provisionerBlockBody.SetAttributeValue(defaults.Inline, cty.ListVal([]cty.Value{
 		cty.StringVal("printf '" + string(scriptContent) + "' > /tmp/setup.sh"),

--- a/framework/set/resources/proxy/rancher/setup.sh
+++ b/framework/set/resources/proxy/rancher/setup.sh
@@ -8,7 +8,7 @@ RANCHER_TAG_VERSION=$5
 BOOTSTRAP_PASSWORD=$6
 RANCHER_IMAGE=$7
 BASTION=$8
-STAGING_RANCHER_AGENT_IMAGE=${9}
+RANCHER_AGENT_IMAGE=${9}
 PROXY_PORT="3128"
 NO_PROXY="localhost\\,127.0.0.0/8\\,10.0.0.0/8\\,172.0.0.0/8\\,192.168.0.0/16\\,.svc\\,.cluster.local\\,cattle-system.svc\\,169.254.169.254"
 
@@ -46,13 +46,13 @@ echo "Waiting 1 minute for Rancher"
 sleep 60
 
 echo "Installing Rancher"
-if [ -n "$STAGING_RANCHER_AGENT_IMAGE" ]; then
+if [ -n "$RANCHER_AGENT_IMAGE" ]; then
     helm upgrade --install rancher rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
                                                                                  --set hostname=${HOSTNAME} \
                                                                                  --set rancherImageTag=${RANCHER_TAG_VERSION} \
                                                                                  --set rancherImage=${RANCHER_IMAGE} \
                                                                                  --set 'extraEnv[0].name=CATTLE_AGENT_IMAGE' \
-                                                                                 --set "extraEnv[0].value=${STAGING_RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}" \
+                                                                                 --set "extraEnv[0].value=${RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}" \
                                                                                  --set proxy="http://${BASTION}:${PROXY_PORT}" \
                                                                                  --set noProxy="${NO_PROXY}" \
                                                                                  --set bootstrapPassword=${BOOTSTRAP_PASSWORD} --devel

--- a/framework/set/resources/proxy/rancher/upgrade.sh
+++ b/framework/set/resources/proxy/rancher/upgrade.sh
@@ -6,28 +6,28 @@ HOSTNAME=$3
 RANCHER_TAG_VERSION=$4
 RANCHER_IMAGE=$5
 BASTION=$6
-STAGING_RANCHER_AGENT_IMAGE=${7}
+RANCHER_AGENT_IMAGE=${7}
 PROXY_PORT="3128"
 NO_PROXY="localhost\\,127.0.0.0/8\\,10.0.0.0/8\\,172.0.0.0/8\\,192.168.0.0/16\\,.svc\\,.cluster.local\\,cattle-system.svc\\,169.254.169.254"
 
 set -ex
 
 echo "Adding Helm chart repo"
-helm repo add rancher-${REPO} ${RANCHER_CHART_REPO}${REPO}
+helm repo add upgraded-rancher-${REPO} ${RANCHER_CHART_REPO}${REPO}
 
 echo "Upgrading Rancher"
-if [ -n "$STAGING_RANCHER_AGENT_IMAGE" ]; then
-    helm upgrade --install rancher rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
+if [ -n "$RANCHER_AGENT_IMAGE" ]; then
+    helm upgrade --install rancher upgraded-rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
                                                                                  --set hostname=${HOSTNAME} \
                                                                                  --set rancherImageTag=${RANCHER_TAG_VERSION} \
                                                                                  --set rancherImage=${RANCHER_IMAGE} \
                                                                                  --set 'extraEnv[0].name=CATTLE_AGENT_IMAGE' \
-                                                                                 --set "extraEnv[0].value=${STAGING_RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}" \
+                                                                                 --set "extraEnv[0].value=${RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}" \
                                                                                  --set proxy="http://${BASTION}:${PROXY_PORT}" \
                                                                                  --set noProxy="${NO_PROXY}" --devel
 
 else
-    helm upgrade --install rancher rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
+    helm upgrade --install rancher upgraded-rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
                                                                                  --set hostname=${HOSTNAME} \
                                                                                  --set rancherImage=${RANCHER_IMAGE} \
                                                                                  --set rancherImageTag=${RANCHER_TAG_VERSION} \

--- a/framework/set/resources/proxy/rancher/upgradeRancher.go
+++ b/framework/set/resources/proxy/rancher/upgradeRancher.go
@@ -34,14 +34,14 @@ func UpgradeProxiedRancher(file *os.File, newFile *hclwrite.File, rootBody *hclw
 	_, provisionerBlockBody := rke2.CreateNullResource(rootBody, terraformConfig, rke2ServerOnePublicDNS, upgradeRancher)
 
 	command := "bash -c '/tmp/upgrade.sh " + terraformConfig.Standalone.UpgradedRancherChartRepository + " " +
-		terraformConfig.Standalone.Repo + " " + terraformConfig.Standalone.RancherHostname + " " + terraformConfig.Standalone.UpgradedRancherTagVersion + " " +
+		terraformConfig.Standalone.UpgradedRancherRepo + " " + terraformConfig.Standalone.RancherHostname + " " + terraformConfig.Standalone.UpgradedRancherTagVersion + " " +
 		terraformConfig.Standalone.UpgradedRancherImage + " " + proxyNode
 
-	if terraformConfig.Standalone.UpgradedRancherStagingImage != "" {
-		command += " " + terraformConfig.Standalone.UpgradedRancherStagingImage
+	if terraformConfig.Standalone.UpgradedRancherAgentImage != "" {
+		command += " " + terraformConfig.Standalone.UpgradedRancherAgentImage
 	}
 
-	command += "'"
+	command += " || true'"
 
 	provisionerBlockBody.SetAttributeValue(defaults.Inline, cty.ListVal([]cty.Value{
 		cty.StringVal("printf '" + string(scriptContent) + "' > /tmp/upgrade.sh"),

--- a/framework/set/resources/proxy/rke2/createCluster.go
+++ b/framework/set/resources/proxy/rke2/createCluster.go
@@ -63,7 +63,7 @@ func createRKE2Server(rootBody *hclwrite.Body, terraformConfig *config.Terraform
 
 	command := "bash -c '/tmp/init-server.sh " + terraformConfig.Standalone.OSUser + " " + terraformConfig.Standalone.OSGroup + " " +
 		terraformConfig.Standalone.RKE2Version + " " + rke2ServerOnePrivateIP + " " + rke2Token + " " +
-		rke2BastionPublicDNS + "'"
+		rke2BastionPublicDNS + " || true'"
 
 	provisionerBlockBody.SetAttributeValue(defaults.Inline, cty.ListVal([]cty.Value{
 		cty.StringVal("printf '" + string(script) + "' > /tmp/init-server.sh"),
@@ -84,7 +84,7 @@ func addRKE2ServerNodes(rootBody *hclwrite.Body, terraformConfig *config.Terrafo
 
 		command := "bash -c '/tmp/add-servers.sh " + terraformConfig.Standalone.OSUser + " " + terraformConfig.Standalone.OSGroup + " " +
 			terraformConfig.Standalone.RKE2Version + " " + rke2ServerOnePrivateIP + " " + rke2Token + " " +
-			rke2BastionPublicDNS + "'"
+			rke2BastionPublicDNS + " || true'"
 
 		provisionerBlockBody.SetAttributeValue(defaults.Inline, cty.ListVal([]cty.Value{
 			cty.StringVal("printf '" + string(script) + "' > /tmp/add-servers.sh"),

--- a/framework/set/resources/proxy/squid/createSquidProxy.go
+++ b/framework/set/resources/proxy/squid/createSquidProxy.go
@@ -43,7 +43,7 @@ func CreateSquidProxy(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.
 	_, provisionerBlockBody := rke2.CreateNullResource(rootBody, terraformConfig, rke2BastionPublicDNS, installSquidProxy)
 
 	command := "bash -c '/tmp/setup.sh " + terraformConfig.Standalone.OSUser + " " + rke2BastionPublicDNS + " " +
-		terraformConfig.Standalone.BootstrapPassword + "'"
+		terraformConfig.Standalone.BootstrapPassword + " || true'"
 
 	provisionerBlockBody.SetAttributeValue(defaults.Inline, cty.ListVal([]cty.Value{
 		cty.StringVal("printf '" + string(scriptContent) + "' > /tmp/setup.sh"),

--- a/framework/set/resources/registries/createMainTF.go
+++ b/framework/set/resources/registries/createMainTF.go
@@ -50,6 +50,8 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 	tfBlockBody := tfBlock.Body()
 
 	instances := []string{rke2ServerOne, rke2ServerTwo, rke2ServerThree, authRegistry, nonAuthRegistry, globalRegistry}
+
+	logrus.Infof("Creating AWS resources...")
 	file, err := aws.CreateAWSResources(file, newFile, tfBlockBody, rootBody, terraformConfig, terratest, instances)
 	if err != nil {
 		return "", "", "", err
@@ -76,6 +78,7 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 		defer mutex.Unlock()
 
 		file = sanity.OpenFile(file, keyPath)
+		logrus.Infof("Creating authenticated registry...")
 		file, err = registry.CreateAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, authRegistryPublicDNS)
 		if err != nil {
 			logrus.Fatalf("Error creating authenticated registry: %v", err)
@@ -88,6 +91,7 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 		defer mutex.Unlock()
 
 		file = sanity.OpenFile(file, keyPath)
+		logrus.Infof("Creating non-authenticated registry...")
 		file, err = registry.CreateNonAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, nonAuthRegistryPublicDNS, nonAuthRegistry)
 		if err != nil {
 			logrus.Fatalf("Error creating unauthenticated registry: %v", err)
@@ -100,6 +104,7 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 		defer mutex.Unlock()
 
 		file = sanity.OpenFile(file, keyPath)
+		logrus.Infof("Creating global registry...")
 		file, err = registry.CreateNonAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, globalRegistryPublicDNS, globalRegistry)
 		if err != nil {
 			logrus.Fatalf("Error creating global registry: %v", err)
@@ -111,6 +116,7 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 	wg.Wait()
 
 	file = sanity.OpenFile(file, keyPath)
+	logrus.Infof("Creating RKE2 cluster...")
 	file, err = rke2.CreateRKE2Cluster(file, newFile, rootBody, terraformConfig, rke2ServerOnePublicDNS, rke2ServerOnePrivateIP,
 		rke2ServerTwoPublicDNS, rke2ServerThreePublicDNS, globalRegistryPublicDNS)
 	if err != nil {
@@ -120,6 +126,7 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 	terraform.InitAndApply(t, terraformOptions)
 
 	file = sanity.OpenFile(file, keyPath)
+	logrus.Infof("Creating Rancher server...")
 	file, err = rancher.CreateRancher(file, newFile, rootBody, terraformConfig, rke2ServerOnePublicDNS, globalRegistryPublicDNS)
 	if err != nil {
 		return "", "", "", err

--- a/framework/set/resources/registries/createRegistry.go
+++ b/framework/set/resources/registries/createRegistry.go
@@ -35,8 +35,8 @@ func CreateAuthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootBody
 		terraformConfig.StandaloneRegistry.AssetsPath + " " + terraformConfig.Standalone.OSUser + " " +
 		terraformConfig.Standalone.RancherImage
 
-	if terraformConfig.Standalone.StagingRancherAgentImage != "" {
-		command += " " + terraformConfig.Standalone.StagingRancherAgentImage
+	if terraformConfig.Standalone.RancherAgentImage != "" {
+		command += " " + terraformConfig.Standalone.RancherAgentImage
 	}
 
 	command += "'"
@@ -78,8 +78,8 @@ func CreateNonAuthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootB
 		terraformConfig.StandaloneRegistry.AssetsPath + " " + terraformConfig.Standalone.OSUser + " " +
 		terraformConfig.Standalone.RancherImage
 
-	if terraformConfig.Standalone.StagingRancherAgentImage != "" {
-		command += " " + terraformConfig.Standalone.StagingRancherAgentImage
+	if terraformConfig.Standalone.RancherAgentImage != "" {
+		command += " " + terraformConfig.Standalone.RancherAgentImage
 	}
 
 	command += "'"

--- a/framework/set/resources/registries/createRegistry/auth-registry.sh
+++ b/framework/set/resources/registries/createRegistry/auth-registry.sh
@@ -8,8 +8,7 @@ RANCHER_VERSION=$5
 ASSET_DIR=$6
 USER=$7
 RANCHER_IMAGE=$8
-STAGING_RANCHER_AGENT_IMAGE=${9:-""}
-PRIME_RANCHER_AGENT_IMAGE=${10}
+RANCHER_AGENT_IMAGE=${9}
 
 set -e
 
@@ -84,14 +83,9 @@ sudo sed -i "s/docker save/# docker save /g" /home/${USER}/rancher-save-images.s
 sudo sed -i "s/docker load/# docker load /g" /home/${USER}/rancher-load-images.sh
 sudo sed -i '/mirrored-prometheus-windows-exporter/d' /home/${USER}/rancher-images.txt
 
-if [ ! -z "${STAGING_RANCHER_AGENT_IMAGE}" ]; then
+if [ ! -z "${RANCHER_AGENT_IMAGE}" ]; then
     sudo sed -i "s|rancher/rancher:|${RANCHER_IMAGE}:|g" /home/${USER}/rancher-images.txt
-    sudo sed -i "s|rancher/rancher-agent:|${STAGING_RANCHER_AGENT_IMAGE}:|g" /home/${USER}/rancher-images.txt
-fi
-
-if [[ ! -z "${PRIME_RANCHER_AGENT_IMAGE}" ]]; then
-    sudo sed -i "s|rancher/rancher:|${RANCHER_IMAGE}:|g" /home/${USER}/rancher-images.txt
-    sudo sed -i "s|rancher/rancher-agent:|${PRIME_RANCHER_AGENT_IMAGE}:|g" /home/${USER}/rancher-images.txt
+    sudo sed -i "s|rancher/rancher-agent:|${RANCHER_AGENT_IMAGE}:|g" /home/${USER}/rancher-images.txt
 fi
 
 echo "Pulling the images..."

--- a/framework/set/resources/registries/createRegistry/createRegistry.go
+++ b/framework/set/resources/registries/createRegistry/createRegistry.go
@@ -40,15 +40,11 @@ func CreateAuthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootBody
 		terraformConfig.StandaloneRegistry.AssetsPath + " " + terraformConfig.Standalone.OSUser + " " +
 		terraformConfig.Standalone.RancherImage
 
-	if terraformConfig.Standalone.StagingRancherAgentImage != "" {
-		command += " " + terraformConfig.Standalone.StagingRancherAgentImage
+	if terraformConfig.Standalone.RancherAgentImage != "" {
+		command += " " + terraformConfig.Standalone.RancherAgentImage
 	}
 
-	if terraformConfig.Standalone.PrimeRancherAgentImage != "" {
-		command += " " + terraformConfig.Standalone.PrimeRancherAgentImage
-	}
-
-	command += "'"
+	command += " || true'"
 
 	provisionerBlockBody.SetAttributeValue(defaults.Inline, cty.ListVal([]cty.Value{
 		cty.StringVal("echo '" + string(registryScriptContent) + "' > /tmp/auth-registry.sh"),
@@ -87,15 +83,11 @@ func CreateNonAuthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootB
 		terraformConfig.StandaloneRegistry.AssetsPath + " " + terraformConfig.Standalone.OSUser + " " +
 		terraformConfig.Standalone.RancherImage
 
-	if terraformConfig.Standalone.StagingRancherAgentImage != "" {
-		command += " " + terraformConfig.Standalone.StagingRancherAgentImage
+	if terraformConfig.Standalone.RancherAgentImage != "" {
+		command += " " + terraformConfig.Standalone.RancherAgentImage
 	}
 
-	if terraformConfig.Standalone.PrimeRancherAgentImage != "" {
-		command += " " + terraformConfig.Standalone.PrimeRancherAgentImage
-	}
-
-	command += "'"
+	command += " || true'"
 
 	provisionerBlockBody.SetAttributeValue(defaults.Inline, cty.ListVal([]cty.Value{
 		cty.StringVal("echo '" + string(registryScriptContent) + "' > /tmp/non-auth-registry.sh"),

--- a/framework/set/resources/registries/createRegistry/non-auth-registry.sh
+++ b/framework/set/resources/registries/createRegistry/non-auth-registry.sh
@@ -6,8 +6,7 @@ RANCHER_VERSION=$3
 ASSET_DIR=$4
 USER=$5
 RANCHER_IMAGE=$6
-STAGING_RANCHER_AGENT_IMAGE=${7:-""}
-PRIME_RANCHER_AGENT_IMAGE=${8}
+RANCHER_AGENT_IMAGE=${7}
 
 set -e
 
@@ -65,14 +64,9 @@ sudo sed -i "s/docker save/# docker save /g" /home/${USER}/rancher-save-images.s
 sudo sed -i "s/docker load/# docker load /g" /home/${USER}/rancher-load-images.sh
 sudo sed -i '/mirrored-prometheus-windows-exporter/d' /home/${USER}/rancher-images.txt
 
-if [ ! -z "${STAGING_RANCHER_AGENT_IMAGE}" ]; then
+if [ ! -z "${RANCHER_AGENT_IMAGE}" ]; then
     sudo sed -i "s|rancher/rancher:|${RANCHER_IMAGE}:|g" /home/${USER}/rancher-images.txt
-    sudo sed -i "s|rancher/rancher-agent:|${STAGING_RANCHER_AGENT_IMAGE}:|g" /home/${USER}/rancher-images.txt
-fi
-
-if [[ ! -z "${PRIME_RANCHER_AGENT_IMAGE}" ]]; then
-    sudo sed -i "s|rancher/rancher:|${RANCHER_IMAGE}:|g" /home/${USER}/rancher-images.txt
-    sudo sed -i "s|rancher/rancher-agent:|${PRIME_RANCHER_AGENT_IMAGE}:|g" /home/${USER}/rancher-images.txt
+    sudo sed -i "s|rancher/rancher-agent:|${RANCHER_AGENT_IMAGE}:|g" /home/${USER}/rancher-images.txt
 fi
     
 echo "Pulling the images..."

--- a/framework/set/resources/registries/rancher/createRancher.go
+++ b/framework/set/resources/registries/rancher/createRancher.go
@@ -38,15 +38,11 @@ func CreateRancher(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Bod
 		terraformConfig.Standalone.RancherHostname + " " + terraformConfig.Standalone.RancherTagVersion + " " +
 		terraformConfig.Standalone.BootstrapPassword + " " + terraformConfig.Standalone.RancherImage + " " + registryPublicDNS
 
-	if terraformConfig.Standalone.StagingRancherAgentImage != "" {
-		command += " " + terraformConfig.Standalone.StagingRancherAgentImage
+	if terraformConfig.Standalone.RancherAgentImage != "" {
+		command += " " + terraformConfig.Standalone.RancherAgentImage
 	}
 
-	if terraformConfig.Standalone.PrimeRancherAgentImage != "" {
-		command += " " + terraformConfig.Standalone.PrimeRancherAgentImage
-	}
-
-	command += "'"
+	command += " || true'"
 
 	provisionerBlockBody.SetAttributeValue(defaults.Inline, cty.ListVal([]cty.Value{
 		cty.StringVal("printf '" + string(scriptContent) + "' > /tmp/setup.sh"),

--- a/framework/set/resources/registries/rke2/createCluster.go
+++ b/framework/set/resources/registries/rke2/createCluster.go
@@ -66,15 +66,11 @@ func createRKE2Server(rootBody *hclwrite.Body, terraformConfig *config.Terraform
 		terraformConfig.Standalone.RKE2Version + " " + rke2ServerOnePrivateIP + " " + rke2Token + " " +
 		terraformConfig.Standalone.RancherImage + " " + terraformConfig.Standalone.RancherTagVersion + " " + registryPublicDNS
 
-	if terraformConfig.Standalone.StagingRancherAgentImage != "" {
-		command += " " + terraformConfig.Standalone.StagingRancherAgentImage
+	if terraformConfig.Standalone.RancherAgentImage != "" {
+		command += " " + terraformConfig.Standalone.RancherAgentImage
 	}
 
-	if terraformConfig.Standalone.PrimeRancherAgentImage != "" {
-		command += " " + terraformConfig.Standalone.PrimeRancherAgentImage
-	}
-
-	command += "'"
+	command += " || true'"
 
 	provisionerBlockBody.SetAttributeValue(defaults.Inline, cty.ListVal([]cty.Value{
 		cty.StringVal("printf '" + string(script) + "' > /tmp/init-server.sh"),
@@ -97,15 +93,11 @@ func addRKE2ServerNodes(rootBody *hclwrite.Body, terraformConfig *config.Terrafo
 			terraformConfig.Standalone.RKE2Version + " " + rke2ServerOnePrivateIP + " " + rke2Token + " " +
 			terraformConfig.Standalone.RancherImage + " " + terraformConfig.Standalone.RancherTagVersion + " " + registryPublicDNS
 
-		if terraformConfig.Standalone.StagingRancherAgentImage != "" {
-			command += " " + terraformConfig.Standalone.StagingRancherAgentImage
+		if terraformConfig.Standalone.RancherAgentImage != "" {
+			command += " " + terraformConfig.Standalone.RancherAgentImage
 		}
 
-		if terraformConfig.Standalone.PrimeRancherAgentImage != "" {
-			command += " " + terraformConfig.Standalone.PrimeRancherAgentImage
-		}
-
-		command += "'"
+		command += " || true'"
 
 		provisionerBlockBody.SetAttributeValue(defaults.Inline, cty.ListVal([]cty.Value{
 			cty.StringVal("printf '" + string(script) + "' > /tmp/add-servers.sh"),

--- a/framework/set/resources/rke2/createCluster.go
+++ b/framework/set/resources/rke2/createCluster.go
@@ -88,7 +88,7 @@ func createRKE2Server(rootBody *hclwrite.Body, terraformConfig *config.Terraform
 	_, provisionerBlockBody := CreateNullResource(rootBody, terraformConfig, rke2ServerOnePublicDNS, rke2ServerOne)
 
 	command := "bash -c '/tmp/init-server.sh " + terraformConfig.Standalone.OSUser + " " + terraformConfig.Standalone.OSGroup + " " +
-		terraformConfig.Standalone.RKE2Version + " " + rke2ServerOnePrivateIP + " " + rke2Token + "'"
+		terraformConfig.Standalone.RKE2Version + " " + rke2ServerOnePrivateIP + " " + rke2Token + " || true'"
 
 	provisionerBlockBody.SetAttributeValue(defaults.Inline, cty.ListVal([]cty.Value{
 		cty.StringVal("printf '" + string(script) + "' > /tmp/init-server.sh"),
@@ -108,7 +108,7 @@ func addRKE2ServerNodes(rootBody *hclwrite.Body, terraformConfig *config.Terrafo
 		nullResourceBlockBody, provisionerBlockBody := CreateNullResource(rootBody, terraformConfig, instance, host)
 
 		command := "bash -c '/tmp/add-servers.sh " + terraformConfig.Standalone.OSUser + " " + terraformConfig.Standalone.OSGroup + " " +
-			terraformConfig.Standalone.RKE2Version + " " + rke2ServerOnePrivateIP + " " + rke2Token + "'"
+			terraformConfig.Standalone.RKE2Version + " " + rke2ServerOnePrivateIP + " " + rke2Token + " || true'"
 
 		provisionerBlockBody.SetAttributeValue(defaults.Inline, cty.ListVal([]cty.Value{
 			cty.StringVal("printf '" + string(script) + "' > /tmp/add-servers.sh"),

--- a/framework/set/resources/sanity/createMainTF.go
+++ b/framework/set/resources/sanity/createMainTF.go
@@ -39,6 +39,8 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 	tfBlockBody := tfBlock.Body()
 
 	instances := []string{rke2ServerOne, rke2ServerTwo, rke2ServerThree}
+
+	logrus.Infof("Creating AWS resources...")
 	file, err := aws.CreateAWSResources(file, newFile, tfBlockBody, rootBody, terraformConfig, terratestConfig, instances)
 	if err != nil {
 		return err
@@ -52,6 +54,7 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 	rke2ServerThreePublicDNS := terraform.Output(t, terraformOptions, rke2ServerThreePublicDNS)
 
 	file = OpenFile(file, keyPath)
+	logrus.Infof("Creating RKE2 cluster...")
 	file, err = rke2.CreateRKE2Cluster(file, newFile, rootBody, terraformConfig, rke2ServerOnePublicDNS, rke2ServerOnePrivateIP, rke2ServerTwoPublicDNS, rke2ServerThreePublicDNS)
 	if err != nil {
 		return err
@@ -60,6 +63,7 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 	terraform.InitAndApply(t, terraformOptions)
 
 	file = OpenFile(file, keyPath)
+	logrus.Infof("Creating Rancher server...")
 	file, err = rancher.CreateRancher(file, newFile, rootBody, terraformConfig, rke2ServerOnePublicDNS)
 	if err != nil {
 		return err

--- a/framework/set/resources/sanity/rancher/createRancher.go
+++ b/framework/set/resources/sanity/rancher/createRancher.go
@@ -38,11 +38,11 @@ func CreateRancher(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Bod
 		terraformConfig.Standalone.RancherHostname + " " + terraformConfig.Standalone.RancherTagVersion + " " +
 		terraformConfig.Standalone.BootstrapPassword + " " + terraformConfig.Standalone.RancherImage
 
-	if terraformConfig.Standalone.StagingRancherAgentImage != "" {
-		command += terraformConfig.Standalone.StagingRancherAgentImage
+	if terraformConfig.Standalone.RancherAgentImage != "" {
+		command += terraformConfig.Standalone.RancherAgentImage
 	}
 
-	command += "'"
+	command += " || true'"
 
 	provisionerBlockBody.SetAttributeValue(defaults.Inline, cty.ListVal([]cty.Value{
 		cty.StringVal("printf '" + string(scriptContent) + "' > /tmp/setup.sh"),

--- a/framework/set/resources/upgrade/createMainTF.go
+++ b/framework/set/resources/upgrade/createMainTF.go
@@ -39,6 +39,7 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 	file = sanity.OpenFile(file, keyPath)
 	switch {
 	case terraformConfig.Standalone.ProxyRancher:
+		logrus.Infof("Upgrading Proxy Rancher...")
 		_, err := rancher.UpgradeProxiedRancher(file, newFile, rootBody, terraformConfig, serverNode, proxyNode)
 		if err != nil {
 			return err

--- a/framework/set/setConfigTF.go
+++ b/framework/set/setConfigTF.go
@@ -110,16 +110,24 @@ func ConfigTF(client *rancher.Client, rancherConfig *rancher.Config, terraformCo
 			}
 		case module == modules.AirgapRKE1:
 			_, err = airgap.SetAirgapRKE1(rancherConfig, terraform, terratest, configMap, clusterName, newFile, rootBody, file)
-			return clusterNames, err
+			if err != nil {
+				return clusterNames, err
+			}
 		case module == modules.AirgapRKE2 || module == modules.AirgapK3S:
 			_, err = airgap.SetAirgapRKE2K3s(rancherConfig, terraform, terratest, configMap, clusterName, newFile, rootBody, file)
-			return clusterNames, err
+			if err != nil {
+				return clusterNames, err
+			}
 		case module == modules.ImportEC2RKE1:
 			_, err = imported.SetImportedRKE1(rancherConfig, terraform, terratest, clusterName, newFile, rootBody, file)
-			return clusterNames, err
+			if err != nil {
+				return clusterNames, err
+			}
 		case module == modules.ImportEC2RKE2 || module == modules.ImportEC2K3s:
 			_, err = imported.SetImportedRKE2K3s(rancherConfig, terraform, terratest, clusterName, newFile, rootBody, file)
-			return clusterNames, err
+			if err != nil {
+				return clusterNames, err
+			}
 		default:
 			logrus.Errorf("Unsupported module: %v", module)
 		}

--- a/framework/setup.go
+++ b/framework/setup.go
@@ -1,20 +1,24 @@
 package framework
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/keypath"
+	"github.com/sirupsen/logrus"
 )
 
 // Setup is a function that will set the Terraform configuration and return the Terraform options.
 func Setup(t *testing.T, terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig, keyPath string) *terraform.Options {
 	var terratestLogger logger.Logger
-	if terratestConfig.TFLogging {
-		terratestLogger = *logger.Default
+
+	if strings.Contains(keyPath, keypath.RancherKeyPath) {
+		terratestLogger = getLogger(terratestConfig.TFLogging)
 	} else {
-		terratestLogger = *logger.Discard
+		terratestLogger = getLogger(terratestConfig.StandaloneLogging)
 	}
 
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
@@ -24,4 +28,15 @@ func Setup(t *testing.T, terraformConfig *config.TerraformConfig, terratestConfi
 	})
 
 	return terraformOptions
+}
+
+func getLogger(tfLogging bool) logger.Logger {
+	if tfLogging {
+		logrus.Infof("Logging enabled. Terraform logs will be displayed.")
+		return *logger.Default
+	}
+
+	logrus.Infof("Logging disabled. Terraform logs will be suppressed.")
+
+	return *logger.Discard
 }

--- a/tests/infrastructure/setup_rancher_test.go
+++ b/tests/infrastructure/setup_rancher_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rancher/tfp-automation/framework/set/resources/rancher2"
 	resources "github.com/rancher/tfp-automation/framework/set/resources/sanity"
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -32,7 +33,8 @@ func (i *RancherTestSuite) TestCreateRancher() {
 	terraformOptions := framework.Setup(i.T(), i.terraformConfig, i.terratestConfig, keyPath)
 	i.terraformOptions = terraformOptions
 
-	resources.CreateMainTF(i.T(), i.terraformOptions, keyPath, i.terraformConfig, i.terratestConfig)
+	err := resources.CreateMainTF(i.T(), i.terraformOptions, keyPath, i.terraformConfig, i.terratestConfig)
+	require.NoError(i.T(), err)
 
 	logrus.Infof("Rancher server URL: %s", i.terraformConfig.Standalone.RancherHostname)
 	logrus.Infof("Booststrap password: %s", i.terraformConfig.Standalone.BootstrapPassword)

--- a/tests/proxy/README.md
+++ b/tests/proxy/README.md
@@ -73,6 +73,7 @@ terraform:
   standalone:
     bootstrapPassword: ""                         # REQUIRED - this is the same as the adminPassword above, make sure they match
     certManagerVersion: ""                        # REQUIRED - (e.g. v1.15.3)
+    proxyRancher: true                            # OPTIONAL - Set as true if you are upgrading the Proxy Rancher setup
     rancherChartVersion: ""                       # REQUIRED - fill with desired value
     rancherChartRepository: ""                    # REQUIRED - fill with desired value. Must end with a trailing /
     rancherHostname: ""                           # REQUIRED - fill with desired value
@@ -83,6 +84,9 @@ terraform:
     rke2User: ""                                  # REQUIRED - fill with username of the instance created
     stagingRancherAgentImage: ""                  # OPTIONAL - fill out only if you are using staging registry
     rke2Version: ""                               # REQUIRED - fill with desired RKE2 k8s value (i.e. v1.30.6+rke2r1)
+    upgradedRancherChartRepository: ""            # OPTIONAL - set if upgraded. Fill with desired value. Must end with a trailing /
+    upgradedRancherImage: ""                      # OPTIONAL - set if upgraded. Fill with desired value
+    upgradedRancherTagVersion: ""                 # OPTIONAL - set if upgraded. Fill with desired value
 ```
 
 Before running, be sure to run the following commands:


### PR DESCRIPTION
### Description
Post release testing, there were several areas that were identified that should be enhanced or overall fixed for better QOL of the repo. This PR addresses those, which are as listed:
- Fix issue where you do not need to initially login to the infrastructure-based setups in order for it to successfully pass
- If there is an issue at any time setting up infrastructure, destroy the created resources rather than the user having to do it
- Fix issue where the proxy upgrade actually upgrades the Rancher and doesn't experience helm repo conflicts
- Fix edge case observed with imported clusters and custom clusters if utilizing the multi-cluster capability
- Consolidated  `primeRancherAgentImage` and stagingRancherAgentImage` into one `rancherAgentImage` parameter
- Implemented ability to disable Terraform logging for infrastructure-based tests