### PR TITLE
Update infra tests to accept EULA post installation

### DIFF
--- a/tests/infrastructure/acceptEULA.go
+++ b/tests/infrastructure/acceptEULA.go
@@ -1,0 +1,50 @@
+package infrastructure
+
+import (
+	"os"
+	"testing"
+
+	"github.com/rancher/rancher/tests/v2/actions/pipeline"
+	"github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/extensions/token"
+	shepherdConfig "github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/tests/extensions/provisioning"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+// AcceptEULA accepts the EULA for the Rancher server post installation
+func AcceptEULA(t *testing.T, session *session.Session, cattleConfig map[string]any, rancherConfig *rancher.Config,
+	terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig, host string) {
+	cattleConfig = shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
+	configMap, err := provisioning.UniquifyTerraform([]map[string]any{cattleConfig})
+	require.NoError(t, err)
+
+	cattleConfig = configMap[0]
+	rancherConfig, terraformConfig, terratestConfig = config.LoadTFPConfigs(cattleConfig)
+
+	adminUser := &management.User{
+		Username: "admin",
+		Password: rancherConfig.AdminPassword,
+	}
+
+	userToken, err := token.GenerateUserToken(adminUser, rancherConfig.Host)
+	require.NoError(t, err)
+
+	rancherConfig.AdminToken = userToken.Token
+
+	client, err := rancher.NewClient(rancherConfig.AdminToken, session)
+	require.NoError(t, err)
+
+	client.RancherConfig.AdminToken = rancherConfig.AdminToken
+	client.RancherConfig.AdminPassword = rancherConfig.AdminPassword
+	client.RancherConfig.Host = host
+
+	err = pipeline.PostRancherInstall(client, client.RancherConfig.AdminPassword)
+	require.NoError(t, err)
+
+	logrus.Infof("Admin bearer token: %s", client.RancherConfig.AdminToken)
+}

--- a/tests/infrastructure/setup_airgap_rancher_test.go
+++ b/tests/infrastructure/setup_airgap_rancher_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/rancher/shepherd/clients/rancher"
 	ranchFrame "github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/defaults/keypath"
 	"github.com/rancher/tfp-automation/framework"
@@ -17,6 +19,10 @@ import (
 
 type AirgapRancherTestSuite struct {
 	suite.Suite
+	client           *rancher.Client
+	session          *session.Session
+	cattleConfig     map[string]any
+	rancherConfig    *rancher.Config
 	terraformConfig  *config.TerraformConfig
 	terratestConfig  *config.TerratestConfig
 	terraformOptions *terraform.Options
@@ -39,6 +45,11 @@ func (i *AirgapRancherTestSuite) TestCreateAirgapRancher() {
 	logrus.Infof("Rancher server URL: %s", i.terraformConfig.Standalone.RancherHostname)
 	logrus.Infof("Booststrap password: %s", i.terraformConfig.Standalone.BootstrapPassword)
 	logrus.Infof("Private registry: %s", registry)
+
+	testSession := session.NewSession()
+	i.session = testSession
+
+	AcceptEULA(i.T(), i.session, i.cattleConfig, i.rancherConfig, i.terraformConfig, i.terratestConfig, i.terraformConfig.Standalone.AirgapInternalFQDN)
 }
 
 func TestAirgapRancherTestSuite(t *testing.T) {

--- a/tests/infrastructure/setup_proxy_rancher_test.go
+++ b/tests/infrastructure/setup_proxy_rancher_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/rancher/shepherd/clients/rancher"
 	ranchFrame "github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/defaults/keypath"
 	"github.com/rancher/tfp-automation/framework"
@@ -17,6 +19,10 @@ import (
 
 type ProxyRancherTestSuite struct {
 	suite.Suite
+	client           *rancher.Client
+	session          *session.Session
+	cattleConfig     map[string]any
+	rancherConfig    *rancher.Config
 	terraformConfig  *config.TerraformConfig
 	terratestConfig  *config.TerratestConfig
 	terraformOptions *terraform.Options
@@ -38,6 +44,11 @@ func (i *ProxyRancherTestSuite) TestCreateProxyRancher() {
 
 	logrus.Infof("Rancher server URL: %s", i.terraformConfig.Standalone.RancherHostname)
 	logrus.Infof("Booststrap password: %s", i.terraformConfig.Standalone.BootstrapPassword)
+
+	testSession := session.NewSession()
+	i.session = testSession
+
+	AcceptEULA(i.T(), i.session, i.cattleConfig, i.rancherConfig, i.terraformConfig, i.terratestConfig, i.terraformConfig.Standalone.RancherHostname)
 }
 
 func TestProxyRancherTestSuite(t *testing.T) {

--- a/tests/infrastructure/setup_rancher_test.go
+++ b/tests/infrastructure/setup_rancher_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/rancher/shepherd/clients/rancher"
 	ranchFrame "github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/defaults/keypath"
 	"github.com/rancher/tfp-automation/framework"
@@ -17,6 +19,10 @@ import (
 
 type RancherTestSuite struct {
 	suite.Suite
+	client           *rancher.Client
+	session          *session.Session
+	cattleConfig     map[string]any
+	rancherConfig    *rancher.Config
 	terraformConfig  *config.TerraformConfig
 	terratestConfig  *config.TerratestConfig
 	terraformOptions *terraform.Options
@@ -38,6 +44,11 @@ func (i *RancherTestSuite) TestCreateRancher() {
 
 	logrus.Infof("Rancher server URL: %s", i.terraformConfig.Standalone.RancherHostname)
 	logrus.Infof("Booststrap password: %s", i.terraformConfig.Standalone.BootstrapPassword)
+
+	testSession := session.NewSession()
+	i.session = testSession
+
+	AcceptEULA(i.T(), i.session, i.cattleConfig, i.rancherConfig, i.terraformConfig, i.terratestConfig, i.terraformConfig.Standalone.RancherHostname)
 }
 
 func TestRancherTestSuite(t *testing.T) {


### PR DESCRIPTION
### Issue: N/A

### PR Description
To assist with the PIT team's efforts with using `tfp-automation` to setup infrastructure, it would be helpful to grab the admin bearer token and accept the EULA. That way, once the setup is done, they will be able to easier run other tests.