### PR TITLE
Cleanup naming parameters

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -164,7 +164,7 @@ type TerraformConfig struct {
 	OktaConfig                          authproviders.OktaConfig     `json:"oktaConfig,omitempty" yaml:"oktaConfig,omitempty"`
 	OpenLDAPConfig                      authproviders.OpenLDAPConfig `json:"openLDAPConfig,omitempty" yaml:"openLDAPConfig,omitempty"`
 	AuthProvider                        string                       `json:"authProvider,omitempty" yaml:"authProvider,omitempty"`
-	CloudCredentialName                 string                       `json:"cloudCredentialName,omitempty" yaml:"cloudCredentialName,omitempty"`
+	ResourcePrefix                      string                       `json:"resourcePrefix,omitempty" yaml:"resourcePrefix,omitempty"`
 	CNI                                 string                       `json:"cni,omitempty" yaml:"cni,omitempty"`
 	ChartValues                         string                       `json:"chartValues,omitempty" yaml:"chartValues,omitempty"`
 	DisableKubeProxy                    string                       `json:"disable-kube-proxy,omitempty" yaml:"disable-kube-proxy,omitempty"`
@@ -172,12 +172,8 @@ type TerraformConfig struct {
 	EnableNetworkPolicy                 bool                         `json:"enableNetworkPolicy,omitempty" yaml:"enableNetworkPolicy,omitempty"`
 	ETCD                                *rkev1.ETCD                  `json:"etcd,omitempty" yaml:"etcd,omitempty"`
 	ETCDRKE1                            *management.ETCDService      `json:"etcdRKE1,omitempty" yaml:"etcdRKE1,omitempty"`
-	ClusterName                         string                       `json:"clusterName,omitempty" yaml:"clusterName,omitempty"`
-	HostnamePrefix                      string                       `json:"hostnamePrefix,omitempty" yaml:"hostnamePrefix,omitempty"`
-	MachineConfigName                   string                       `json:"machineConfigName,omitempty" yaml:"machineConfigName,omitempty"`
 	Module                              string                       `json:"module,omitempty" yaml:"module,omitempty"`
 	NetworkPlugin                       string                       `json:"networkPlugin,omitempty" yaml:"networkPlugin,omitempty"`
-	NodeTemplateName                    string                       `json:"nodeTemplateName,omitempty" yaml:"nodeTemplateName,omitempty"`
 	PrivateKeyPath                      string                       `json:"privateKeyPath,omitempty" yaml:"privateKeyPath,omitempty"`
 	PrivateRegistries                   *PrivateRegistries           `json:"privateRegistries,omitempty" yaml:"privateRegistries,omitempty"`
 	Proxy                               *Proxy                       `json:"proxy,omitempty" yaml:"proxy,omitempty"`

--- a/defaults/configs/configs.go
+++ b/defaults/configs/configs.go
@@ -23,11 +23,9 @@ const (
 )
 
 // CreateTestCredentials creates test credentials for the test user, password, cluster name, and pool name.
-func CreateTestCredentials() (string, string, string, string) {
+func CreateTestCredentials() (string, string) {
 	testUser := namegen.AppendRandomString(TestUser)
 	testPassword := namegen.AppendRandomString(TestPassword)
-	clusterName := namegen.AppendRandomString(TFP)
-	poolName := namegen.AppendRandomString(TFP)
 
-	return testUser, testPassword, clusterName, poolName
+	return testUser, testPassword
 }

--- a/framework/set/defaults/defaults.go
+++ b/framework/set/defaults/defaults.go
@@ -53,7 +53,7 @@ const (
 	MachineGlobalConfig   = "machine_global_config"
 	MachineSelectorConfig = "machine_selector_config"
 	MachinePools          = "machine_pools"
-	NodePool              = "auto-tfp-pool"
+	NodePool              = "node-pool"
 	Etcd                  = "etcd"
 	Enabled               = "enabled"
 	RancherClusterID      = "cluster_id"

--- a/framework/set/provisioning/airgap/setRKE1Config.go
+++ b/framework/set/provisioning/airgap/setRKE1Config.go
@@ -18,8 +18,8 @@ import (
 
 // // SetAirgapRKE1 is a function that will set the airgap RKE1 cluster configurations in the main.tf file.
 func SetAirgapRKE1(rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig,
-	configMap []map[string]any, clusterName string, newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File) (*os.File, error) {
-	rke1.SetRancher2Cluster(rootBody, terraformConfig, terratestConfig, clusterName)
+	configMap []map[string]any, newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File) (*os.File, error) {
+	rke1.SetRancher2Cluster(rootBody, terraformConfig, terratestConfig)
 	rootBody.AppendNewline()
 
 	aws.CreateAWSInstances(rootBody, terraformConfig, terratestConfig, bastion)
@@ -39,7 +39,7 @@ func SetAirgapRKE1(rancherConfig *rancher.Config, terraformConfig *config.Terraf
 
 	rootBody.AppendNewline()
 
-	file, _ = locals.SetLocals(rootBody, terraformConfig, configMap, clusterName, newFile, file, nil)
+	file, _ = locals.SetLocals(rootBody, terraformConfig, configMap, newFile, file, nil)
 
 	rootBody.AppendNewline()
 
@@ -48,7 +48,7 @@ func SetAirgapRKE1(rancherConfig *rancher.Config, terraformConfig *config.Terraf
 		return nil, err
 	}
 
-	registrationCommands, nodePrivateIPs := getRKE1RegistrationCommands(clusterName)
+	registrationCommands, nodePrivateIPs := getRKE1RegistrationCommands(terraformConfig.ResourcePrefix)
 
 	for _, instance := range instances {
 		var dependsOn []string

--- a/framework/set/provisioning/airgap/setRKE2K3SConfig.go
+++ b/framework/set/provisioning/airgap/setRKE2K3SConfig.go
@@ -27,8 +27,8 @@ const (
 
 // // SetAirgapRKE2K3s is a function that will set the airgap RKE2/K3s cluster configurations in the main.tf file.
 func SetAirgapRKE2K3s(rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig,
-	configMap []map[string]any, clusterName string, newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File) (*os.File, error) {
-	v2.SetRancher2ClusterV2(rootBody, terraformConfig, terratestConfig, clusterName)
+	configMap []map[string]any, newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File) (*os.File, error) {
+	v2.SetRancher2ClusterV2(rootBody, terraformConfig, terratestConfig)
 	rootBody.AppendNewline()
 
 	aws.CreateAWSInstances(rootBody, terraformConfig, terratestConfig, bastion)
@@ -54,7 +54,7 @@ func SetAirgapRKE2K3s(rancherConfig *rancher.Config, terraformConfig *config.Ter
 
 	rootBody.AppendNewline()
 
-	file, _ = locals.SetLocals(rootBody, terraformConfig, configMap, clusterName, newFile, file, nil)
+	file, _ = locals.SetLocals(rootBody, terraformConfig, configMap, newFile, file, nil)
 
 	rootBody.AppendNewline()
 
@@ -63,7 +63,7 @@ func SetAirgapRKE2K3s(rancherConfig *rancher.Config, terraformConfig *config.Ter
 		return nil, err
 	}
 
-	registrationCommands, nodePrivateIPs := getRKE2K3sRegistrationCommands(terraformConfig, clusterName)
+	registrationCommands, nodePrivateIPs := getRKE2K3sRegistrationCommands(terraformConfig)
 
 	for _, instance := range instances {
 		var dependsOn []string
@@ -106,14 +106,14 @@ func SetAirgapRKE2K3s(rancherConfig *rancher.Config, terraformConfig *config.Ter
 }
 
 // getRKE2K3sRegistrationCommands is a helper function that will return the registration commands for the airgap nodes.
-func getRKE2K3sRegistrationCommands(terraformConfig *config.TerraformConfig, clusterName string) (map[string]string, map[string]string) {
+func getRKE2K3sRegistrationCommands(terraformConfig *config.TerraformConfig) (map[string]string, map[string]string) {
 	commands := make(map[string]string)
 	nodePrivateIPs := make(map[string]string)
 
-	etcdRegistrationCommand := fmt.Sprintf("${%s.%s_%s} %s", defaults.Local, clusterName, defaults.InsecureNodeCommand, defaults.EtcdRoleFlag)
-	controlPlaneRegistrationCommand := fmt.Sprintf("${%s.%s_%s} %s", defaults.Local, clusterName, defaults.InsecureNodeCommand, defaults.ControlPlaneRoleFlag)
-	workerRegistrationCommand := fmt.Sprintf("${%s.%s_%s} %s", defaults.Local, clusterName, defaults.InsecureNodeCommand, defaults.WorkerRoleFlag)
-	allRolesRegistrationCommand := fmt.Sprintf("${%s.%s_%s} %s", defaults.Local, clusterName, defaults.InsecureNodeCommand, defaults.AllFlags)
+	etcdRegistrationCommand := fmt.Sprintf("${%s.%s_%s} %s", defaults.Local, terraformConfig.ResourcePrefix, defaults.InsecureNodeCommand, defaults.EtcdRoleFlag)
+	controlPlaneRegistrationCommand := fmt.Sprintf("${%s.%s_%s} %s", defaults.Local, terraformConfig.ResourcePrefix, defaults.InsecureNodeCommand, defaults.ControlPlaneRoleFlag)
+	workerRegistrationCommand := fmt.Sprintf("${%s.%s_%s} %s", defaults.Local, terraformConfig.ResourcePrefix, defaults.InsecureNodeCommand, defaults.WorkerRoleFlag)
+	allRolesRegistrationCommand := fmt.Sprintf("${%s.%s_%s} %s", defaults.Local, terraformConfig.ResourcePrefix, defaults.InsecureNodeCommand, defaults.AllFlags)
 
 	airgapNodeOnePrivateIP := fmt.Sprintf("${%s.%s.%s}", defaults.AwsInstance, airgapNodeOne, defaults.PrivateIp)
 	airgapNodeTwoPrivateIP := fmt.Sprintf("${%s.%s.%s}", defaults.AwsInstance, airgapNodeTwo, defaults.PrivateIp)

--- a/framework/set/provisioning/custom/locals/setLocals.go
+++ b/framework/set/provisioning/custom/locals/setLocals.go
@@ -13,7 +13,7 @@ import (
 )
 
 // SetLocals is a function that will set the locals configurations in the main.tf file.
-func SetLocals(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, configMap []map[string]any, clusterName string, newFile *hclwrite.File, file *os.File, customClusterNames []string) (*os.File, error) {
+func SetLocals(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, configMap []map[string]any, newFile *hclwrite.File, file *os.File, customClusterNames []string) (*os.File, error) {
 	localsBlock := rootBody.AppendNewBlock(defaults.Locals, nil)
 	localsBlockBody := localsBlock.Body()
 
@@ -45,19 +45,19 @@ func SetLocals(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
 		//Temporary workaround until fetching insecure node command is available for rancher2_cluster_v2 resoureces with tfp-rancher2
 		if terraformConfig.Module == modules.CustomEC2RKE2 || terraformConfig.Module == modules.CustomEC2K3s ||
 			terraformConfig.Module == modules.AirgapRKE2 || terraformConfig.Module == modules.AirgapK3S {
-			originalNodeCommandExpressionClusterV2 := defaults.ClusterV2 + "." + clusterName + "." + defaults.ClusterRegistrationToken + "[0]." + defaults.NodeCommand
+			originalNodeCommandExpressionClusterV2 := defaults.ClusterV2 + "." + terraformConfig.ResourcePrefix + "." + defaults.ClusterRegistrationToken + "[0]." + defaults.NodeCommand
 			originalNodeCommand := hclwrite.Tokens{
 				{Type: hclsyntax.TokenIdent, Bytes: []byte(originalNodeCommandExpressionClusterV2)},
 			}
 
-			localsBlockBody.SetAttributeRaw(clusterName+"_"+defaults.OriginalNodeCommand, originalNodeCommand)
+			localsBlockBody.SetAttributeRaw(terraformConfig.ResourcePrefix+"_"+defaults.OriginalNodeCommand, originalNodeCommand)
 
-			insecureNodeCommandExpressionClusterV2 := fmt.Sprintf(`"curl --insecure ${substr(local.%s_original_node_command, 4, length(local.%s_original_node_command) - 4)}"`, clusterName, clusterName)
+			insecureNodeCommandExpressionClusterV2 := fmt.Sprintf(`"curl --insecure ${substr(local.%s_original_node_command, 4, length(local.%s_original_node_command) - 4)}"`, terraformConfig.ResourcePrefix, terraformConfig.ResourcePrefix)
 			insecureNodeCommand := hclwrite.Tokens{
 				{Type: hclsyntax.TokenIdent, Bytes: []byte(insecureNodeCommandExpressionClusterV2)},
 			}
 
-			localsBlockBody.SetAttributeRaw(clusterName+"_"+defaults.InsecureNodeCommand, insecureNodeCommand)
+			localsBlockBody.SetAttributeRaw(terraformConfig.ResourcePrefix+"_"+defaults.InsecureNodeCommand, insecureNodeCommand)
 		}
 	}
 

--- a/framework/set/provisioning/custom/nullresource/setNullResource.go
+++ b/framework/set/provisioning/custom/nullresource/setNullResource.go
@@ -11,11 +11,11 @@ import (
 
 // SetNullResource is a function that will set the null_resource configurations in the main.tf file,
 // to register the nodes to the cluster
-func SetNullResource(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, clusterName string) error {
-	nullResourceBlock := rootBody.AppendNewBlock(defaults.Resource, []string{defaults.NullResource, defaults.RegisterNodes + "-" + clusterName})
+func SetNullResource(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig) error {
+	nullResourceBlock := rootBody.AppendNewBlock(defaults.Resource, []string{defaults.NullResource, defaults.RegisterNodes + "-" + terraformConfig.ResourcePrefix})
 	nullResourceBlockBody := nullResourceBlock.Body()
 
-	countExpression := defaults.Length + `(` + defaults.AwsInstance + `.` + clusterName + `)`
+	countExpression := defaults.Length + `(` + defaults.AwsInstance + `.` + terraformConfig.ResourcePrefix + `)`
 	nullResourceBlockBody.SetAttributeRaw(defaults.Count, hclwrite.TokensForIdentifier(countExpression))
 
 	provisionerBlock := nullResourceBlockBody.AppendNewBlock(defaults.Provisioner, []string{defaults.RemoteExec})
@@ -23,7 +23,7 @@ func SetNullResource(rootBody *hclwrite.Body, terraformConfig *config.TerraformC
 
 	if terraformConfig.Module == modules.CustomEC2RKE1 {
 		regCommand := hclwrite.Tokens{
-			{Type: hclsyntax.TokenIdent, Bytes: []byte(`["${` + defaults.Cluster + `.` + clusterName + `.` + defaults.ClusterRegistrationToken + `[0].` + defaults.NodeCommand + `} ${` + defaults.Local + `.` + defaults.RoleFlags + `[` + defaults.Count + `.` + defaults.Index + `]}"]`)},
+			{Type: hclsyntax.TokenIdent, Bytes: []byte(`["${` + defaults.Cluster + `.` + terraformConfig.ResourcePrefix + `.` + defaults.ClusterRegistrationToken + `[0].` + defaults.NodeCommand + `} ${` + defaults.Local + `.` + defaults.RoleFlags + `[` + defaults.Count + `.` + defaults.Index + `]}"]`)},
 		}
 
 		provisionerBlockBody.SetAttributeRaw(defaults.Inline, regCommand)
@@ -31,7 +31,7 @@ func SetNullResource(rootBody *hclwrite.Body, terraformConfig *config.TerraformC
 
 	if terraformConfig.Module == modules.CustomEC2RKE2 || terraformConfig.Module == modules.CustomEC2K3s {
 		regCommand := hclwrite.Tokens{
-			{Type: hclsyntax.TokenIdent, Bytes: []byte(`["${` + defaults.Local + `.` + clusterName + "_" + defaults.InsecureNodeCommand + `} ${` + defaults.Local + `.` + defaults.RoleFlags + `[` + defaults.Count + `.` + defaults.Index + `]}"]`)},
+			{Type: hclsyntax.TokenIdent, Bytes: []byte(`["${` + defaults.Local + `.` + terraformConfig.ResourcePrefix + "_" + defaults.InsecureNodeCommand + `} ${` + defaults.Local + `.` + defaults.RoleFlags + `[` + defaults.Count + `.` + defaults.Index + `]}"]`)},
 		}
 
 		provisionerBlockBody.SetAttributeRaw(defaults.Inline, regCommand)
@@ -43,7 +43,7 @@ func SetNullResource(rootBody *hclwrite.Body, terraformConfig *config.TerraformC
 	connectionBlockBody.SetAttributeValue(defaults.Type, cty.StringVal(defaults.Ssh))
 	connectionBlockBody.SetAttributeValue(defaults.User, cty.StringVal(terraformConfig.AWSConfig.AWSUser))
 
-	hostExpression := defaults.AwsInstance + `.` + clusterName + `[` + defaults.Count + `.` + defaults.Index + `].` + defaults.PublicIp
+	hostExpression := defaults.AwsInstance + `.` + terraformConfig.ResourcePrefix + `[` + defaults.Count + `.` + defaults.Index + `].` + defaults.PublicIp
 	host := hclwrite.Tokens{
 		{Type: hclsyntax.TokenIdent, Bytes: []byte(hostExpression)},
 	}
@@ -58,7 +58,7 @@ func SetNullResource(rootBody *hclwrite.Body, terraformConfig *config.TerraformC
 	connectionBlockBody.SetAttributeRaw(defaults.PrivateKey, keyPath)
 
 	if terraformConfig.Module == modules.CustomEC2RKE1 {
-		clusterExpression := `[` + defaults.Cluster + `.` + clusterName + `]`
+		clusterExpression := `[` + defaults.Cluster + `.` + terraformConfig.ResourcePrefix + `]`
 		cluster := hclwrite.Tokens{
 			{Type: hclsyntax.TokenIdent, Bytes: []byte(clusterExpression)},
 		}
@@ -67,7 +67,7 @@ func SetNullResource(rootBody *hclwrite.Body, terraformConfig *config.TerraformC
 	}
 
 	if terraformConfig.Module == modules.CustomEC2RKE2 || terraformConfig.Module == modules.CustomEC2K3s {
-		clusterV2Expression := `[` + defaults.ClusterV2 + `.` + clusterName + `]`
+		clusterV2Expression := `[` + defaults.ClusterV2 + `.` + terraformConfig.ResourcePrefix + `]`
 		clusterV2 := hclwrite.Tokens{
 			{Type: hclsyntax.TokenIdent, Bytes: []byte(clusterV2Expression)},
 		}

--- a/framework/set/provisioning/custom/rke1/setConfig.go
+++ b/framework/set/provisioning/custom/rke1/setConfig.go
@@ -12,13 +12,13 @@ import (
 )
 
 // SetCustomRKE1 is a function that will set the custom RKE1 cluster configurations in the main.tf file.
-func SetCustomRKE1(rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig, configMap []map[string]any, clusterName string,
+func SetCustomRKE1(rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig, configMap []map[string]any,
 	newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File) (*os.File, error) {
-	aws.CreateAWSInstances(rootBody, terraformConfig, terratestConfig, clusterName)
+	aws.CreateAWSInstances(rootBody, terraformConfig, terratestConfig, terraformConfig.ResourcePrefix)
 
-	SetRancher2Cluster(rootBody, terraformConfig, terratestConfig, clusterName)
+	SetRancher2Cluster(rootBody, terraformConfig, terratestConfig)
 
-	nullresource.SetNullResource(rootBody, terraformConfig, clusterName)
+	nullresource.SetNullResource(rootBody, terraformConfig)
 
 	_, err := file.Write(newFile.Bytes())
 	if err != nil {

--- a/framework/set/provisioning/custom/rke1/setRancher2Cluster.go
+++ b/framework/set/provisioning/custom/rke1/setRancher2Cluster.go
@@ -8,12 +8,11 @@ import (
 )
 
 // SetRancher2Cluster is a function that will set the rancher2_cluster configurations in the main.tf file.
-func SetRancher2Cluster(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig,
-	clusterName string) error {
-	clusterBlock := rootBody.AppendNewBlock(defaults.Resource, []string{defaults.Cluster, clusterName})
+func SetRancher2Cluster(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig) error {
+	clusterBlock := rootBody.AppendNewBlock(defaults.Resource, []string{defaults.Cluster, terraformConfig.ResourcePrefix})
 	clusterBlockBody := clusterBlock.Body()
 
-	clusterBlockBody.SetAttributeValue(defaults.ResourceName, cty.StringVal(clusterName))
+	clusterBlockBody.SetAttributeValue(defaults.ResourceName, cty.StringVal(terraformConfig.ResourcePrefix))
 
 	rkeConfigBlock := clusterBlockBody.AppendNewBlock(defaults.RkeConfig, nil)
 	rkeConfigBlockBody := rkeConfigBlock.Body()

--- a/framework/set/provisioning/custom/rke2k3s/setConfig.go
+++ b/framework/set/provisioning/custom/rke2k3s/setConfig.go
@@ -12,13 +12,12 @@ import (
 )
 
 // SetCustomRKE2K3s is a function that will set the custom RKE2/K3s cluster configurations in the main.tf file.
-func SetCustomRKE2K3s(rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig, configMap []map[string]any, clusterName string,
-	newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File) (*os.File, error) {
-	aws.CreateAWSInstances(rootBody, terraformConfig, terratestConfig, clusterName)
+func SetCustomRKE2K3s(rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig, configMap []map[string]any, newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File) (*os.File, error) {
+	aws.CreateAWSInstances(rootBody, terraformConfig, terratestConfig, terraformConfig.ResourcePrefix)
 
-	SetRancher2ClusterV2(rootBody, terraformConfig, terratestConfig, clusterName)
+	SetRancher2ClusterV2(rootBody, terraformConfig, terratestConfig)
 
-	nullresource.SetNullResource(rootBody, terraformConfig, clusterName)
+	nullresource.SetNullResource(rootBody, terraformConfig)
 
 	_, err := file.Write(newFile.Bytes())
 	if err != nil {

--- a/framework/set/provisioning/custom/rke2k3s/setRancher2ClusterV2.go
+++ b/framework/set/provisioning/custom/rke2k3s/setRancher2ClusterV2.go
@@ -12,11 +12,11 @@ import (
 )
 
 // SetRancher2ClusterV2 is a function that will set the rancher2_cluster_v2 configurations in the main.tf file.
-func SetRancher2ClusterV2(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig, clusterName string) error {
-	rancher2ClusterV2Block := rootBody.AppendNewBlock(defaults.Resource, []string{defaults.ClusterV2, clusterName})
+func SetRancher2ClusterV2(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig) error {
+	rancher2ClusterV2Block := rootBody.AppendNewBlock(defaults.Resource, []string{defaults.ClusterV2, terraformConfig.ResourcePrefix})
 	rancher2ClusterV2BlockBody := rancher2ClusterV2Block.Body()
 
-	rancher2ClusterV2BlockBody.SetAttributeValue(defaults.ResourceName, cty.StringVal(clusterName))
+	rancher2ClusterV2BlockBody.SetAttributeValue(defaults.ResourceName, cty.StringVal(terraformConfig.ResourcePrefix))
 	rancher2ClusterV2BlockBody.SetAttributeValue(defaults.KubernetesVersion, cty.StringVal(terratestConfig.KubernetesVersion))
 
 	rkeConfigBlock := rancher2ClusterV2BlockBody.AppendNewBlock(defaults.RkeConfig, nil)
@@ -32,7 +32,7 @@ func SetRancher2ClusterV2(rootBody *hclwrite.Body, terraformConfig *config.Terra
 	if terraformConfig.PrivateRegistries != nil {
 		if terraformConfig.PrivateRegistries.Username != "" {
 			rootBody.AppendNewline()
-			v2.CreateRegistrySecret(terraformConfig, clusterName, rootBody)
+			v2.CreateRegistrySecret(terraformConfig, rootBody)
 		}
 
 		v2.SetMachineSelectorConfig(rkeConfigBlockBody, terraformConfig)

--- a/framework/set/provisioning/hosted/setAKS.go
+++ b/framework/set/provisioning/hosted/setAKS.go
@@ -16,12 +16,12 @@ import (
 )
 
 // SetAKS is a function that will set the AKS configurations in the main.tf file.
-func SetAKS(terraformConfig *config.TerraformConfig, clusterName, k8sVersion string, nodePools []config.Nodepool, newFile *hclwrite.File,
+func SetAKS(terraformConfig *config.TerraformConfig, k8sVersion string, nodePools []config.Nodepool, newFile *hclwrite.File,
 	rootBody *hclwrite.Body, file *os.File) (*os.File, error) {
 	cloudCredBlock := rootBody.AppendNewBlock(defaults.Resource, []string{defaults.CloudCredential, defaults.CloudCredential})
 	cloudCredBlockBody := cloudCredBlock.Body()
 
-	cloudCredBlockBody.SetAttributeValue(defaults.ResourceName, cty.StringVal(terraformConfig.CloudCredentialName))
+	cloudCredBlockBody.SetAttributeValue(defaults.ResourceName, cty.StringVal(terraformConfig.ResourcePrefix))
 
 	azCredConfigBlock := cloudCredBlockBody.AppendNewBlock(azure.AzureCredentialConfig, nil)
 	azCredConfigBlockBody := azCredConfigBlock.Body()
@@ -36,7 +36,7 @@ func SetAKS(terraformConfig *config.TerraformConfig, clusterName, k8sVersion str
 	clusterBlock := rootBody.AppendNewBlock(defaults.Resource, []string{defaults.Cluster, defaults.Cluster})
 	clusterBlockBody := clusterBlock.Body()
 
-	clusterBlockBody.SetAttributeValue(defaults.ResourceName, cty.StringVal(clusterName))
+	clusterBlockBody.SetAttributeValue(defaults.ResourceName, cty.StringVal(terraformConfig.ResourcePrefix))
 
 	aksConfigBlock := clusterBlockBody.AppendNewBlock(azure.AKSConfig, nil)
 	aksConfigBlockBody := aksConfigBlock.Body()
@@ -49,7 +49,7 @@ func SetAKS(terraformConfig *config.TerraformConfig, clusterName, k8sVersion str
 	aksConfigBlockBody.SetAttributeValue(azure.OutboundType, cty.StringVal(terraformConfig.AzureConfig.OutboundType))
 	aksConfigBlockBody.SetAttributeValue(azure.ResourceGroup, cty.StringVal(terraformConfig.AzureConfig.ResourceGroup))
 	aksConfigBlockBody.SetAttributeValue(azure.ResourceLocation, cty.StringVal(terraformConfig.AzureConfig.ResourceLocation))
-	aksConfigBlockBody.SetAttributeValue(azure.DNSPrefix, cty.StringVal(terraformConfig.HostnamePrefix))
+	aksConfigBlockBody.SetAttributeValue(azure.DNSPrefix, cty.StringVal(terraformConfig.ResourcePrefix))
 	aksConfigBlockBody.SetAttributeValue(defaults.KubernetesVersion, cty.StringVal(k8sVersion))
 	aksConfigBlockBody.SetAttributeValue(azure.NetworkPlugin, cty.StringVal(terraformConfig.NetworkPlugin))
 	aksConfigBlockBody.SetAttributeValue(azure.VirtualNetwork, cty.StringVal(terraformConfig.AzureConfig.Vnet))

--- a/framework/set/provisioning/hosted/setEKS.go
+++ b/framework/set/provisioning/hosted/setEKS.go
@@ -16,12 +16,12 @@ import (
 )
 
 // SetEKS is a function that will set the EKS configurations in the main.tf file.
-func SetEKS(terraformConfig *config.TerraformConfig, clusterName, k8sVersion string, nodePools []config.Nodepool, newFile *hclwrite.File,
+func SetEKS(terraformConfig *config.TerraformConfig, k8sVersion string, nodePools []config.Nodepool, newFile *hclwrite.File,
 	rootBody *hclwrite.Body, file *os.File) (*os.File, error) {
 	cloudCredBlock := rootBody.AppendNewBlock(defaults.Resource, []string{defaults.CloudCredential, defaults.CloudCredential})
 	cloudCredBlockBody := cloudCredBlock.Body()
 
-	cloudCredBlockBody.SetAttributeValue(defaults.ResourceName, cty.StringVal(terraformConfig.CloudCredentialName))
+	cloudCredBlockBody.SetAttributeValue(defaults.ResourceName, cty.StringVal(terraformConfig.ResourcePrefix))
 
 	ec2CredConfigBlock := cloudCredBlockBody.AppendNewBlock(amazon.EC2CredentialConfig, nil)
 	ec2CredConfigBlockBody := ec2CredConfigBlock.Body()
@@ -34,7 +34,7 @@ func SetEKS(terraformConfig *config.TerraformConfig, clusterName, k8sVersion str
 	clusterBlock := rootBody.AppendNewBlock(defaults.Resource, []string{defaults.Cluster, defaults.Cluster})
 	clusterBlockBody := clusterBlock.Body()
 
-	clusterBlockBody.SetAttributeValue(defaults.ResourceName, cty.StringVal(clusterName))
+	clusterBlockBody.SetAttributeValue(defaults.ResourceName, cty.StringVal(terraformConfig.ResourcePrefix))
 
 	eksConfigBlock := clusterBlockBody.AppendNewBlock(amazon.EKSConfig, nil)
 	eksConfigBlockBody := eksConfigBlock.Body()
@@ -64,7 +64,7 @@ func SetEKS(terraformConfig *config.TerraformConfig, clusterName, k8sVersion str
 		nodePoolsBlock := eksConfigBlockBody.AppendNewBlock(amazon.NodeGroups, nil)
 		nodePoolsBlockBody := nodePoolsBlock.Body()
 
-		nodePoolsBlockBody.SetAttributeValue(defaults.ResourceName, cty.StringVal(terraformConfig.HostnamePrefix+`-pool`+poolNum))
+		nodePoolsBlockBody.SetAttributeValue(defaults.ResourceName, cty.StringVal(terraformConfig.ResourcePrefix+`-pool`+poolNum))
 		nodePoolsBlockBody.SetAttributeValue(amazon.InstanceType, cty.StringVal(pool.InstanceType))
 		nodePoolsBlockBody.SetAttributeValue(amazon.DesiredSize, cty.NumberIntVal(pool.DesiredSize))
 		nodePoolsBlockBody.SetAttributeValue(amazon.MaxSize, cty.NumberIntVal(pool.MaxSize))

--- a/framework/set/provisioning/hosted/setGKE.go
+++ b/framework/set/provisioning/hosted/setGKE.go
@@ -15,11 +15,11 @@ import (
 )
 
 // SetGKE is a function that will set the GKE configurations in the main.tf file.
-func SetGKE(terraformConfig *config.TerraformConfig, clusterName, k8sVersion string, nodePools []config.Nodepool, newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File) (*os.File, error) {
+func SetGKE(terraformConfig *config.TerraformConfig, k8sVersion string, nodePools []config.Nodepool, newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File) (*os.File, error) {
 	cloudCredBlock := rootBody.AppendNewBlock(defaults.Resource, []string{defaults.CloudCredential, defaults.CloudCredential})
 	cloudCredBlockBody := cloudCredBlock.Body()
 
-	cloudCredBlockBody.SetAttributeValue(defaults.ResourceName, cty.StringVal(terraformConfig.CloudCredentialName))
+	cloudCredBlockBody.SetAttributeValue(defaults.ResourceName, cty.StringVal(terraformConfig.ResourcePrefix))
 
 	googleCredConfigBlock := cloudCredBlockBody.AppendNewBlock(google.GoogleCredentialConfig, nil)
 	googleCredConfigBlock.Body().SetAttributeValue(google.AuthEncodedJSON, cty.StringVal(terraformConfig.GoogleCredentials.AuthEncodedJSON))
@@ -29,12 +29,12 @@ func SetGKE(terraformConfig *config.TerraformConfig, clusterName, k8sVersion str
 	clusterBlock := rootBody.AppendNewBlock(defaults.Resource, []string{defaults.Cluster, defaults.Cluster})
 	clusterBlockBody := clusterBlock.Body()
 
-	clusterBlockBody.SetAttributeValue(defaults.ResourceName, cty.StringVal(clusterName))
+	clusterBlockBody.SetAttributeValue(defaults.ResourceName, cty.StringVal(terraformConfig.ResourcePrefix))
 
 	gkeConfigBlock := clusterBlockBody.AppendNewBlock(google.GKEConfig, nil)
 	gkeConfigBlockBody := gkeConfigBlock.Body()
 
-	gkeConfigBlockBody.SetAttributeValue(defaults.ResourceName, cty.StringVal(clusterName))
+	gkeConfigBlockBody.SetAttributeValue(defaults.ResourceName, cty.StringVal(terraformConfig.ResourcePrefix))
 
 	cloudCredSecret := hclwrite.Tokens{
 		{Type: hclsyntax.TokenIdent, Bytes: []byte(defaults.CloudCredential + "." + defaults.CloudCredential + ".id")},
@@ -60,7 +60,7 @@ func SetGKE(terraformConfig *config.TerraformConfig, clusterName, k8sVersion str
 
 		nodePoolsBlockBody.SetAttributeValue(google.InitialNodeCount, cty.NumberIntVal(pool.Quantity))
 		nodePoolsBlockBody.SetAttributeValue(google.MaxPodsConstraint, cty.NumberIntVal(pool.MaxPodsContraint))
-		nodePoolsBlockBody.SetAttributeValue(defaults.ResourceName, cty.StringVal(terraformConfig.HostnamePrefix+`-pool`+poolNum))
+		nodePoolsBlockBody.SetAttributeValue(defaults.ResourceName, cty.StringVal(terraformConfig.ResourcePrefix+`-pool`+poolNum))
 		nodePoolsBlockBody.SetAttributeValue(google.Version, cty.StringVal(k8sVersion))
 	}
 

--- a/framework/set/provisioning/imported/importedRKE2K3SConfig.go
+++ b/framework/set/provisioning/imported/importedRKE2K3SConfig.go
@@ -30,13 +30,13 @@ const (
 
 // // SetImportedRKE2K3s is a function that will set the imported RKE2/K3s cluster configurations in the main.tf file.
 func SetImportedRKE2K3s(rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig,
-	clusterName string, newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File) (*os.File, error) {
-	SetImportedCluster(rootBody, clusterName)
+	newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File) (*os.File, error) {
+	SetImportedCluster(rootBody, terraformConfig.ResourcePrefix)
 
 	rootBody.AppendNewline()
-	serverOneName := clusterName + `_` + serverOne
-	serverTwoName := clusterName + `_` + serverTwo
-	serverThreeName := clusterName + `_` + serverThree
+	serverOneName := terraformConfig.ResourcePrefix + `_` + serverOne
+	serverTwoName := terraformConfig.ResourcePrefix + `_` + serverTwo
+	serverThreeName := terraformConfig.ResourcePrefix + `_` + serverThree
 	instances := []string{serverOneName, serverTwoName, serverThreeName}
 
 	for _, instance := range instances {
@@ -51,13 +51,13 @@ func SetImportedRKE2K3s(rancherConfig *rancher.Config, terraformConfig *config.T
 	nodeTwoPublicDNS = fmt.Sprintf("${%s.%s.public_dns}", defaults.AwsInstance, serverTwoName)
 	nodeThreePublicDNS = fmt.Sprintf("${%s.%s.public_dns}", defaults.AwsInstance, serverThreeName)
 
-	imported.CreateRKE2K3SImportedCluster(rootBody, terraformConfig, nodeOnePublicDNS, nodeOnePrivateIP, nodeTwoPublicDNS, nodeThreePublicDNS, clusterName)
+	imported.CreateRKE2K3SImportedCluster(rootBody, terraformConfig, nodeOnePublicDNS, nodeOnePrivateIP, nodeTwoPublicDNS, nodeThreePublicDNS)
 
 	rootBody.AppendNewline()
 
-	importCommand := getImportCommand(clusterName)
+	importCommand := getImportCommand(terraformConfig.ResourcePrefix)
 
-	err := importNodes(rootBody, terraformConfig, nodeOnePublicDNS, "", importCommand[serverOneName], clusterName)
+	err := importNodes(rootBody, terraformConfig, nodeOnePublicDNS, "", importCommand[serverOneName])
 	if err != nil {
 		return nil, err
 	}

--- a/framework/set/provisioning/nodedriver/rke2k3s/createRegistrySecret.go
+++ b/framework/set/provisioning/nodedriver/rke2k3s/createRegistrySecret.go
@@ -17,8 +17,8 @@ const (
 )
 
 // CreateRegistrySecret is a function that will set the airgap RKE2/K3s cluster configurations in the main.tf file.
-func CreateRegistrySecret(terraformConfig *config.TerraformConfig, clusterName string, rootBody *hclwrite.Body) {
-	secretBlock := rootBody.AppendNewBlock(defaults.Resource, []string{defaults.SecretV2, clusterName})
+func CreateRegistrySecret(terraformConfig *config.TerraformConfig, rootBody *hclwrite.Body) {
+	secretBlock := rootBody.AppendNewBlock(defaults.Resource, []string{defaults.SecretV2, terraformConfig.ResourcePrefix})
 	secretBlockBody := secretBlock.Body()
 
 	secretBlockBody.SetAttributeValue(clusterID, cty.StringVal(localCluster))

--- a/framework/set/provisioning/nodedriver/rke2k3s/setEtcdConfig.go
+++ b/framework/set/provisioning/nodedriver/rke2k3s/setEtcdConfig.go
@@ -12,7 +12,7 @@ import (
 )
 
 // setEtcdConfig is a function that will set the etcd configurations in the main.tf file.
-func setEtcdConfig(rkeConfigBlockBody *hclwrite.Body, terraformConfig *config.TerraformConfig, clusterName string) error {
+func setEtcdConfig(rkeConfigBlockBody *hclwrite.Body, terraformConfig *config.TerraformConfig) error {
 	snapshotBlock := rkeConfigBlockBody.AppendNewBlock(defaults.Etcd, nil)
 	snapshotBlockBody := snapshotBlock.Body()
 
@@ -25,7 +25,7 @@ func setEtcdConfig(rkeConfigBlockBody *hclwrite.Body, terraformConfig *config.Te
 		s3ConfigBlockBody := s3ConfigBlock.Body()
 
 		cloudCredSecretName := hclwrite.Tokens{
-			{Type: hclsyntax.TokenIdent, Bytes: []byte(defaults.CloudCredential + "." + clusterName + ".id")},
+			{Type: hclsyntax.TokenIdent, Bytes: []byte(defaults.CloudCredential + "." + terraformConfig.ResourcePrefix + ".id")},
 		}
 
 		s3ConfigBlockBody.SetAttributeValue(bucket, cty.StringVal(terraformConfig.ETCD.S3.Bucket))

--- a/framework/set/provisioning/nodedriver/rke2k3s/setMachinePool.go
+++ b/framework/set/provisioning/nodedriver/rke2k3s/setMachinePool.go
@@ -11,8 +11,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-func setMachinePool(terraformConfig *config.TerraformConfig, count int, pool config.Nodepool, rkeConfigBlockBody *hclwrite.Body,
-	poolName, clusterName string) error {
+func setMachinePool(terraformConfig *config.TerraformConfig, count int, pool config.Nodepool, rkeConfigBlockBody *hclwrite.Body) error {
 	poolNum := strconv.Itoa(count)
 
 	_, err := resources.SetResourceNodepoolValidation(terraformConfig, pool, poolNum)
@@ -23,10 +22,10 @@ func setMachinePool(terraformConfig *config.TerraformConfig, count int, pool con
 	machinePoolsBlock := rkeConfigBlockBody.AppendNewBlock(defaults.MachinePools, nil)
 	machinePoolsBlockBody := machinePoolsBlock.Body()
 
-	machinePoolsBlockBody.SetAttributeValue(defaults.ResourceName, cty.StringVal(clusterName+poolName+poolNum))
+	machinePoolsBlockBody.SetAttributeValue(defaults.ResourceName, cty.StringVal("pool"+poolNum))
 
 	cloudCredSecretName := hclwrite.Tokens{
-		{Type: hclsyntax.TokenIdent, Bytes: []byte(defaults.CloudCredential + "." + clusterName + ".id")},
+		{Type: hclsyntax.TokenIdent, Bytes: []byte(defaults.CloudCredential + "." + terraformConfig.ResourcePrefix + ".id")},
 	}
 
 	machinePoolsBlockBody.SetAttributeRaw(cloudCredentialSecretName, cloudCredSecretName)
@@ -39,13 +38,13 @@ func setMachinePool(terraformConfig *config.TerraformConfig, count int, pool con
 	machineConfigBlockBody := machineConfigBlock.Body()
 
 	kind := hclwrite.Tokens{
-		{Type: hclsyntax.TokenIdent, Bytes: []byte(machineConfigV2 + "." + clusterName + ".kind")},
+		{Type: hclsyntax.TokenIdent, Bytes: []byte(machineConfigV2 + "." + terraformConfig.ResourcePrefix + ".kind")},
 	}
 
 	machineConfigBlockBody.SetAttributeRaw(defaults.ResourceKind, kind)
 
 	name := hclwrite.Tokens{
-		{Type: hclsyntax.TokenIdent, Bytes: []byte(machineConfigV2 + "." + clusterName + ".name")},
+		{Type: hclsyntax.TokenIdent, Bytes: []byte(machineConfigV2 + "." + terraformConfig.ResourcePrefix + ".name")},
 	}
 
 	machineConfigBlockBody.SetAttributeRaw(defaults.ResourceName, name)

--- a/framework/set/provisioning/providers/aws/awsProviders.go
+++ b/framework/set/provisioning/providers/aws/awsProviders.go
@@ -40,11 +40,11 @@ func SetAWSRKE1Provider(nodeTemplateBlockBody *hclwrite.Body, terraformConfig *c
 
 // SetAWSRKE2K3SProvider is a helper function that will set the AWS RKE2/K3S
 // Terraform provider details in the main.tf file.
-func SetAWSRKE2K3SProvider(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, clusterName string) {
-	cloudCredBlock := rootBody.AppendNewBlock(defaults.Resource, []string{defaults.CloudCredential, clusterName})
+func SetAWSRKE2K3SProvider(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig) {
+	cloudCredBlock := rootBody.AppendNewBlock(defaults.Resource, []string{defaults.CloudCredential, terraformConfig.ResourcePrefix})
 	cloudCredBlockBody := cloudCredBlock.Body()
 
-	cloudCredBlockBody.SetAttributeValue(defaults.ResourceName, cty.StringVal(clusterName))
+	cloudCredBlockBody.SetAttributeValue(defaults.ResourceName, cty.StringVal(terraformConfig.ResourcePrefix))
 
 	awsCredBlock := cloudCredBlockBody.AppendNewBlock(amazon.EC2CredentialConfig, nil)
 	awsCredBlockBody := awsCredBlock.Body()

--- a/framework/set/provisioning/providers/azure/azureProviders.go
+++ b/framework/set/provisioning/providers/azure/azureProviders.go
@@ -43,11 +43,11 @@ func SetAzureRKE1Provider(nodeTemplateBlockBody *hclwrite.Body, terraformConfig 
 }
 
 // SetAzureRKE2K3SProvider is a helper function that will set the Azure RKE2/K3S Terraform provider details in the main.tf file.
-func SetAzureRKE2K3SProvider(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, clusterName string) {
-	cloudCredBlock := rootBody.AppendNewBlock(defaults.Resource, []string{defaults.CloudCredential, clusterName})
+func SetAzureRKE2K3SProvider(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig) {
+	cloudCredBlock := rootBody.AppendNewBlock(defaults.Resource, []string{defaults.CloudCredential, terraformConfig.ResourcePrefix})
 	cloudCredBlockBody := cloudCredBlock.Body()
 
-	cloudCredBlockBody.SetAttributeValue(defaults.ResourceName, cty.StringVal(terraformConfig.CloudCredentialName))
+	cloudCredBlockBody.SetAttributeValue(defaults.ResourceName, cty.StringVal(terraformConfig.ResourcePrefix))
 
 	azureCredBlock := cloudCredBlockBody.AppendNewBlock(azure.AzureCredentialConfig, nil)
 	azureCredBlockBody := azureCredBlock.Body()

--- a/framework/set/provisioning/providers/harvester/harvesterProviders.go
+++ b/framework/set/provisioning/providers/harvester/harvesterProviders.go
@@ -11,11 +11,11 @@ import (
 )
 
 // SetHarvesterRKE1Provider is a helper function that will set the Harvester RKE1 terraform configurations in the main.tf file.
-func SetHarvesterRKE1Provider(nodeTemplateBlockBody *hclwrite.Body, terraformConfig *config.TerraformConfig, clusterName string) {
+func SetHarvesterRKE1Provider(nodeTemplateBlockBody *hclwrite.Body, terraformConfig *config.TerraformConfig) {
 	nodeTemplateBlockBody.SetAttributeValue("engine_install_url", cty.StringVal("https://releases.rancher.com/install-docker/26.1.sh"))
 
 	cloudCredID := hclwrite.Tokens{
-		{Type: hclsyntax.TokenIdent, Bytes: []byte(defaults.CloudCredential + "." + clusterName + ".id")},
+		{Type: hclsyntax.TokenIdent, Bytes: []byte(defaults.CloudCredential + "." + terraformConfig.ResourcePrefix + ".id")},
 	}
 	nodeTemplateBlockBody.SetAttributeRaw(defaults.CloudCredentialID, cloudCredID)
 
@@ -37,11 +37,11 @@ func SetHarvesterRKE1Provider(nodeTemplateBlockBody *hclwrite.Body, terraformCon
 }
 
 // SetHarvesterCredentialProvider is a helper function that will set the Harvester cloud provider in main.tf
-func SetHarvesterCredentialProvider(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, clusterName string) {
-	cloudCredBlock := rootBody.AppendNewBlock(defaults.Resource, []string{defaults.CloudCredential, clusterName})
+func SetHarvesterCredentialProvider(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig) {
+	cloudCredBlock := rootBody.AppendNewBlock(defaults.Resource, []string{defaults.CloudCredential, terraformConfig.ResourcePrefix})
 	cloudCredBlockBody := cloudCredBlock.Body()
 
-	cloudCredBlockBody.SetAttributeValue(defaults.ResourceName, cty.StringVal(clusterName))
+	cloudCredBlockBody.SetAttributeValue(defaults.ResourceName, cty.StringVal(terraformConfig.ResourcePrefix))
 
 	harvesterCredBlock := cloudCredBlockBody.AppendNewBlock(harvester.HarvesterCredentialConfig, nil)
 	harvesterCredBlockBody := harvesterCredBlock.Body()

--- a/framework/set/provisioning/providers/linode/linodeProviders.go
+++ b/framework/set/provisioning/providers/linode/linodeProviders.go
@@ -23,11 +23,11 @@ func SetLinodeRKE1Provider(nodeTemplateBlockBody *hclwrite.Body, terraformConfig
 
 // SetLinodeRKE2K3SProvider is a helper function that will set the Linode RKE2/K3S
 // Terraform provider details in the main.tf file.
-func SetLinodeRKE2K3SProvider(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, clusterName string) {
-	cloudCredBlock := rootBody.AppendNewBlock(defaults.Resource, []string{defaults.CloudCredential, clusterName})
+func SetLinodeRKE2K3SProvider(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig) {
+	cloudCredBlock := rootBody.AppendNewBlock(defaults.Resource, []string{defaults.CloudCredential, terraformConfig.ResourcePrefix})
 	cloudCredBlockBody := cloudCredBlock.Body()
 
-	cloudCredBlockBody.SetAttributeValue(defaults.ResourceName, cty.StringVal(terraformConfig.CloudCredentialName))
+	cloudCredBlockBody.SetAttributeValue(defaults.ResourceName, cty.StringVal(terraformConfig.ResourcePrefix))
 
 	linodeCredBlock := cloudCredBlockBody.AppendNewBlock(linode.LinodeCredentialConfig, nil)
 	linodeCredBlockBody := linodeCredBlock.Body()

--- a/framework/set/provisioning/providers/vsphere/vsphereProviders.go
+++ b/framework/set/provisioning/providers/vsphere/vsphereProviders.go
@@ -52,11 +52,11 @@ func SetVsphereRKE1Provider(nodeTemplateBlockBody *hclwrite.Body, terraformConfi
 }
 
 // SetVsphereRKE2K3SProvider is a helper function that will set the Vsphere RKE2/K3S Terraform provider details in the main.tf file.
-func SetVsphereRKE2K3SProvider(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, clusterName string) {
-	cloudCredBlock := rootBody.AppendNewBlock(defaults.Resource, []string{defaults.CloudCredential, clusterName})
+func SetVsphereRKE2K3SProvider(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig) {
+	cloudCredBlock := rootBody.AppendNewBlock(defaults.Resource, []string{defaults.CloudCredential, terraformConfig.ResourcePrefix})
 	cloudCredBlockBody := cloudCredBlock.Body()
 
-	cloudCredBlockBody.SetAttributeValue(defaults.ResourceName, cty.StringVal(terraformConfig.CloudCredentialName))
+	cloudCredBlockBody.SetAttributeValue(defaults.ResourceName, cty.StringVal(terraformConfig.ResourcePrefix))
 
 	vsphereCredBlock := cloudCredBlockBody.AppendNewBlock(vsphere.VsphereCredentialConfig, nil)
 	vsphereCredBlockBody := vsphereCredBlock.Body()

--- a/framework/set/rbac/setProject.go
+++ b/framework/set/rbac/setProject.go
@@ -27,8 +27,8 @@ const (
 )
 
 // AddProjectMember is a helper function that will add the RBAC project member to `user` in the main.tf file.
-func AddProjectMember(client *rancher.Client, clusterName string, newFile *hclwrite.File, rootBody *hclwrite.Body,
-	clusterBlockID hclwrite.Tokens, rbacRole config.Role, newUser string, isRKE1 bool) (*hclwrite.File, *hclwrite.Body) {
+func AddProjectMember(client *rancher.Client, newFile *hclwrite.File, rootBody *hclwrite.Body,
+	clusterBlockID hclwrite.Tokens, rbacRole config.Role, newUser, clusterName string, isRKE1 bool) (*hclwrite.File, *hclwrite.Body) {
 	projectBlock := rootBody.AppendNewBlock(defaults.Resource, []string{project, project})
 	projectBlockBody := projectBlock.Body()
 
@@ -65,8 +65,8 @@ func AddProjectMember(client *rancher.Client, clusterName string, newFile *hclwr
 }
 
 // AddClusterRole is a helper function that will add the RBAC cluster role to non `user` member in the main.tf file.
-func AddClusterRole(client *rancher.Client, clusterName string, newFile *hclwrite.File, rootBody *hclwrite.Body, clusterBlockID hclwrite.Tokens,
-	rbacRole config.Role, newUser string, isRKE1 bool) (*hclwrite.File, *hclwrite.Body) {
+func AddClusterRole(client *rancher.Client, newFile *hclwrite.File, rootBody *hclwrite.Body, clusterBlockID hclwrite.Tokens,
+	rbacRole config.Role, newUser, clusterName string, isRKE1 bool) (*hclwrite.File, *hclwrite.Body) {
 	clusterRoleTemplateBindingBlock := rootBody.AppendNewBlock(defaults.Resource, []string{clusterRoleTemplateBinding, clusterRoleTemplateBinding})
 	clusterRoleTemplateBindingBlockBody := clusterRoleTemplateBindingBlock.Body()
 

--- a/framework/set/resources/airgap/aws/instances.go
+++ b/framework/set/resources/airgap/aws/instances.go
@@ -39,7 +39,7 @@ func CreateAirgappedAWSInstances(rootBody *hclwrite.Body, terraformConfig *confi
 	tagsBlock := configBlockBody.AppendNewBlock(defaults.Tags+" =", nil)
 	tagsBlockBody := tagsBlock.Body()
 
-	expression := fmt.Sprintf(`"%s`, terraformConfig.HostnamePrefix+"-"+hostnamePrefix+`"`)
+	expression := fmt.Sprintf(`"%s`, terraformConfig.ResourcePrefix+"-"+hostnamePrefix+`"`)
 	tags := hclwrite.Tokens{
 		{Type: hclsyntax.TokenIdent, Bytes: []byte(expression)},
 	}

--- a/framework/set/resources/sanity/aws/instances.go
+++ b/framework/set/resources/sanity/aws/instances.go
@@ -57,14 +57,14 @@ func CreateAWSInstances(rootBody *hclwrite.Body, terraformConfig *config.Terrafo
 	tagsBlockBody := tagsBlock.Body()
 
 	if strings.Contains(terraformConfig.Module, "custom") {
-		expression := fmt.Sprintf(`"%s-${`+defaults.Count+`.`+defaults.Index+`}"`, terraformConfig.HostnamePrefix)
+		expression := fmt.Sprintf(`"%s-${`+defaults.Count+`.`+defaults.Index+`}"`, terraformConfig.ResourcePrefix)
 		tags := hclwrite.Tokens{
 			{Type: hclsyntax.TokenIdent, Bytes: []byte(expression)},
 		}
 
 		tagsBlockBody.SetAttributeRaw(defaults.Name, tags)
 	} else {
-		expression := fmt.Sprintf(`"%s`, terraformConfig.HostnamePrefix+"-"+hostnamePrefix+`"`)
+		expression := fmt.Sprintf(`"%s`, terraformConfig.ResourcePrefix+`"`)
 		tags := hclwrite.Tokens{
 			{Type: hclsyntax.TokenIdent, Bytes: []byte(expression)},
 		}

--- a/framework/set/resources/sanity/aws/loadbalancer.go
+++ b/framework/set/resources/sanity/aws/loadbalancer.go
@@ -24,7 +24,7 @@ func CreateLoadBalancer(rootBody *hclwrite.Body, terraformConfig *config.Terrafo
 
 	subnetList := format.ListOfStrings([]string{terraformConfig.AWSConfig.AWSSubnetID})
 	loadBalancerGroupBodyBlockBody.SetAttributeRaw(defaults.Subnets, subnetList)
-	loadBalancerGroupBodyBlockBody.SetAttributeValue(name, cty.StringVal(terraformConfig.HostnamePrefix))
+	loadBalancerGroupBodyBlockBody.SetAttributeValue(name, cty.StringVal(terraformConfig.ResourcePrefix))
 }
 
 // CreateInternalLoadBalancer is a function that will set the internal load balancer configurations in the main.tf file.
@@ -37,5 +37,5 @@ func CreateInternalLoadBalancer(rootBody *hclwrite.Body, terraformConfig *config
 
 	subnetList := format.ListOfStrings([]string{terraformConfig.AWSConfig.AWSSubnetID})
 	loadBalancerGroupBodyBlockBody.SetAttributeRaw(defaults.Subnets, subnetList)
-	loadBalancerGroupBodyBlockBody.SetAttributeValue(name, cty.StringVal(terraformConfig.HostnamePrefix+"-"+internal))
+	loadBalancerGroupBodyBlockBody.SetAttributeValue(name, cty.StringVal(terraformConfig.ResourcePrefix+"-"+internal))
 }

--- a/framework/set/resources/sanity/aws/route53.go
+++ b/framework/set/resources/sanity/aws/route53.go
@@ -29,7 +29,7 @@ func CreateRoute53Record(rootBody *hclwrite.Body, terraformConfig *config.Terraf
 	}
 
 	routeRecordBlockBody.SetAttributeRaw(zoneID, values)
-	routeRecordBlockBody.SetAttributeValue(name, cty.StringVal(terraformConfig.HostnamePrefix))
+	routeRecordBlockBody.SetAttributeValue(name, cty.StringVal(terraformConfig.ResourcePrefix))
 	routeRecordBlockBody.SetAttributeValue(defaults.Type, cty.StringVal(CNAME))
 	routeRecordBlockBody.SetAttributeValue(ttl, cty.NumberIntVal(300))
 
@@ -60,7 +60,7 @@ func CreateRoute53InternalRecord(rootBody *hclwrite.Body, terraformConfig *confi
 	}
 
 	routeRecordBlockBody.SetAttributeRaw(zoneID, values)
-	routeRecordBlockBody.SetAttributeValue(name, cty.StringVal(terraformConfig.HostnamePrefix+"-internal"))
+	routeRecordBlockBody.SetAttributeValue(name, cty.StringVal(terraformConfig.ResourcePrefix+"-internal"))
 	routeRecordBlockBody.SetAttributeValue(defaults.Type, cty.StringVal(CNAME))
 	routeRecordBlockBody.SetAttributeValue(ttl, cty.NumberIntVal(300))
 

--- a/framework/set/resources/sanity/aws/targetGroups.go
+++ b/framework/set/resources/sanity/aws/targetGroups.go
@@ -31,7 +31,7 @@ func CreateTargetGroups(rootBody *hclwrite.Body, terraformConfig *config.Terrafo
 	targetGroupBlockBody.SetAttributeValue(defaults.Port, cty.NumberIntVal(port))
 	targetGroupBlockBody.SetAttributeValue(protocol, cty.StringVal(TCP))
 	targetGroupBlockBody.SetAttributeValue(defaults.VpcId, cty.StringVal(terraformConfig.AWSConfig.AWSVpcID))
-	targetGroupBlockBody.SetAttributeValue(name, cty.StringVal(terraformConfig.HostnamePrefix+"-tg-"+strconv.FormatInt(port, 10)))
+	targetGroupBlockBody.SetAttributeValue(name, cty.StringVal(terraformConfig.ResourcePrefix+"-tg-"+strconv.FormatInt(port, 10)))
 
 	healthCheckGroupBlock := targetGroupBlockBody.AppendNewBlock(defaults.HealthCheck, nil)
 	healthCheckGroupBlockBody := healthCheckGroupBlock.Body()
@@ -54,7 +54,7 @@ func CreateInternalTargetGroups(rootBody *hclwrite.Body, terraformConfig *config
 	targetGroupBlockBody.SetAttributeValue(defaults.Port, cty.NumberIntVal(port))
 	targetGroupBlockBody.SetAttributeValue(protocol, cty.StringVal(TCP))
 	targetGroupBlockBody.SetAttributeValue(defaults.VpcId, cty.StringVal(terraformConfig.AWSConfig.AWSVpcID))
-	targetGroupBlockBody.SetAttributeValue(name, cty.StringVal(terraformConfig.HostnamePrefix+"-internal-tg-"+strconv.FormatInt(port, 10)))
+	targetGroupBlockBody.SetAttributeValue(name, cty.StringVal(terraformConfig.ResourcePrefix+"-internal-tg-"+strconv.FormatInt(port, 10)))
 
 	healthCheckGroupBlock := targetGroupBlockBody.AppendNewBlock(defaults.HealthCheck, nil)
 	healthCheckGroupBlockBody := healthCheckGroupBlock.Body()

--- a/framework/set/setAuthConfig.go
+++ b/framework/set/setAuthConfig.go
@@ -38,7 +38,7 @@ func AuthConfig(terraformConfig *config.TerraformConfig, testUser, testPassword 
 
 	defer file.Close()
 
-	newFile, rootBody := resources.SetProvidersAndUsersTF(rancherConfig, terraformConfig, testUser, testPassword, true, nil)
+	newFile, rootBody := resources.SetProvidersAndUsersTF(testUser, testPassword, true, nil)
 
 	rootBody.AppendNewline()
 

--- a/tests/extensions/provisioning/buildModule.go
+++ b/tests/extensions/provisioning/buildModule.go
@@ -17,7 +17,7 @@ import (
 func BuildModule(t *testing.T, rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig, configMap []map[string]any) error {
 	keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath)
 
-	_, err := framework.ConfigTF(nil, rancherConfig, terraformConfig, terratestConfig, "", "", "", "", "", configMap)
+	_, err := framework.ConfigTF(nil, "", "", "", configMap)
 	if err != nil {
 		return err
 	}

--- a/tests/extensions/provisioning/kubernetesUpgrade.go
+++ b/tests/extensions/provisioning/kubernetesUpgrade.go
@@ -13,10 +13,10 @@ import (
 // KubernetesUpgrade is a function that will run terraform apply and uprade the
 // Kubernetes version of the provisioned cluster.
 func KubernetesUpgrade(t *testing.T, client *rancher.Client, rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig,
-	terratestConfig *config.TerratestConfig, testUser, testPassword, clusterName, poolName string, terraformOptions *terraform.Options, configMap []map[string]any) {
+	terratestConfig *config.TerratestConfig, testUser, testPassword string, terraformOptions *terraform.Options, configMap []map[string]any) {
 	DefaultUpgradedK8sVersion(t, client, terratestConfig, terraformConfig, configMap)
 
-	_, err := framework.ConfigTF(client, rancherConfig, terraformConfig, terratestConfig, testUser, testPassword, clusterName, poolName, "", configMap)
+	_, err := framework.ConfigTF(client, testUser, testPassword, "", configMap)
 	require.NoError(t, err)
 
 	terraform.Apply(t, terraformOptions)

--- a/tests/extensions/provisioning/provision.go
+++ b/tests/extensions/provisioning/provision.go
@@ -13,7 +13,7 @@ import (
 
 // Provision is a function that will run terraform init and apply Terraform resources to provision a cluster.
 func Provision(t *testing.T, client *rancher.Client, rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig,
-	terratestConfig *config.TerratestConfig, testUser, testPassword, clusterName, poolName string, terraformOptions *terraform.Options, configMap []map[string]any) []string {
+	terratestConfig *config.TerratestConfig, testUser, testPassword string, terraformOptions *terraform.Options, configMap []map[string]any) []string {
 	var err error
 	var clusterNames []string
 	var clusterIDs []string
@@ -21,7 +21,7 @@ func Provision(t *testing.T, client *rancher.Client, rancherConfig *rancher.Conf
 	isSupported := SupportedModules(terraformConfig, terraformOptions, configMap)
 	require.True(t, isSupported)
 
-	clusterNames, err = framework.ConfigTF(client, rancherConfig, terraformConfig, terratestConfig, testUser, testPassword, clusterName, poolName, "", configMap)
+	clusterNames, err = framework.ConfigTF(client, testUser, testPassword, "", configMap)
 	require.NoError(t, err)
 
 	terraform.InitAndApply(t, terraformOptions)

--- a/tests/extensions/provisioning/scale.go
+++ b/tests/extensions/provisioning/scale.go
@@ -13,8 +13,8 @@ import (
 // Scale is a function that will run terraform apply and scale the provisioned
 // cluster, according to user's desired amount.
 func Scale(t *testing.T, client *rancher.Client, rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig,
-	testUser, testPassword, clusterName, poolName string, terraformOptions *terraform.Options, configMap []map[string]any) {
-	_, err := framework.ConfigTF(client, rancherConfig, terraformConfig, terratestConfig, testUser, testPassword, clusterName, poolName, "", configMap)
+	testUser, testPassword string, terraformOptions *terraform.Options, configMap []map[string]any) {
+	_, err := framework.ConfigTF(client, testUser, testPassword, "", configMap)
 	require.NoError(t, err)
 
 	terraform.Apply(t, terraformOptions)

--- a/tests/extensions/provisioning/uniquify.go
+++ b/tests/extensions/provisioning/uniquify.go
@@ -1,0 +1,42 @@
+package provisioning
+
+import (
+	"github.com/rancher/shepherd/pkg/config/operations"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	"github.com/rancher/tfp-automation/config"
+)
+
+const (
+	resourcePrefixKey = "resourcePrefix"
+)
+
+func UniquifyTerraform(cattleConfigs []map[string]any) ([]map[string]any, error) {
+	resourcePrefix := []string{config.TerraformConfigurationFileKey, resourcePrefixKey}
+	var uniqueCattleConfigs []map[string]any
+	for _, cattleConfig := range cattleConfigs {
+		cattleConfig, err := uniquifyField(resourcePrefix, cattleConfig)
+		if err != nil {
+			return nil, err
+		}
+
+		uniqueCattleConfigs = append(uniqueCattleConfigs, cattleConfig)
+	}
+
+	return uniqueCattleConfigs, nil
+}
+
+func uniquifyField(keyPath []string, cattleConfig map[string]any) (map[string]any, error) {
+	keyPathValue, err := operations.GetValue(keyPath, cattleConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	keyPathValue = namegen.AppendRandomString(keyPathValue.(string))
+
+	uniqueCattleConfig, err := operations.ReplaceValue(keyPath, keyPathValue, cattleConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return uniqueCattleConfig, nil
+}

--- a/tests/extensions/rbac/rbac.go
+++ b/tests/extensions/rbac/rbac.go
@@ -12,9 +12,9 @@ import (
 
 // RBAC is a function that will run terraform apply to create users.
 func RBAC(t *testing.T, client *rancher.Client, rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig,
-	terratestConfig *config.TerratestConfig, testUser, testPassword, clusterName, poolName string, terraformOptions *terraform.Options,
+	terratestConfig *config.TerratestConfig, testUser, testPassword string, terraformOptions *terraform.Options,
 	rbacRole config.Role) {
-	_, err := framework.ConfigTF(client, rancherConfig, terraformConfig, terratestConfig, testUser, testPassword, clusterName, poolName, rbacRole, nil)
+	_, err := framework.ConfigTF(client, testUser, testPassword, rbacRole, nil)
 	require.NoError(t, err)
 
 	terraform.Apply(t, terraformOptions)

--- a/tests/proxy/proxy_provisioning_test.go
+++ b/tests/proxy/proxy_provisioning_test.go
@@ -62,6 +62,10 @@ func (p *TfpProxyProvisioningTestSuite) TfpSetupSuite() map[string]any {
 	p.session = testSession
 
 	p.cattleConfig = shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
+	configMap, err := provisioning.UniquifyTerraform([]map[string]any{p.cattleConfig})
+	require.NoError(p.T(), err)
+
+	p.cattleConfig = configMap[0]
 	p.rancherConfig, p.terraformConfig, p.terratestConfig = config.LoadTFPConfigs(p.cattleConfig)
 
 	adminUser := &management.User{
@@ -122,13 +126,13 @@ func (p *TfpProxyProvisioningTestSuite) TestTfpNoProxyProvisioning() {
 		operations.LoadObjectFromMap(config.TerratestConfigurationFileKey, configMap[0], terratest)
 
 		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion
-		testUser, testPassword, clusterName, poolName := configs.CreateTestCredentials()
+		testUser, testPassword := configs.CreateTestCredentials()
 
 		p.Run((tt.name), func() {
 			keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath)
 			defer cleanup.Cleanup(p.T(), p.terraformOptions, keyPath)
 
-			clusterIDs := provisioning.Provision(p.T(), p.client, p.rancherConfig, terraform, terratest, testUser, testPassword, clusterName, poolName, p.terraformOptions, configMap)
+			clusterIDs := provisioning.Provision(p.T(), p.client, p.rancherConfig, terraform, terratest, testUser, testPassword, p.terraformOptions, configMap)
 			provisioning.VerifyClustersState(p.T(), p.client, clusterIDs)
 		})
 	}
@@ -168,13 +172,13 @@ func (p *TfpProxyProvisioningTestSuite) TestTfpProxyProvisioning() {
 		operations.LoadObjectFromMap(config.TerratestConfigurationFileKey, configMap[0], terratest)
 
 		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion
-		testUser, testPassword, clusterName, poolName := configs.CreateTestCredentials()
+		testUser, testPassword := configs.CreateTestCredentials()
 
 		p.Run((tt.name), func() {
 			keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath)
 			defer cleanup.Cleanup(p.T(), p.terraformOptions, keyPath)
 
-			clusterIDs := provisioning.Provision(p.T(), p.client, p.rancherConfig, terraform, terratest, testUser, testPassword, clusterName, poolName, p.terraformOptions, configMap)
+			clusterIDs := provisioning.Provision(p.T(), p.client, p.rancherConfig, terraform, terratest, testUser, testPassword, p.terraformOptions, configMap)
 			provisioning.VerifyClustersState(p.T(), p.client, clusterIDs)
 		})
 	}

--- a/tests/rancher2/psact/psact_test.go
+++ b/tests/rancher2/psact/psact_test.go
@@ -41,13 +41,15 @@ func (p *PSACTTestSuite) SetupSuite() {
 	p.client = client
 
 	p.cattleConfig = shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
+	configMap, err := provisioning.UniquifyTerraform([]map[string]any{p.cattleConfig})
+	require.NoError(p.T(), err)
+
+	p.cattleConfig = configMap[0]
 	p.rancherConfig, p.terraformConfig, p.terratestConfig = config.LoadTFPConfigs(p.cattleConfig)
 
 	keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath)
 	terraformOptions := framework.Setup(p.T(), p.terraformConfig, p.terratestConfig, keyPath)
 	p.terraformOptions = terraformOptions
-
-	configMap := []map[string]any{p.cattleConfig}
 
 	provisioning.GetK8sVersion(p.T(), p.client, p.terratestConfig, p.terraformConfig, configs.DefaultK8sVersion, configMap)
 }
@@ -72,7 +74,7 @@ func (p *PSACTTestSuite) TestTfpPSACT() {
 
 		tt.name = tt.name + " Module: " + p.terraformConfig.Module + " Kubernetes version: " + p.terratestConfig.KubernetesVersion
 
-		testUser, testPassword, clusterName, poolName := configs.CreateTestCredentials()
+		testUser, testPassword := configs.CreateTestCredentials()
 
 		p.Run((tt.name), func() {
 			keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath)
@@ -83,7 +85,7 @@ func (p *PSACTTestSuite) TestTfpPSACT() {
 
 			configMap := []map[string]any{p.cattleConfig}
 
-			clusterIDs := provisioning.Provision(p.T(), p.client, p.rancherConfig, p.terraformConfig, &terratestConfig, testUser, testPassword, clusterName, poolName, p.terraformOptions, configMap)
+			clusterIDs := provisioning.Provision(p.T(), p.client, p.rancherConfig, p.terraformConfig, &terratestConfig, testUser, testPassword, p.terraformOptions, configMap)
 			provisioning.VerifyClustersState(p.T(), adminClient, clusterIDs)
 			provisioning.VerifyClusterPSACT(p.T(), p.client, clusterIDs)
 		})

--- a/tests/rancher2/rbac/auth_test.go
+++ b/tests/rancher2/rbac/auth_test.go
@@ -74,7 +74,7 @@ func (r *AuthConfigTestSuite) TestTfpAuthConfig() {
 		authConfig := *r.terraformConfig
 		authConfig.AuthProvider = tt.authProvider
 
-		testUser, testPassword, _, _ := configs.CreateTestCredentials()
+		testUser, testPassword := configs.CreateTestCredentials()
 
 		r.Run((tt.name), func() {
 			keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath)
@@ -101,7 +101,7 @@ func (r *AuthConfigTestSuite) TestTfpAuthConfigDynamicInput() {
 	}
 
 	for _, tt := range tests {
-		testUser, testPassword, _, _ := configs.CreateTestCredentials()
+		testUser, testPassword := configs.CreateTestCredentials()
 
 		r.Run((tt.name), func() {
 			keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath)

--- a/tests/registries/registries_test.go
+++ b/tests/registries/registries_test.go
@@ -47,6 +47,10 @@ func (r *TfpRegistriesTestSuite) TearDownSuite() {
 
 func (r *TfpRegistriesTestSuite) SetupSuite() {
 	r.cattleConfig = shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
+	configMap, err := provisioning.UniquifyTerraform([]map[string]any{r.cattleConfig})
+	require.NoError(r.T(), err)
+
+	r.cattleConfig = configMap[0]
 	r.rancherConfig, r.terraformConfig, r.terratestConfig = config.LoadTFPConfigs(r.cattleConfig)
 
 	keyPath := rancher2.SetKeyPath(keypath.RegistryKeyPath)
@@ -131,13 +135,13 @@ func (r *TfpRegistriesTestSuite) TestTfpGlobalRegistry() {
 		operations.LoadObjectFromMap(config.TerratestConfigurationFileKey, configMap[0], terratest)
 
 		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion
-		testUser, testPassword, clusterName, poolName := configs.CreateTestCredentials()
+		testUser, testPassword := configs.CreateTestCredentials()
 
 		r.Run((tt.name), func() {
 			keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath)
 			defer cleanup.Cleanup(r.T(), r.terraformOptions, keyPath)
 
-			clusterIDs := provisioning.Provision(r.T(), r.client, r.rancherConfig, terraform, terratest, testUser, testPassword, clusterName, poolName, r.terraformOptions, configMap)
+			clusterIDs := provisioning.Provision(r.T(), r.client, r.rancherConfig, terraform, terratest, testUser, testPassword, r.terraformOptions, configMap)
 			provisioning.VerifyClustersState(r.T(), r.client, clusterIDs)
 			provisioning.VerifyRegistry(r.T(), r.client, clusterIDs[0], r.terraformConfig)
 		})
@@ -181,13 +185,13 @@ func (r *TfpRegistriesTestSuite) TestTfpAuthenticatedRegistry() {
 		operations.LoadObjectFromMap(config.TerratestConfigurationFileKey, configMap[0], terratest)
 
 		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion
-		testUser, testPassword, clusterName, poolName := configs.CreateTestCredentials()
+		testUser, testPassword := configs.CreateTestCredentials()
 
 		r.Run((tt.name), func() {
 			keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath)
 			defer cleanup.Cleanup(r.T(), r.terraformOptions, keyPath)
 
-			clusterIDs := provisioning.Provision(r.T(), r.client, r.rancherConfig, terraform, terratest, testUser, testPassword, clusterName, poolName, r.terraformOptions, configMap)
+			clusterIDs := provisioning.Provision(r.T(), r.client, r.rancherConfig, terraform, terratest, testUser, testPassword, r.terraformOptions, configMap)
 			provisioning.VerifyClustersState(r.T(), r.client, clusterIDs)
 			provisioning.VerifyRegistry(r.T(), r.client, clusterIDs[0], r.terraformConfig)
 		})
@@ -233,13 +237,13 @@ func (r *TfpRegistriesTestSuite) TestTfpNonAuthenticatedRegistry() {
 		operations.LoadObjectFromMap(config.TerratestConfigurationFileKey, configMap[0], terratest)
 
 		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion
-		testUser, testPassword, clusterName, poolName := configs.CreateTestCredentials()
+		testUser, testPassword := configs.CreateTestCredentials()
 
 		r.Run((tt.name), func() {
 			keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath)
 			defer cleanup.Cleanup(r.T(), r.terraformOptions, keyPath)
 
-			clusterIDs := provisioning.Provision(r.T(), r.client, r.rancherConfig, terraform, terratest, testUser, testPassword, clusterName, poolName, r.terraformOptions, configMap)
+			clusterIDs := provisioning.Provision(r.T(), r.client, r.rancherConfig, terraform, terratest, testUser, testPassword, r.terraformOptions, configMap)
 			provisioning.VerifyClustersState(r.T(), r.client, clusterIDs)
 			provisioning.VerifyRegistry(r.T(), r.client, clusterIDs[0], r.terraformConfig)
 		})


### PR DESCRIPTION
Remove all passing of clusterName and poolName since we now expect the config file to have the generated name before provisioning occurs.