### PR TITLE
Add additional Windows support to airgap and proxy

### DIFF
--- a/defaults/modules/modules.go
+++ b/defaults/modules/modules.go
@@ -26,5 +26,6 @@ const (
 	VsphereK3s           = "vsphere_k3s"
 	AirgapRKE1           = "airgap_rke1"
 	AirgapRKE2           = "airgap_rke2"
+	AirgapRKE2Windows    = "airgap_rke2_windows"
 	AirgapK3S            = "airgap_k3s"
 )

--- a/framework/set/provisioning/airgap/copyScriptToBastion.go
+++ b/framework/set/provisioning/airgap/copyScriptToBastion.go
@@ -9,7 +9,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-// copyScript is a function that will copy the register-nodes.sh script to the bastion node
+// copyScript is a function that will copy the register scripts to the bastion node
 func copyScript(provisionerBlockBody *hclwrite.Body) error {
 	userDir, err := os.UserHomeDir()
 	if err != nil {
@@ -17,15 +17,23 @@ func copyScript(provisionerBlockBody *hclwrite.Body) error {
 	}
 
 	nodesScriptPath := filepath.Join(userDir, "go/src/github.com/rancher/tfp-automation/framework/set/provisioning/airgap/register-nodes.sh")
+	windowsScriptPath := filepath.Join(userDir, "go/src/github.com/rancher/tfp-automation/framework/set/provisioning/airgap/register-windows-nodes.sh")
 
 	nodesScriptContent, err := os.ReadFile(nodesScriptPath)
 	if err != nil {
 		return nil
 	}
 
+	windowsScriptContent, err := os.ReadFile(windowsScriptPath)
+	if err != nil {
+		return nil
+	}
+
 	provisionerBlockBody.SetAttributeValue(defaults.Inline, cty.ListVal([]cty.Value{
-		cty.StringVal("echo '" + string(nodesScriptContent) + "' > /tmp/register-nodes.sh"),
+		cty.StringVal("cat << 'EOF' > /tmp/register-nodes.sh\n" + string(nodesScriptContent) + "\nEOF"),
 		cty.StringVal("chmod +x /tmp/register-nodes.sh"),
+		cty.StringVal("cat << 'EOF' > /tmp/register-windows-nodes.sh\n" + string(windowsScriptContent) + "\nEOF"),
+		cty.StringVal("chmod +x /tmp/register-windows-nodes.sh"),
 	}))
 
 	return nil

--- a/framework/set/provisioning/airgap/nullresource/setWindowsAirgapNullResource.go
+++ b/framework/set/provisioning/airgap/nullresource/setWindowsAirgapNullResource.go
@@ -1,0 +1,44 @@
+package nullresource
+
+import (
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/framework/set/defaults"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// SetWindowsAirgapNullResource is a function that will set the Windows airgap null_resource configurations in the main.tf
+// file, to register the nodes to the cluster
+func SetWindowsAirgapNullResource(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, description string,
+	dependsOn []string) (*hclwrite.Body, error) {
+	nullResourceBlock := rootBody.AppendNewBlock(defaults.Resource, []string{defaults.NullResource, description})
+	nullResourceBlockBody := nullResourceBlock.Body()
+
+	provisionerBlock := nullResourceBlockBody.AppendNewBlock(defaults.Provisioner, []string{defaults.RemoteExec})
+	provisionerBlockBody := provisionerBlock.Body()
+
+	connectionBlock := provisionerBlockBody.AppendNewBlock(defaults.Connection, nil)
+	connectionBlockBody := connectionBlock.Body()
+
+	bastionHostExpression := defaults.AwsInstance + `.` + bastion + `.` + defaults.PublicIp
+
+	bastionHost := hclwrite.Tokens{
+		{Type: hclsyntax.TokenIdent, Bytes: []byte(bastionHostExpression)},
+	}
+
+	connectionBlockBody.SetAttributeRaw(defaults.Host, bastionHost)
+
+	connectionBlockBody.SetAttributeValue(defaults.Type, cty.StringVal(defaults.Ssh))
+	connectionBlockBody.SetAttributeValue(defaults.User, cty.StringVal(terraformConfig.AWSConfig.WindowsAWSUser))
+
+	keyPathExpression := defaults.File + `("` + terraformConfig.WindowsPrivateKeyPath + `")`
+	keyPath := hclwrite.Tokens{
+		{Type: hclsyntax.TokenIdent, Bytes: []byte(keyPathExpression)},
+	}
+
+	connectionBlockBody.SetAttributeRaw(defaults.PrivateKey, keyPath)
+	connectionBlockBody.SetAttributeValue(defaults.Timeout, cty.StringVal(terraformConfig.AWSConfig.Timeout))
+
+	return provisionerBlockBody, nil
+}

--- a/framework/set/provisioning/airgap/register-windows-nodes.sh
+++ b/framework/set/provisioning/airgap/register-windows-nodes.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+PEM_FILE=$1
+WINS_PEM_FILE=$2
+USER=$3
+GROUP=$4
+WINS_USER=$5
+BASTION_IP=$6
+NODE_PRIVATE_IP=$7
+REGISTRATION_COMMAND=$8
+REGISTRY=$9
+
+set -e
+
+echo ${PEM_FILE} | base64 -d | sudo tee /home/${USER}/airgap.pem > /dev/null
+echo ${WINS_PEM_FILE} | base64 -d | sudo tee /home/${USER}/wins.pem > /dev/null
+
+echo "powershell.exe ${REGISTRATION_COMMAND}" > /home/${USER}/wins_registration_command.txt
+
+REGISTRATION_COMMAND=$(cat /home/$USER/wins_registration_command.txt)
+
+PEM=/home/${USER}/airgap.pem
+WINS_PEM=/home/${USER}/wins.pem
+
+sudo chmod 600 ${PEM}
+sudo chmod 600 /home/${USER}/wins.pem
+sudo chown ${USER}:${GROUP} ${PEM} 
+sudo chown ${USER}:${GROUP} /home/${USER}/wins.pem
+
+DOCKER_DAEMON="{ \"\\\"insecure-registries\\\"\" : [ \"\\\"${REGISTRY}\\\"\" ] }"
+
+ssh -o ProxyCommand="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $PEM -W %h:%p $USER@$BASTION_IP" \
+    -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $WINS_PEM $WINS_USER@$NODE_PRIVATE_IP \
+    powershell.exe -Command New-Item -Path C:\\ProgramData\\docker\\config -ItemType Directory -Force
+
+ssh -o ProxyCommand="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $PEM -W %h:%p $USER@$BASTION_IP" \
+    -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $WINS_PEM $WINS_USER@$NODE_PRIVATE_IP \
+    icacls C:\\ProgramData\\docker\\config /grant "Everyone:(F)"
+
+ssh -o ProxyCommand="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $PEM -W %h:%p $USER@$BASTION_IP" \
+    -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $WINS_PEM $WINS_USER@$NODE_PRIVATE_IP \
+    powershell.exe -Command "Set-Content -Path C:\\ProgramData\\docker\\config\\daemon.json -Value '$DOCKER_DAEMON'"
+
+ssh -o ProxyCommand="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $PEM -W %h:%p $USER@$BASTION_IP" \
+    -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $WINS_PEM $WINS_USER@$NODE_PRIVATE_IP \
+    powershell.exe -Command "Restart-Service docker"
+
+ssh -o ProxyCommand="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $PEM -W %h:%p $USER@$BASTION_IP" \
+    -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $WINS_PEM $WINS_USER@$NODE_PRIVATE_IP "$REGISTRATION_COMMAND"

--- a/framework/set/provisioning/airgap/setWindowsConfig.go
+++ b/framework/set/provisioning/airgap/setWindowsConfig.go
@@ -1,0 +1,36 @@
+package airgap
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/framework/set/defaults"
+	"github.com/rancher/tfp-automation/framework/set/provisioning/airgap/nullresource"
+	"github.com/sirupsen/logrus"
+)
+
+// SetAirgapRKE2Windows is a function that will set the airgap RKE2 cluster configurations in the main.tf file.
+func SetAirgapRKE2Windows(client *rancher.Client, rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig,
+	terratestConfig *config.TerratestConfig, configMap []map[string]any, newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File) (*os.File, error) {
+	provisionerBlockBody, err := nullresource.SetAirgapNullResource(rootBody, terraformConfig, "register_"+airgapWindowsNode, nil)
+	rootBody.AppendNewline()
+
+	bastionPublicIP := fmt.Sprintf("${%s.%s.%s}", defaults.AwsInstance, bastion, defaults.PublicIp)
+	registrationCommands, nodePrivateIPs := GetRKE2K3sRegistrationCommands(terraformConfig)
+
+	err = registerWindowsPrivateNodes(provisionerBlockBody, terraformConfig, bastionPublicIP, nodePrivateIPs[airgapWindowsNode], registrationCommands[airgapWindowsNode])
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = file.Write(newFile.Bytes())
+	if err != nil {
+		logrus.Infof("Failed to write airgap Windows RKE2 configurations to main.tf file. Error: %v", err)
+		return nil, err
+	}
+
+	return file, nil
+}

--- a/framework/set/provisioning/custom/nullresource/setWindowsNullResource.go
+++ b/framework/set/provisioning/custom/nullresource/setWindowsNullResource.go
@@ -41,8 +41,16 @@ func SetWindowsNullResource(rootBody *hclwrite.Body, terraformConfig *config.Ter
 
 	connectionBlockBody.SetAttributeRaw(defaults.PrivateKey, keyPath)
 
-	regCommand := hclwrite.Tokens{
-		{Type: hclsyntax.TokenIdent, Bytes: []byte(`["powershell.exe ${` + defaults.Local + `.` + terraformConfig.ResourcePrefix + "_" + defaults.InsecureWindowsNodeCommand + `}"]`)},
+	var regCommand hclwrite.Tokens
+
+	if terraformConfig.Proxy.ProxyBastion != "" {
+		regCommand = hclwrite.Tokens{
+			{Type: hclsyntax.TokenIdent, Bytes: []byte(`["powershell.exe ${` + defaults.Local + `.` + terraformConfig.ResourcePrefix + "_" + defaults.InsecureWindowsProxyNodeCommand + `}"]`)},
+		}
+	} else {
+		regCommand = hclwrite.Tokens{
+			{Type: hclsyntax.TokenIdent, Bytes: []byte(`["powershell.exe ${` + defaults.Local + `.` + terraformConfig.ResourcePrefix + "_" + defaults.InsecureWindowsNodeCommand + `}"]`)},
+		}
 	}
 
 	provisionerBlockBody.SetAttributeRaw(defaults.Inline, regCommand)

--- a/framework/set/provisioning/providers/aws/awsMachineConfig.go
+++ b/framework/set/provisioning/providers/aws/awsMachineConfig.go
@@ -1,12 +1,10 @@
 package aws
 
 import (
-	"fmt"
-
-	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/defaults/resourceblocks/nodeproviders/amazon"
+	"github.com/rancher/tfp-automation/framework/format"
 	"github.com/rancher/tfp-automation/framework/set/defaults"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -24,11 +22,8 @@ func SetAWSRKE2K3SMachineConfig(machineConfigBlockBody *hclwrite.Body, terraform
 	awsConfigBlockBody.SetAttributeValue(amazon.VolumeType, cty.StringVal(terraformConfig.AWSConfig.AWSVolumeType))
 	awsConfigBlockBody.SetAttributeValue(amazon.RootSize, cty.NumberIntVal(terraformConfig.AWSConfig.AWSRootSize))
 
-	awsSecGroupsExpression := fmt.Sprintf(`["%s"]`, terraformConfig.AWSConfig.AWSSecurityGroupNames[0])
-	awsSecGroupsList := hclwrite.Tokens{
-		{Type: hclsyntax.TokenIdent, Bytes: []byte(awsSecGroupsExpression)},
-	}
-	awsConfigBlockBody.SetAttributeRaw(amazon.SecurityGroup, awsSecGroupsList)
+	securityGroups := format.ListOfStrings(terraformConfig.AWSConfig.AWSSecurityGroupNames)
+	awsConfigBlockBody.SetAttributeRaw(amazon.SecurityGroup, securityGroups)
 
 	awsConfigBlockBody.SetAttributeValue(amazon.SubnetID, cty.StringVal(terraformConfig.AWSConfig.AWSSubnetID))
 	awsConfigBlockBody.SetAttributeValue(amazon.VPCID, cty.StringVal(terraformConfig.AWSConfig.AWSVpcID))

--- a/framework/set/provisioning/providers/aws/awsProviders.go
+++ b/framework/set/provisioning/providers/aws/awsProviders.go
@@ -1,12 +1,10 @@
 package aws
 
 import (
-	"fmt"
-
-	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/defaults/resourceblocks/nodeproviders/amazon"
+	"github.com/rancher/tfp-automation/framework/format"
 	"github.com/rancher/tfp-automation/framework/set/defaults"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -27,12 +25,9 @@ func SetAWSRKE1Provider(nodeTemplateBlockBody *hclwrite.Body, terraformConfig *c
 	awsConfigBlockBody.SetAttributeValue(amazon.VolumeType, cty.StringVal(terraformConfig.AWSConfig.AWSVolumeType))
 	awsConfigBlockBody.SetAttributeValue(amazon.RootSize, cty.NumberIntVal(terraformConfig.AWSConfig.AWSRootSize))
 
-	awsSecGroupsExpression := fmt.Sprintf(`["%s"]`, terraformConfig.AWSConfig.AWSSecurityGroupNames[0])
-	awsSecGroupsList := hclwrite.Tokens{
-		{Type: hclsyntax.TokenIdent, Bytes: []byte(awsSecGroupsExpression)},
-	}
+	securityGroups := format.ListOfStrings(terraformConfig.AWSConfig.AWSSecurityGroupNames)
+	awsConfigBlockBody.SetAttributeRaw(amazon.SecurityGroup, securityGroups)
 
-	awsConfigBlockBody.SetAttributeRaw(amazon.SecurityGroup, awsSecGroupsList)
 	awsConfigBlockBody.SetAttributeValue(amazon.SubnetID, cty.StringVal(terraformConfig.AWSConfig.AWSSubnetID))
 	awsConfigBlockBody.SetAttributeValue(amazon.VPCID, cty.StringVal(terraformConfig.AWSConfig.AWSVpcID))
 	awsConfigBlockBody.SetAttributeValue(amazon.Zone, cty.StringVal(terraformConfig.AWSConfig.AWSZoneLetter))

--- a/framework/set/resources/airgap/aws/instances.go
+++ b/framework/set/resources/airgap/aws/instances.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/framework/format"
 	"github.com/rancher/tfp-automation/framework/set/defaults"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -20,12 +21,8 @@ func CreateAirgappedAWSInstances(rootBody *hclwrite.Body, terraformConfig *confi
 	configBlockBody.SetAttributeValue(defaults.InstanceType, cty.StringVal(terraformConfig.AWSConfig.AWSInstanceType))
 	configBlockBody.SetAttributeValue(defaults.SubnetId, cty.StringVal(terraformConfig.AWSConfig.AWSSubnetID))
 
-	awsSecGroupsExpression := fmt.Sprintf(`["%s"]`, terraformConfig.AWSConfig.AWSSecurityGroups[0])
-	awsSecGroupsList := hclwrite.Tokens{
-		{Type: hclsyntax.TokenIdent, Bytes: []byte(awsSecGroupsExpression)},
-	}
-
-	configBlockBody.SetAttributeRaw(defaults.VpcSecurityGroupIds, awsSecGroupsList)
+	securityGroups := format.ListOfStrings(terraformConfig.AWSConfig.AWSSecurityGroups)
+	configBlockBody.SetAttributeRaw(defaults.VpcSecurityGroupIds, securityGroups)
 	configBlockBody.SetAttributeValue(defaults.KeyName, cty.StringVal(terraformConfig.AWSConfig.AWSKeyName))
 
 	configBlockBody.AppendNewline()

--- a/framework/set/resources/proxy/rancher/setup.sh
+++ b/framework/set/resources/proxy/rancher/setup.sh
@@ -64,7 +64,7 @@ else
                                                                                  --set rancherImageTag=${RANCHER_TAG_VERSION} \
                                                                                  --set proxy="http://${BASTION}:${PROXY_PORT}" \
                                                                                  --set noProxy="${NO_PROXY}" \
-                                                                                 --set bootstrapPassword=${BOOTSTRAP_PASSWORD}
+                                                                                 --set bootstrapPassword=${BOOTSTRAP_PASSWORD} --devel
 fi
 
 echo "Waiting for Rancher to be rolled out"

--- a/framework/set/resources/proxy/rancher/upgrade.sh
+++ b/framework/set/resources/proxy/rancher/upgrade.sh
@@ -32,7 +32,7 @@ else
                                                                                  --set rancherImage=${RANCHER_IMAGE} \
                                                                                  --set rancherImageTag=${RANCHER_TAG_VERSION} \
                                                                                  --set proxy="http://${BASTION}:${PROXY_PORT}" \
-                                                                                 --set noProxy="${NO_PROXY}"
+                                                                                 --set noProxy="${NO_PROXY}" --devel
 fi
 
 echo "Waiting for Rancher to be rolled out"

--- a/framework/set/resources/registries/createRegistry.go
+++ b/framework/set/resources/registries/createRegistry.go
@@ -39,7 +39,7 @@ func CreateAuthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootBody
 		command += " " + terraformConfig.Standalone.RancherAgentImage
 	}
 
-	command += "'"
+	command += " || true'"
 
 	provisionerBlockBody.SetAttributeValue(defaults.Inline, cty.ListVal([]cty.Value{
 		cty.StringVal("echo '" + string(registryScriptContent) + "' > /tmp/auth-registry.sh"),
@@ -82,7 +82,7 @@ func CreateNonAuthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootB
 		command += " " + terraformConfig.Standalone.RancherAgentImage
 	}
 
-	command += "'"
+	command += " || true'"
 
 	provisionerBlockBody.SetAttributeValue(defaults.Inline, cty.ListVal([]cty.Value{
 		cty.StringVal("echo '" + string(registryScriptContent) + "' > /tmp/non-auth-registry.sh"),

--- a/framework/set/resources/registries/createRegistry/auth-registry.sh
+++ b/framework/set/resources/registries/createRegistry/auth-registry.sh
@@ -41,6 +41,40 @@ action() {
     fi
 }
 
+copyImagesWithSkopeo() {
+    if skopeo -v > /dev/null 2>&1; then
+        echo -e "\nSkopeo is already installed"
+    else
+        . /etc/os-release
+
+        [[ "${ID}" == "ubuntu" || "${ID}" == "debian" ]] && sudo apt update && sudo apt -y install skopeo
+        [[ "${ID}" == "rhel" || "${ID}" == "fedora" ]] && sudo yum install skopeo -y
+        [[ "${ID}" == "opensuse-leap" || "${ID}" == "sles" ]] && sudo zypper install  -y skopeo
+    fi
+
+    declare -A IMAGE_PATTERNS=(
+        ["system-agent-installer-rke2"]="system-agent-installer-rke2"
+        ["rke2-runtime"]="rke2-runtime"
+    )
+
+    for PATTERN in "${!IMAGE_PATTERNS[@]}"; do
+        if [ "${PATTERN}" == "rke2-runtime" ]; then
+            mapfile -t VERSIONS < <(grep -oP "${PATTERN}:\K[^ ]+" /home/${USER}/rancher-images.txt | sort -rV | head -n 2)
+            for VERSION in "${VERSIONS[@]}"; do
+                skopeo copy -a docker://docker.io/rancher/${IMAGE_PATTERNS[$PATTERN]}:${VERSION}-windows-amd64 docker://${HOST}/rancher/${IMAGE_PATTERNS[$PATTERN]}:${VERSION}-windows-amd64
+            done
+        else
+            mapfile -t VERSIONS < <(grep -oP "${PATTERN}:\K[^ ]+" /home/${USER}/rancher-images.txt | sort -rV | head -n 2)
+            for VERSION in "${VERSIONS[@]}"; do
+                skopeo copy -a docker://docker.io/rancher/${IMAGE_PATTERNS[$PATTERN]}:${VERSION} docker://${HOST}/rancher/${IMAGE_PATTERNS[$PATTERN]}:${VERSION}
+            done
+        fi
+    done
+
+    mapfile -t WINDOWS_IMAGES < <(grep -oP "wins:\K[^ ]+" /home/${USER}/rancher-windows-images.txt)
+    skopeo copy -a docker://docker.io/rancher/wins:${WINDOWS_IMAGES[0]} docker://${HOST}/rancher/wins:${WINDOWS_IMAGES[0]}
+}
+
 echo "Setting up htpasswd..."
 . /etc/os-release
 
@@ -79,6 +113,7 @@ else
 fi
 
 sudo wget ${ASSET_DIR}${RANCHER_VERSION}/rancher-images.txt -O /home/${USER}/rancher-images.txt
+sudo wget ${ASSET_DIR}${RANCHER_VERSION}/rancher-windows-images.txt -O /home/${USER}/rancher-windows-images.txt
 sudo wget ${ASSET_DIR}${RANCHER_VERSION}/rancher-save-images.sh -O /home/${USER}/rancher-save-images.sh
 sudo wget ${ASSET_DIR}${RANCHER_VERSION}/rancher-load-images.sh -O /home/${USER}/rancher-load-images.sh
     
@@ -97,3 +132,6 @@ manageImages "pull"
 
 echo "Pushing the newly tagged images..."
 manageImages "push"
+
+echo "Copying needed Windows images with skopeo..."
+copyImagesWithSkopeo

--- a/framework/set/resources/registries/rancher/setup.sh
+++ b/framework/set/resources/registries/rancher/setup.sh
@@ -58,7 +58,7 @@ elif [ -n "$PRIME_RANCHER_AGENT_IMAGE" ]; then
                                                                                  --set systemDefaultRegistry=${REGISTRY} \
                                                                                  --set 'extraEnv[0].name=CATTLE_AGENT_IMAGE' \
                                                                                  --set "extraEnv[0].value=${PRIME_RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}" \
-                                                                                 --set bootstrapPassword=${BOOTSTRAP_PASSWORD}
+                                                                                 --set bootstrapPassword=${BOOTSTRAP_PASSWORD} --devel
 
 else
     helm upgrade --install rancher rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
@@ -66,7 +66,7 @@ else
                                                                                  --set rancherImage=${REGISTRY}/${RANCHER_IMAGE} \
                                                                                  --set rancherImageTag=${RANCHER_TAG_VERSION} \
                                                                                  --set systemDefaultRegistry=${REGISTRY} \
-                                                                                 --set bootstrapPassword=${BOOTSTRAP_PASSWORD}
+                                                                                 --set bootstrapPassword=${BOOTSTRAP_PASSWORD} --devel
 fi
 
 echo "Waiting for Rancher to be rolled out"

--- a/framework/set/resources/sanity/aws/instances.go
+++ b/framework/set/resources/sanity/aws/instances.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/framework/format"
 	"github.com/rancher/tfp-automation/framework/set/defaults"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -25,13 +26,8 @@ func CreateAWSInstances(rootBody *hclwrite.Body, terraformConfig *config.Terrafo
 	configBlockBody.SetAttributeValue(defaults.InstanceType, cty.StringVal(terraformConfig.AWSConfig.AWSInstanceType))
 	configBlockBody.SetAttributeValue(defaults.SubnetId, cty.StringVal(terraformConfig.AWSConfig.AWSSubnetID))
 
-	awsSecGroupsExpression := fmt.Sprintf(`["%s"]`, terraformConfig.AWSConfig.AWSSecurityGroups[0])
-
-	awsSecGroupsList := hclwrite.Tokens{
-		{Type: hclsyntax.TokenIdent, Bytes: []byte(awsSecGroupsExpression)},
-	}
-
-	configBlockBody.SetAttributeRaw(defaults.VpcSecurityGroupIds, awsSecGroupsList)
+	securityGroups := format.ListOfStrings(terraformConfig.AWSConfig.AWSSecurityGroups)
+	configBlockBody.SetAttributeRaw(defaults.VpcSecurityGroupIds, securityGroups)
 	configBlockBody.SetAttributeValue(defaults.KeyName, cty.StringVal(terraformConfig.AWSConfig.AWSKeyName))
 
 	configBlockBody.AppendNewline()
@@ -95,6 +91,6 @@ func CreateAWSInstances(rootBody *hclwrite.Body, terraformConfig *config.Terrafo
 	provisionerBlockBody := provisionerBlock.Body()
 
 	provisionerBlockBody.SetAttributeValue(defaults.Inline, cty.ListVal([]cty.Value{
-		cty.StringVal("cloud-init status --wait"),
+		cty.StringVal("echo Connected!!!"),
 	}))
 }

--- a/framework/set/resources/sanity/rancher/setup.sh
+++ b/framework/set/resources/sanity/rancher/setup.sh
@@ -52,7 +52,7 @@ else
                                                                                  --set hostname=${HOSTNAME} \
                                                                                  --set rancherImage=${RANCHER_IMAGE} \
                                                                                  --set rancherImageTag=${RANCHER_TAG_VERSION} \
-                                                                                 --set bootstrapPassword=${BOOTSTRAP_PASSWORD}
+                                                                                 --set bootstrapPassword=${BOOTSTRAP_PASSWORD} --devel
 fi
 
 echo "Waiting for Rancher to be rolled out"

--- a/framework/set/setConfigTF.go
+++ b/framework/set/setConfigTF.go
@@ -114,10 +114,17 @@ func ConfigTF(client *rancher.Client, testUser, testPassword string, rbacRole co
 			if err != nil {
 				return clusterNames, err
 			}
-		case module == modules.AirgapRKE2 || module == modules.AirgapK3S:
+		case module == modules.AirgapRKE2 || module == modules.AirgapK3S || module == modules.AirgapRKE2Windows:
 			_, err = airgap.SetAirgapRKE2K3s(rancherConfig, terraform, terratest, configMap, newFile, rootBody, file)
 			if err != nil {
 				return clusterNames, err
+			}
+
+			if isWindows {
+				file, err = airgap.SetAirgapRKE2Windows(client, rancherConfig, terraform, terratest, configMap, newFile, rootBody, file)
+				if err != nil {
+					return clusterNames, err
+				}
 			}
 		case module == modules.ImportEC2RKE1:
 			_, err = imported.SetImportedRKE1(rancherConfig, terraform, terratest, newFile, rootBody, file)

--- a/tests/airgap/README.md
+++ b/tests/airgap/README.md
@@ -73,13 +73,12 @@ terraform:
     certManagerVersion: ""                        # REQUIRED - (e.g. v1.15.3)
     osGroup: ""                                   # REQUIRED - fill with group of the instance created
     osUser: ""                                    # REQUIRED - fill with username of the instance created
-    primeRancherAgentImage: ""                    # OPTIONAL - fill out only if you are using Rancher Prime
+    rancherAgentImage: ""                         # OPTIONAL - fill out only if you are using Rancher Prime or staging registry
     rancherChartRepository: ""                    # REQUIRED - fill with desired value. Must end with a trailing /
     rancherHostname: ""                           # REQUIRED - fill with desired value
     rancherImage: ""                              # REQUIRED - fill with desired value
     rancherTagVersion: ""                         # REQUIRED - fill with desired value
     repo: ""                                      # REQUIRED - fill with desired value
-    stagingRancherAgentImage: ""                  # OPTIONAL - fill out only if you are using staging registry
     rke2Version: ""                               # REQUIRED - the format MUST be in `v1.xx.x` (i.e. v1.31.3)
   ####################################
   # STANDALONE CONFIG - REGISTRY SETUP

--- a/tests/airgap/airgap_provisioning_test.go
+++ b/tests/airgap/airgap_provisioning_test.go
@@ -2,6 +2,7 @@ package airgap
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
@@ -15,6 +16,7 @@ import (
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/defaults/configs"
 	"github.com/rancher/tfp-automation/defaults/keypath"
+	"github.com/rancher/tfp-automation/defaults/modules"
 	"github.com/rancher/tfp-automation/framework"
 	"github.com/rancher/tfp-automation/framework/cleanup"
 	"github.com/rancher/tfp-automation/framework/set/resources/airgap"
@@ -111,6 +113,7 @@ func (a *TfpAirgapProvisioningTestSuite) TestTfpAirgapProvisioning() {
 	}{
 		{"Airgap RKE1", "airgap_rke1"},
 		{"Airgap RKE2", "airgap_rke2"},
+		{"Airgap RKE2 Windows", "airgap_rke2_windows"},
 		{"Airgap K3S", "airgap_k3s"},
 	}
 
@@ -140,6 +143,12 @@ func (a *TfpAirgapProvisioningTestSuite) TestTfpAirgapProvisioning() {
 			clusterIDs := provisioning.Provision(a.T(), a.client, a.rancherConfig, terraform, terratest, testUser, testPassword, a.terraformOptions, configMap, false)
 			provisioning.VerifyClustersState(a.T(), a.client, clusterIDs)
 			provisioning.VerifyRegistry(a.T(), a.client, clusterIDs[0], terraform)
+
+			if strings.Contains(terraform.Module, modules.AirgapRKE2Windows) {
+				clusterIDs := provisioning.Provision(a.T(), a.client, a.rancherConfig, terraform, terratest, testUser, testPassword, a.terraformOptions, configMap, true)
+				provisioning.VerifyClustersState(a.T(), a.client, clusterIDs)
+				provisioning.VerifyRegistry(a.T(), a.client, clusterIDs[0], terraform)
+			}
 		})
 	}
 
@@ -155,6 +164,7 @@ func (a *TfpAirgapProvisioningTestSuite) TestTfpAirgapUpgrading() {
 	}{
 		{"Upgrading Airgap RKE1", "airgap_rke1"},
 		{"Upgrading Airgap RKE2", "airgap_rke2"},
+		{"Upgrading Airgap RKE2 Windows", "airgap_rke2_windows"},
 		{"Upgrading Airgap K3S", "airgap_k3s"},
 	}
 
@@ -184,6 +194,12 @@ func (a *TfpAirgapProvisioningTestSuite) TestTfpAirgapUpgrading() {
 			clusterIDs := provisioning.Provision(a.T(), a.client, a.rancherConfig, terraform, terratest, testUser, testPassword, a.terraformOptions, configMap, false)
 			provisioning.VerifyClustersState(a.T(), a.client, clusterIDs)
 			provisioning.VerifyRegistry(a.T(), a.client, clusterIDs[0], terraform)
+
+			if strings.Contains(terraform.Module, modules.AirgapRKE2Windows) {
+				clusterIDs := provisioning.Provision(a.T(), a.client, a.rancherConfig, terraform, terratest, testUser, testPassword, a.terraformOptions, configMap, true)
+				provisioning.VerifyClustersState(a.T(), a.client, clusterIDs)
+				provisioning.VerifyRegistry(a.T(), a.client, clusterIDs[0], terraform)
+			}
 
 			provisioning.KubernetesUpgrade(a.T(), a.client, a.rancherConfig, terraform, terratest, testUser, testPassword, a.terraformOptions, configMap)
 			provisioning.VerifyClustersState(a.T(), a.client, clusterIDs)

--- a/tests/extensions/provisioning/supportedModules.go
+++ b/tests/extensions/provisioning/supportedModules.go
@@ -49,6 +49,7 @@ func verifyModule(module string) bool {
 		modules.CustomEC2K3s,
 		modules.AirgapRKE1,
 		modules.AirgapRKE2,
+		modules.AirgapRKE2Windows,
 		modules.AirgapK3S,
 		modules.ImportEC2RKE1,
 		modules.ImportEC2RKE2,

--- a/tests/proxy/README.md
+++ b/tests/proxy/README.md
@@ -74,6 +74,7 @@ terraform:
   standalone:
     bootstrapPassword: ""                         # REQUIRED - this is the same as the adminPassword above, make sure they match
     certManagerVersion: ""                        # REQUIRED - (e.g. v1.15.3)
+    rancherAgentImage: ""                         # OPTIONAL - fill out only if you are using Rancher Prime or staging registry
     rancherChartVersion: ""                       # REQUIRED - fill with desired value
     rancherChartRepository: ""                    # REQUIRED - fill with desired value. Must end with a trailing /
     rancherHostname: ""                           # REQUIRED - fill with desired value
@@ -82,7 +83,6 @@ terraform:
     repo: ""                                      # REQUIRED - fill with desired value
     rke2Group: ""                                 # REQUIRED - fill with group of the instance created
     rke2User: ""                                  # REQUIRED - fill with username of the instance created
-    stagingRancherAgentImage: ""                  # OPTIONAL - fill out only if you are using staging registry
     rke2Version: ""                               # REQUIRED - fill with desired RKE2 k8s value (i.e. v1.30.6+rke2r1)
     upgradedRancherChartRepository: ""            # OPTIONAL - set if upgraded. Fill with desired value. Must end with a trailing /
     upgradedRancherImage: ""                      # OPTIONAL - set if upgraded. Fill with desired value

--- a/tests/proxy/proxy_provisioning_test.go
+++ b/tests/proxy/proxy_provisioning_test.go
@@ -164,6 +164,7 @@ func (p *TfpProxyProvisioningTestSuite) TestTfpProxyProvisioning() {
 	}{
 		{"Proxy RKE1", nodeRolesDedicated, "ec2_rke1"},
 		{"Proxy RKE2", nodeRolesDedicated, "ec2_rke2"},
+		{"Proxy RKE2 Windows", nil, "ec2_rke2_windows_custom"},
 		{"Proxy K3S", nodeRolesDedicated, "ec2_k3s"},
 	}
 
@@ -192,6 +193,11 @@ func (p *TfpProxyProvisioningTestSuite) TestTfpProxyProvisioning() {
 
 			clusterIDs := provisioning.Provision(p.T(), p.client, p.rancherConfig, terraform, terratest, testUser, testPassword, p.terraformOptions, configMap, false)
 			provisioning.VerifyClustersState(p.T(), p.client, clusterIDs)
+
+			if strings.Contains(terraform.Module, modules.CustomEC2RKE2Windows) {
+				clusterIDs := provisioning.Provision(p.T(), p.client, p.rancherConfig, terraform, terratest, testUser, testPassword, p.terraformOptions, configMap, true)
+				provisioning.VerifyClustersState(p.T(), p.client, clusterIDs)
+			}
 		})
 	}
 

--- a/tests/proxy/proxy_upgrade_rancher_test.go
+++ b/tests/proxy/proxy_upgrade_rancher_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
@@ -15,6 +16,7 @@ import (
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/defaults/configs"
 	"github.com/rancher/tfp-automation/defaults/keypath"
+	"github.com/rancher/tfp-automation/defaults/modules"
 	"github.com/rancher/tfp-automation/framework"
 	"github.com/rancher/tfp-automation/framework/cleanup"
 	resources "github.com/rancher/tfp-automation/framework/set/resources/proxy"
@@ -113,8 +115,6 @@ func (p *TfpProxyUpgradeRancherTestSuite) TfpSetupSuite() map[string]any {
 }
 
 func (p *TfpProxyUpgradeRancherTestSuite) TestTfpUpgradeProxyRancher() {
-	p.provisionAndVerifyCluster("Pre-Upgrade Proxy ")
-
 	p.terraformConfig.Standalone.UpgradeProxyRancher = true
 
 	keyPath := rancher2.SetKeyPath(keypath.UpgradeKeyPath)
@@ -138,6 +138,7 @@ func (p *TfpProxyUpgradeRancherTestSuite) provisionAndVerifyCluster(name string)
 	}{
 		{"RKE1", nodeRolesDedicated, "ec2_rke1"},
 		{"RKE2", nodeRolesDedicated, "ec2_rke2"},
+		{"RKE2 Windows", nil, "ec2_rke2_windows_custom"},
 		{"K3S", nodeRolesDedicated, "ec2_k3s"},
 	}
 
@@ -166,6 +167,11 @@ func (p *TfpProxyUpgradeRancherTestSuite) provisionAndVerifyCluster(name string)
 
 			clusterIDs := provisioning.Provision(p.T(), p.client, p.rancherConfig, terraform, terratest, testUser, testPassword, p.terraformOptions, configMap, false)
 			provisioning.VerifyClustersState(p.T(), p.client, clusterIDs)
+
+			if strings.Contains(terraform.Module, modules.CustomEC2RKE2Windows) {
+				clusterIDs := provisioning.Provision(p.T(), p.client, p.rancherConfig, terraform, terratest, testUser, testPassword, p.terraformOptions, configMap, true)
+				provisioning.VerifyClustersState(p.T(), p.client, clusterIDs)
+			}
 		})
 	}
 }

--- a/tests/registries/README.md
+++ b/tests/registries/README.md
@@ -74,13 +74,12 @@ terraform:
     certManagerVersion: ""                        # REQUIRED - (e.g. v1.15.3)
     osGroup: ""                                   # REQUIRED - fill with group of the instance created
     osUser: ""                                    # REQUIRED - fill with username of the instance created
-    primeRancherAgentImage: ""                    # OPTIONAL - fill out only if you are using Rancher Prime
+    rancherAgentImage: ""                         # OPTIONAL - fill out only if you are using Rancher Prime or staging registry
     rancherChartRepository: ""                    # REQUIRED - fill with desired value. Must end with a trailing /
     rancherHostname: ""                           # REQUIRED - fill with desired value
     rancherImage: ""                              # REQUIRED - fill with desired value
     rancherTagVersion: ""                         # REQUIRED - fill with desired value
     repo: ""                                      # REQUIRED - fill with desired value
-    stagingRancherAgentImage: ""                  # OPTIONAL - fill out only if you are using staging registry
     rke2Version: ""                               # REQUIRED - fill with desired RKE2 k8s value (i.e. v1.30.6+rke2r1)
   ####################################
   # STANDALONE CONFIG - REGISTRY SETUP

--- a/tests/sanity/README.md
+++ b/tests/sanity/README.md
@@ -70,6 +70,7 @@ terraform:
   standalone:
     bootstrapPassword: ""                         # REQUIRED - this is the same as the adminPassword above, make sure they match
     certManagerVersion: ""                        # REQUIRED - (e.g. v1.15.3)
+    rancherAgentImage: ""                         # OPTIONAL - fill out only if you are using Rancher Prime or staging registry
     rancherChartVersion: ""                       # REQUIRED - fill with desired value
     rancherChartRepository: ""                    # REQUIRED - fill with desired value. Must end with a trailing /
     rancherHostname: ""                           # REQUIRED - fill with desired value
@@ -78,7 +79,6 @@ terraform:
     repo: ""                                      # REQUIRED - fill with desired value
     rke2Group: ""                                 # REQUIRED - fill with group of the instance created
     rke2User: ""                                  # REQUIRED - fill with username of the instance created
-    stagingRancherAgentImage: ""                  # OPTIONAL - fill out only if you are using staging registry
     rke2Version: ""                               # REQUIRED - fill with desired RKE2 k8s value (i.e. v1.30.6+rke2r1)
 #######################
 # TERRATEST CONFIG


### PR DESCRIPTION
### Issue: [Add support for Windows test cases in tfp-automation](https://github.com/rancher/qa-tasks/issues/1712)

### Description
This is a continuation of a previous PR that introduced Windows support to `tfp-automation`. This PR expands by doing the following:
- Adds Windows support to airgap tests
- Adds Windows support to proxy-specific provisioning tests
- Adds back support for specifying multiple security groups