### PR TITLE
Fix airgap Windows tests

### DIFF
--- a/tests/airgap/airgap_provisioning_test.go
+++ b/tests/airgap/airgap_provisioning_test.go
@@ -113,6 +113,7 @@ func (a *TfpAirgapProvisioningTestSuite) TestTfpAirgapProvisioning() {
 	}{
 		{"Airgap RKE1", "airgap_rke1"},
 		{"Airgap RKE2", "airgap_rke2"},
+		{"Airgap RKE2 Windows", "airgap_rke2_windows"},
 		{"Airgap K3S", "airgap_k3s"},
 	}
 
@@ -159,6 +160,7 @@ func (a *TfpAirgapProvisioningTestSuite) TestTfpAirgapUpgrading() {
 	}{
 		{"Upgrading Airgap RKE1", "airgap_rke1"},
 		{"Upgrading Airgap RKE2", "airgap_rke2"},
+		{"Upgrading Airgap RKE2 Windows", "airgap_rke2_windows"},
 		{"Upgrading Airgap K3S", "airgap_k3s"},
 	}
 

--- a/tests/airgap/airgap_upgrade_rancher_test.go
+++ b/tests/airgap/airgap_upgrade_rancher_test.go
@@ -136,6 +136,7 @@ func (a *TfpAirgapUpgradeRancherTestSuite) provisionAndVerifyCluster(name string
 	}{
 		{"RKE1", "airgap_rke1"},
 		{"RKE2", "airgap_rke2"},
+		{"RKE2 Windows", "airgap_rke2_windows"},
 		{"K3S", "airgap_k3s"},
 	}
 


### PR DESCRIPTION
### Issue: N/A

### PR Description
The Windows airgap tests were previously removed as they were not consistently provisioning the RKE2 Windows clusters. Troubleshooting further, `skopeo` was not collecting all of the needed manifests each run. As a result, switched to `crane` and have consistenetly had the clusters provision.

Additionally, needed to pull `rancher/rke2-runtime`, `rancher/rke2-runtime-windows-amd64`, `mirrored-pause` and all of the architectures to assist in properly getting Windows clusters to come up with all workloads active.