### PR TITLE
allow usage from user-defined GOROOT

### DIFF
--- a/Jenkinsfile_harvester
+++ b/Jenkinsfile_harvester
@@ -1,5 +1,5 @@
 #!groovy
-node("vsphere-vpn-1") {
+node("harvester-vpn-1") {
   def homePath = pwd() + "/"
   def rootPath = "/root/go/src/github.com/rancher/tfp-automation/"
   def testsDir = "github.com/rancher/tfp-automation/tests/${env.TEST_PACKAGE}"

--- a/Jenkinsfile_vpn
+++ b/Jenkinsfile_vpn
@@ -1,5 +1,5 @@
 #!groovy
-node {
+node ("vsphere-vpn-1") {
   def homePath = pwd() + "/"
   def rootPath = "/root/go/src/github.com/rancher/tfp-automation/"
   def testsDir = "github.com/rancher/tfp-automation/tests/${env.TEST_PACKAGE}"

--- a/framework/set/resources/airgap/rancher/setupAirgapRancher.go
+++ b/framework/set/resources/airgap/rancher/setupAirgapRancher.go
@@ -19,12 +19,18 @@ const (
 // CreateAirgapRancher is a function that will set the airgap Rancher configurations in the main.tf file.
 func CreateAirgapRancher(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
 	rke2BastionPublicDNS, registryPublicDNS string) (*os.File, error) {
-	userDir, err := os.UserHomeDir()
-	if err != nil {
-		return nil, err
+	var err error
+	userDir := os.Getenv("GOROOT")
+	if userDir == "" {
+		userDir, err = os.UserHomeDir()
+		if err != nil {
+			return nil, err
+		}
+
+		userDir = filepath.Join(userDir, "go/")
 	}
 
-	scriptPath := filepath.Join(userDir, "go/src/github.com/rancher/tfp-automation/framework/set/resources/airgap/rancher/setup.sh")
+	scriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/airgap/rancher/setup.sh")
 
 	scriptContent, err := os.ReadFile(scriptPath)
 	if err != nil {

--- a/framework/set/resources/airgap/rke2/createAirgapCluster.go
+++ b/framework/set/resources/airgap/rke2/createAirgapCluster.go
@@ -26,14 +26,20 @@ const (
 // CreateAirgapRKE2Cluster is a helper function that will create the RKE2 cluster.
 func CreateAirgapRKE2Cluster(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
 	rke2BastionPublicDNS, registryPublicDNS, rke2ServerOnePrivateIP, rke2ServerTwoPrivateIP, rke2ServerThreePrivateIP string) (*os.File, error) {
-	userDir, err := os.UserHomeDir()
-	if err != nil {
-		return nil, err
+	var err error
+	userDir := os.Getenv("GOROOT")
+	if userDir == "" {
+		userDir, err = os.UserHomeDir()
+		if err != nil {
+			return nil, err
+		}
+
+		userDir = filepath.Join(userDir, "go/")
 	}
 
-	bastionScriptPath := filepath.Join(userDir, "go/src/github.com/rancher/tfp-automation/framework/set/resources/airgap/rke2/bastion.sh")
-	serverScriptPath := filepath.Join(userDir, "go/src/github.com/rancher/tfp-automation/framework/set/resources/airgap/rke2/init-server.sh")
-	newServersScriptPath := filepath.Join(userDir, "go/src/github.com/rancher/tfp-automation/framework/set/resources/airgap/rke2/add-servers.sh")
+	bastionScriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/airgap/rke2/bastion.sh")
+	serverScriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/airgap/rke2/init-server.sh")
+	newServersScriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/airgap/rke2/add-servers.sh")
 
 	bastionScriptContent, err := os.ReadFile(bastionScriptPath)
 	if err != nil {

--- a/framework/set/resources/k3s/createCluster.go
+++ b/framework/set/resources/k3s/createCluster.go
@@ -24,13 +24,19 @@ const (
 // CreateK3SCluster is a helper function that will create the K3S cluster.
 func CreateK3SCluster(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
 	k3sServerOnePublicDNS, k3sServerOnePrivateIP, k3sServerTwoPublicDNS, k3sServerThreePublicDNS string) (*os.File, error) {
-	userDir, err := os.UserHomeDir()
-	if err != nil {
-		return nil, err
+	var err error
+	userDir := os.Getenv("GOROOT")
+	if userDir == "" {
+		userDir, err = os.UserHomeDir()
+		if err != nil {
+			return nil, err
+		}
+
+		userDir = filepath.Join(userDir, "go/")
 	}
 
-	serverScriptPath := filepath.Join(userDir, "go/src/github.com/rancher/tfp-automation/framework/set/resources/k3s/init-server.sh")
-	newServersScriptPath := filepath.Join(userDir, "go/src/github.com/rancher/tfp-automation/framework/set/resources/k3s/add-servers.sh")
+	serverScriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/k3s/init-server.sh")
+	newServersScriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/k3s/add-servers.sh")
 
 	serverOneScriptContent, err := os.ReadFile(serverScriptPath)
 	if err != nil {

--- a/framework/set/resources/proxy/createMainTF.go
+++ b/framework/set/resources/proxy/createMainTF.go
@@ -85,5 +85,7 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 
 	terraform.InitAndApply(t, terraformOptions)
 
+	terraformConfig.Proxy.ProxyBastion = rke2BastionPublicDNS
+
 	return rke2BastionPublicDNS, rke2BastionPrivateIP, nil
 }

--- a/framework/set/resources/proxy/rancher/createRancher.go
+++ b/framework/set/resources/proxy/rancher/createRancher.go
@@ -20,12 +20,18 @@ const (
 func CreateProxiedRancher(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
 	rke2BastionPublicDNS, rke2BastionPrivateIP string) (*os.File, error) {
 
-	userDir, err := os.UserHomeDir()
-	if err != nil {
-		return nil, err
+	var err error
+	userDir := os.Getenv("GOROOT")
+	if userDir == "" {
+		userDir, err = os.UserHomeDir()
+		if err != nil {
+			return nil, err
+		}
+
+		userDir = filepath.Join(userDir, "go/")
 	}
 
-	scriptPath := filepath.Join(userDir, "go/src/github.com/rancher/tfp-automation/framework/set/resources/proxy/rancher/setup.sh")
+	scriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/proxy/rancher/setup.sh")
 
 	scriptContent, err := os.ReadFile(scriptPath)
 	if err != nil {

--- a/framework/set/resources/proxy/rancher/upgradeRancher.go
+++ b/framework/set/resources/proxy/rancher/upgradeRancher.go
@@ -18,13 +18,19 @@ const (
 
 // UpgradeProxiedRancher is a function that will upgrade the Rancher configurations in the main.tf file.
 func UpgradeProxiedRancher(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
-	proxyNode, proxyPrivateIP string) (*os.File, error) {
-	userDir, err := os.UserHomeDir()
-	if err != nil {
-		return nil, err
+	proxyPrivateIP, proxyNode string) (*os.File, error) {
+	var err error
+	userDir := os.Getenv("GOROOT")
+	if userDir == "" {
+		userDir, err = os.UserHomeDir()
+		if err != nil {
+			return nil, err
+		}
+
+		userDir = filepath.Join(userDir, "go/")
 	}
 
-	scriptPath := filepath.Join(userDir, "go/src/github.com/rancher/tfp-automation/framework/set/resources/proxy/rancher/upgrade.sh")
+	scriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/proxy/rancher/upgrade.sh")
 
 	scriptContent, err := os.ReadFile(scriptPath)
 	if err != nil {

--- a/framework/set/resources/proxy/rke2/createCluster.go
+++ b/framework/set/resources/proxy/rke2/createCluster.go
@@ -24,13 +24,19 @@ const (
 // CreateRKE2Cluster is a helper function that will create the RKE2 cluster.
 func CreateRKE2Cluster(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
 	rke2BastionPublicDNS, rke2BastionPrivateIP, rke2ServerOnePrivateIP, rke2ServerTwoPrivateIP, rke2ServerThreePrivateIP string) (*os.File, error) {
-	userDir, err := os.UserHomeDir()
-	if err != nil {
-		return nil, err
+	var err error
+	userDir := os.Getenv("GOROOT")
+	if userDir == "" {
+		userDir, err = os.UserHomeDir()
+		if err != nil {
+			return nil, err
+		}
+
+		userDir = filepath.Join(userDir, "go/")
 	}
 
-	serverScriptPath := filepath.Join(userDir, "go/src/github.com/rancher/tfp-automation/framework/set/resources/proxy/rke2/init-server.sh")
-	newServersScriptPath := filepath.Join(userDir, "go/src/github.com/rancher/tfp-automation/framework/set/resources/proxy/rke2/add-servers.sh")
+	serverScriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/proxy/rke2/init-server.sh")
+	newServersScriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/proxy/rke2/add-servers.sh")
 
 	serverOneScriptContent, err := os.ReadFile(serverScriptPath)
 	if err != nil {

--- a/framework/set/resources/proxy/squid/createSquidProxy.go
+++ b/framework/set/resources/proxy/squid/createSquidProxy.go
@@ -19,13 +19,20 @@ const (
 // CreateSquidProxy is a function that will set the squid proxy configurations in the main.tf file.
 func CreateSquidProxy(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
 	rke2BastionPublicDNS, rke2ServerOnePrivateIP, rke2ServerTwoPrivateIP, rke2ServerThreePrivateIP string) (*os.File, error) {
-	userDir, err := os.UserHomeDir()
-	if err != nil {
-		return nil, err
+
+	var err error
+	userDir := os.Getenv("GOROOT")
+	if userDir == "" {
+		userDir, err = os.UserHomeDir()
+		if err != nil {
+			return nil, err
+		}
+
+		userDir = filepath.Join(userDir, "go/")
 	}
 
-	scriptPath := filepath.Join(userDir, "go/src/github.com/rancher/tfp-automation/framework/set/resources/proxy/squid/setup.sh")
-	squidConf := filepath.Join(userDir, "go/src/github.com/rancher/tfp-automation/framework/set/resources/proxy/squid/squid.conf")
+	scriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/proxy/squid/setup.sh")
+	squidConf := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/proxy/squid/squid.conf")
 
 	scriptContent, err := os.ReadFile(scriptPath)
 	if err != nil {

--- a/framework/set/resources/rancher2/setKeyPath.go
+++ b/framework/set/resources/rancher2/setKeyPath.go
@@ -7,9 +7,13 @@ import (
 
 // SetKeyPath is a function that will set the path to the key file.
 func SetKeyPath(keyPath string) string {
-	userDir, err := os.UserHomeDir()
-	if err != nil {
-		return ""
+	var err error
+	userDir := os.Getenv("GOROOT")
+	if userDir == "" {
+		userDir, err = os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
 	}
 
 	keyPath = filepath.Join(userDir, keyPath)

--- a/framework/set/resources/registries/createRegistry.go
+++ b/framework/set/resources/registries/createRegistry.go
@@ -15,12 +15,18 @@ import (
 // CreateAuthenticatedRegistry is a helper function that will create an authenticated registry.
 func CreateAuthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
 	rke2AuthRegistryPublicDNS string) (*os.File, error) {
-	userDir, err := os.UserHomeDir()
-	if err != nil {
-		return nil, err
+	var err error
+	userDir := os.Getenv("GOROOT")
+	if userDir == "" {
+		userDir, err = os.UserHomeDir()
+		if err != nil {
+			return nil, err
+		}
+
+		userDir = filepath.Join(userDir, "go/")
 	}
 
-	registryScriptPath := filepath.Join(userDir, "go/src/github.com/rancher/tfp-automation/framework/set/resources/registries/auth-registry.sh")
+	registryScriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/registries/auth-registry.sh")
 
 	registryScriptContent, err := os.ReadFile(registryScriptPath)
 	if err != nil {
@@ -59,12 +65,18 @@ func CreateAuthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootBody
 // CreateNonAuthenticatedRegistry is a helper function that will create a non-authenticated registry.
 func CreateNonAuthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
 	rke2NonAuthRegistryPublicDNS, registryType string) (*os.File, error) {
-	userDir, err := os.UserHomeDir()
-	if err != nil {
-		return nil, err
+	var err error
+	userDir := os.Getenv("GOROOT")
+	if userDir == "" {
+		userDir, err = os.UserHomeDir()
+		if err != nil {
+			return nil, err
+		}
+
+		userDir = filepath.Join(userDir, "go/")
 	}
 
-	registryScriptPath := filepath.Join(userDir, "go/src/github.com/rancher/tfp-automation/framework/set/resources/registries/non-auth-registry.sh")
+	registryScriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/registries/non-auth-registry.sh")
 
 	registryScriptContent, err := os.ReadFile(registryScriptPath)
 	if err != nil {

--- a/framework/set/resources/registries/createRegistry/createRegistry.go
+++ b/framework/set/resources/registries/createRegistry/createRegistry.go
@@ -20,12 +20,18 @@ const (
 // CreateAuthenticatedRegistry is a helper function that will create an authenticated registry.
 func CreateAuthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
 	rke2AuthRegistryPublicDNS string) (*os.File, error) {
-	userDir, err := os.UserHomeDir()
-	if err != nil {
-		return nil, err
+	var err error
+	userDir := os.Getenv("GOROOT")
+	if userDir == "" {
+		userDir, err = os.UserHomeDir()
+		if err != nil {
+			return nil, err
+		}
+
+		userDir = filepath.Join(userDir, "go/")
 	}
 
-	registryScriptPath := filepath.Join(userDir, "go/src/github.com/rancher/tfp-automation/framework/set/resources/registries/createRegistry/auth-registry.sh")
+	registryScriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/registries/createRegistry/auth-registry.sh")
 
 	registryScriptContent, err := os.ReadFile(registryScriptPath)
 	if err != nil {
@@ -64,12 +70,18 @@ func CreateAuthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootBody
 // CreateNonAuthenticatedRegistry is a helper function that will create a non-authenticated registry.
 func CreateNonAuthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
 	rke2NonAuthRegistryPublicDNS, registryType string) (*os.File, error) {
-	userDir, err := os.UserHomeDir()
-	if err != nil {
-		return nil, err
+	var err error
+	userDir := os.Getenv("GOROOT")
+	if userDir == "" {
+		userDir, err = os.UserHomeDir()
+		if err != nil {
+			return nil, err
+		}
+
+		userDir = filepath.Join(userDir, "go/")
 	}
 
-	registryScriptPath := filepath.Join(userDir, "go/src/github.com/rancher/tfp-automation/framework/set/resources/registries/createRegistry/non-auth-registry.sh")
+	registryScriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/registries/createRegistry/non-auth-registry.sh")
 
 	registryScriptContent, err := os.ReadFile(registryScriptPath)
 	if err != nil {

--- a/framework/set/resources/registries/rancher/createRancher.go
+++ b/framework/set/resources/registries/rancher/createRancher.go
@@ -19,12 +19,18 @@ const (
 // CreateRancher is a function that will set the Rancher configurations in the main.tf file.
 func CreateRancher(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
 	rke2ServerOnePublicDNS, registryPublicDNS string) (*os.File, error) {
-	userDir, err := os.UserHomeDir()
-	if err != nil {
-		return nil, err
+	var err error
+	userDir := os.Getenv("GOROOT")
+	if userDir == "" {
+		userDir, err = os.UserHomeDir()
+		if err != nil {
+			return nil, err
+		}
+
+		userDir = filepath.Join(userDir, "go/")
 	}
 
-	scriptPath := filepath.Join(userDir, "go/src/github.com/rancher/tfp-automation/framework/set/resources/registries/rancher/setup.sh")
+	scriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/registries/rancher/setup.sh")
 
 	scriptContent, err := os.ReadFile(scriptPath)
 	if err != nil {

--- a/framework/set/resources/registries/rke2/createCluster.go
+++ b/framework/set/resources/registries/rke2/createCluster.go
@@ -25,13 +25,19 @@ const (
 func CreateRKE2Cluster(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
 	rke2ServerOnePublicDNS, rke2ServerOnePrivateIP, rke2ServerTwoPublicDNS, rke2ServerThreePublicDNS,
 	registryPublicDNS string) (*os.File, error) {
-	userDir, err := os.UserHomeDir()
-	if err != nil {
-		return nil, err
+	var err error
+	userDir := os.Getenv("GOROOT")
+	if userDir == "" {
+		userDir, err = os.UserHomeDir()
+		if err != nil {
+			return nil, err
+		}
+
+		userDir = filepath.Join(userDir, "go/")
 	}
 
-	serverScriptPath := filepath.Join(userDir, "go/src/github.com/rancher/tfp-automation/framework/set/resources/registries/rke2/init-server.sh")
-	newServersScriptPath := filepath.Join(userDir, "go/src/github.com/rancher/tfp-automation/framework/set/resources/registries/rke2/add-servers.sh")
+	serverScriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/registries/rke2/init-server.sh")
+	newServersScriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/registries/rke2/add-servers.sh")
 
 	serverOneScriptContent, err := os.ReadFile(serverScriptPath)
 	if err != nil {

--- a/framework/set/resources/rke/rke/clusterCheck.go
+++ b/framework/set/resources/rke/rke/clusterCheck.go
@@ -17,12 +17,18 @@ import (
 // CheckClusterStatus is a helper function that will check the status of the RKE1 cluster.
 func CheckClusterStatus(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
 	rkeServerOnePublicIP, kubeConfig string) (*os.File, error) {
-	userDir, err := os.UserHomeDir()
-	if err != nil {
-		return nil, err
+	var err error
+	userDir := os.Getenv("GOROOT")
+	if userDir == "" {
+		userDir, err = os.UserHomeDir()
+		if err != nil {
+			return nil, err
+		}
+
+		userDir = filepath.Join(userDir, "go/")
 	}
 
-	scriptPath := filepath.Join(userDir, "go/src/github.com/rancher/tfp-automation/framework/set/resources/rke/rke/cluster.sh")
+	scriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/rke/rke/cluster.sh")
 
 	scriptContent, err := os.ReadFile(scriptPath)
 	if err != nil {

--- a/framework/set/resources/rke2/createCluster.go
+++ b/framework/set/resources/rke2/createCluster.go
@@ -23,13 +23,19 @@ const (
 // CreateRKE2Cluster is a helper function that will create the RKE2 cluster.
 func CreateRKE2Cluster(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
 	rke2ServerOnePublicDNS, rke2ServerOnePrivateIP, rke2ServerTwoPublicDNS, rke2ServerThreePublicDNS string) (*os.File, error) {
-	userDir, err := os.UserHomeDir()
-	if err != nil {
-		return nil, err
+	var err error
+	userDir := os.Getenv("GOROOT")
+	if userDir == "" {
+		userDir, err = os.UserHomeDir()
+		if err != nil {
+			return nil, err
+		}
+
+		userDir = filepath.Join(userDir, "go/")
 	}
 
-	serverScriptPath := filepath.Join(userDir, "go/src/github.com/rancher/tfp-automation/framework/set/resources/rke2/init-server.sh")
-	newServersScriptPath := filepath.Join(userDir, "go/src/github.com/rancher/tfp-automation/framework/set/resources/rke2/add-servers.sh")
+	serverScriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/rke2/init-server.sh")
+	newServersScriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/rke2/add-servers.sh")
 
 	serverOneScriptContent, err := os.ReadFile(serverScriptPath)
 	if err != nil {

--- a/framework/set/resources/sanity/rancher/createRancher.go
+++ b/framework/set/resources/sanity/rancher/createRancher.go
@@ -19,12 +19,18 @@ const (
 // CreateRancher is a function that will set the Rancher configurations in the main.tf file.
 func CreateRancher(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
 	rke2ServerOnePublicDNS string) (*os.File, error) {
-	userDir, err := os.UserHomeDir()
-	if err != nil {
-		return nil, err
+	var err error
+	userDir := os.Getenv("GOROOT")
+	if userDir == "" {
+		userDir, err = os.UserHomeDir()
+		if err != nil {
+			return nil, err
+		}
+
+		userDir = filepath.Join(userDir, "go/")
 	}
 
-	scriptPath := filepath.Join(userDir, "go/src/github.com/rancher/tfp-automation/framework/set/resources/sanity/rancher/setup.sh")
+	scriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/sanity/rancher/setup.sh")
 
 	scriptContent, err := os.ReadFile(scriptPath)
 	if err != nil {

--- a/tests/infrastructure/setup_proxy_rancher_test.go
+++ b/tests/infrastructure/setup_proxy_rancher_test.go
@@ -44,6 +44,7 @@ func (i *ProxyRancherTestSuite) TestCreateProxyRancher() {
 
 	logrus.Infof("Rancher server URL: %s", i.terraformConfig.Standalone.RancherHostname)
 	logrus.Infof("Booststrap password: %s", i.terraformConfig.Standalone.BootstrapPassword)
+	logrus.Infof("Proxy Address: %s:3228", i.terraformConfig.Proxy.ProxyBastion)
 
 	testSession := session.NewSession()
 	i.session = testSession


### PR DESCRIPTION
adding logic to use goroot variable to use go on systems with it defined. If it is not defined, fallback to the existing code. 

The existing code wasn't working on my machine as-is so this is a workaround to fix it