### PR TITLE
Change rancherAgentImage to upgradedRancherAgentImage

### DIFF
--- a/framework/set/resources/sanity/rancher/upgradeRancher.go
+++ b/framework/set/resources/sanity/rancher/upgradeRancher.go
@@ -37,7 +37,7 @@ func UpgradeRancher(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Bo
 		terraformConfig.Standalone.UpgradedRancherRepo + " " + terraformConfig.Standalone.RancherHostname + " " +
 		terraformConfig.Standalone.UpgradedRancherTagVersion + " " + terraformConfig.Standalone.UpgradedRancherImage
 
-	if terraformConfig.Standalone.RancherAgentImage != "" {
+	if terraformConfig.Standalone.UpgradedRancherAgentImage != "" {
 		command += " " + terraformConfig.Standalone.UpgradedRancherAgentImage
 	}
 


### PR DESCRIPTION
### Issue: N/A

### Description
Noted when release testing that upgrading to the staging registry was not working. Looking into it, it is because we are referencing the incorrect agent image...