### PR TITLE
Fix snapshots

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -194,13 +194,10 @@ type Scaling struct {
 }
 
 type Snapshots struct {
-	CreateSnapshot               bool   `json:"createSnapshot,omitempty" yaml:"createSnapshot,omitempty"`
-	RestoreSnapshot              bool   `json:"restoreSnapshot,omitempty" yaml:"restoreSnapshot,omitempty"`
-	SnapshotName                 string `json:"snapshotName,omitempty" yaml:"snapshotName,omitempty"`
-	UpgradeKubernetesVersion     string `json:"upgradeKubernetesVersion,omitempty" yaml:"upgradeKubernetesVersion,omitempty"`
-	SnapshotRestore              string `json:"snapshotRestore,omitempty" yaml:"snapshotRestore,omitempty"`
-	ControlPlaneConcurrencyValue string `json:"controlPlaneConcurrencyValue,omitempty" yaml:"controlPlaneConcurrencyValue,omitempty"`
-	WorkerConcurrencyValue       string `json:"workerConcurrencyValue,omitempty" yaml:"workerConcurrencyValue,omitempty"`
+	CreateSnapshot  bool   `json:"createSnapshot,omitempty" yaml:"createSnapshot,omitempty"`
+	RestoreSnapshot bool   `json:"restoreSnapshot,omitempty" yaml:"restoreSnapshot,omitempty"`
+	SnapshotName    string `json:"snapshotName,omitempty" yaml:"snapshotName,omitempty"`
+	SnapshotRestore string `json:"snapshotRestore,omitempty" yaml:"snapshotRestore,omitempty"`
 }
 
 type TerratestConfig struct {

--- a/framework/set/provisioning/nodedriver/rke2k3s/setConfig.go
+++ b/framework/set/provisioning/nodedriver/rke2k3s/setConfig.go
@@ -160,12 +160,6 @@ func SetRKE2K3s(client *rancher.Client, terraformConfig *config.TerraformConfig,
 		SetPrivateRegistryConfig(registryBlockBody, terraformConfig)
 	}
 
-	upgradeStrategyBlock := rkeConfigBlockBody.AppendNewBlock(upgradeStrategy, nil)
-	upgradeStrategyBlockBody := upgradeStrategyBlock.Body()
-
-	upgradeStrategyBlockBody.SetAttributeValue(controlPlaneConcurrency, cty.StringVal(("10%")))
-	upgradeStrategyBlockBody.SetAttributeValue(workerConcurrency, cty.StringVal(("10%")))
-
 	if terraformConfig.ETCD != nil {
 		setEtcdConfig(rkeConfigBlockBody, terraformConfig)
 	}

--- a/tests/rancher2/snapshot/snapshot_restore_test.go
+++ b/tests/rancher2/snapshot/snapshot_restore_test.go
@@ -101,46 +101,7 @@ func (s *SnapshotRestoreTestSuite) TestTfpSnapshotRestore() {
 			clusterIDs := provisioning.Provision(s.T(), s.client, s.rancherConfig, terraform, terratest, testUser, testPassword, s.terraformOptions, configMap, false)
 			provisioning.VerifyClustersState(s.T(), adminClient, clusterIDs)
 
-			snapshotRestore(s.T(), s.client, s.rancherConfig, s.terraformConfig, terratest, testUser, testPassword, s.terraformOptions, configMap)
-			provisioning.VerifyClustersState(s.T(), adminClient, clusterIDs)
-		})
-	}
-
-	if s.terratestConfig.LocalQaseReporting {
-		qase.ReportTest()
-	}
-}
-
-func (s *SnapshotRestoreTestSuite) TestTfpSnapshotRestoreDynamicInput() {
-	if s.terratestConfig.SnapshotInput == (config.Snapshots{}) {
-		s.T().Skip()
-	}
-
-	tests := []struct {
-		name string
-	}{
-		{config.StandardClientName.String()},
-	}
-
-	for _, tt := range tests {
-		configMap := []map[string]any{s.cattleConfig}
-		provisioning.GetK8sVersion(s.T(), s.client, s.terratestConfig, s.terraformConfig, configs.DefaultK8sVersion, configMap)
-
-		tt.name = tt.name + " Module: " + s.terraformConfig.Module + " Kubernetes version: " + s.terratestConfig.KubernetesVersion
-
-		testUser, testPassword := configs.CreateTestCredentials()
-
-		s.Run((tt.name), func() {
-			keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath)
-			defer cleanup.Cleanup(s.T(), s.terraformOptions, keyPath)
-
-			adminClient, err := provisioning.FetchAdminClient(s.T(), s.client)
-			require.NoError(s.T(), err)
-
-			clusterIDs := provisioning.Provision(s.T(), s.client, s.rancherConfig, s.terraformConfig, s.terratestConfig, testUser, testPassword, s.terraformOptions, nil, false)
-			provisioning.VerifyClustersState(s.T(), adminClient, clusterIDs)
-
-			snapshotRestore(s.T(), s.client, s.rancherConfig, s.terraformConfig, s.terratestConfig, testUser, testPassword, s.terraformOptions, configMap)
+			snapshotRestore(s.T(), s.client, s.terraformConfig, testUser, testPassword, s.terraformOptions, configMap)
 			provisioning.VerifyClustersState(s.T(), adminClient, clusterIDs)
 		})
 	}


### PR DESCRIPTION
Our recent changes broke snapshot testing. This fix updates the snapshot tests to remove unused fields and upgrading as part of the snapshot test case since this isn't really testing anything in the terraform provider.