### PR TITLE
Update GOROOT to GOPATH throughout the framework

### DIFF
--- a/framework/set/resources/airgap/rancher/setupAirgapRancher.go
+++ b/framework/set/resources/airgap/rancher/setupAirgapRancher.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/keypath"
 	"github.com/rancher/tfp-automation/framework/set/defaults"
+	"github.com/rancher/tfp-automation/framework/set/resources/rancher2"
 	"github.com/rancher/tfp-automation/framework/set/resources/rke2"
 	"github.com/sirupsen/logrus"
 	"github.com/zclconf/go-cty/cty"
@@ -19,16 +21,7 @@ const (
 // CreateAirgapRancher is a function that will set the airgap Rancher configurations in the main.tf file.
 func CreateAirgapRancher(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
 	rke2BastionPublicDNS, registryPublicDNS string) (*os.File, error) {
-	var err error
-	userDir := os.Getenv("GOROOT")
-	if userDir == "" {
-		userDir, err = os.UserHomeDir()
-		if err != nil {
-			return nil, err
-		}
-
-		userDir = filepath.Join(userDir, "go/")
-	}
+	userDir, _ := rancher2.SetKeyPath(keypath.AirgapKeyPath, terraformConfig.Provider)
 
 	scriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/airgap/rancher/setup.sh")
 

--- a/framework/set/resources/airgap/rke2/createAirgapCluster.go
+++ b/framework/set/resources/airgap/rke2/createAirgapCluster.go
@@ -9,7 +9,9 @@ import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	namegen "github.com/rancher/shepherd/pkg/namegenerator"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/keypath"
 	"github.com/rancher/tfp-automation/framework/set/defaults"
+	"github.com/rancher/tfp-automation/framework/set/resources/rancher2"
 	"github.com/rancher/tfp-automation/framework/set/resources/rke2"
 	"github.com/sirupsen/logrus"
 	"github.com/zclconf/go-cty/cty"
@@ -26,16 +28,7 @@ const (
 // CreateAirgapRKE2Cluster is a helper function that will create the RKE2 cluster.
 func CreateAirgapRKE2Cluster(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
 	rke2BastionPublicDNS, registryPublicDNS, rke2ServerOnePrivateIP, rke2ServerTwoPrivateIP, rke2ServerThreePrivateIP string) (*os.File, error) {
-	var err error
-	userDir := os.Getenv("GOROOT")
-	if userDir == "" {
-		userDir, err = os.UserHomeDir()
-		if err != nil {
-			return nil, err
-		}
-
-		userDir = filepath.Join(userDir, "go/")
-	}
+	userDir, _ := rancher2.SetKeyPath(keypath.AirgapKeyPath, terraformConfig.Provider)
 
 	bastionScriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/airgap/rke2/bastion.sh")
 	serverScriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/airgap/rke2/init-server.sh")

--- a/framework/set/resources/ipv6/rancher/setupIPv6Rancher.go
+++ b/framework/set/resources/ipv6/rancher/setupIPv6Rancher.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/keypath"
 	"github.com/rancher/tfp-automation/framework/set/defaults"
+	"github.com/rancher/tfp-automation/framework/set/resources/rancher2"
 	"github.com/rancher/tfp-automation/framework/set/resources/rke2"
 	"github.com/sirupsen/logrus"
 	"github.com/zclconf/go-cty/cty"
@@ -19,16 +21,7 @@ const (
 // CreateIPv6Rancher is a function that will set the IPv6 Rancher configurations in the main.tf file.
 func CreateIPv6Rancher(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
 	rke2BastionPublicDNS string) (*os.File, error) {
-	var err error
-	userDir := os.Getenv("GOROOT")
-	if userDir == "" {
-		userDir, err = os.UserHomeDir()
-		if err != nil {
-			return nil, err
-		}
-
-		userDir = filepath.Join(userDir, "go/")
-	}
+	userDir, _ := rancher2.SetKeyPath(keypath.IPv6KeyPath, terraformConfig.Provider)
 
 	scriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/ipv6/rancher/setup.sh")
 

--- a/framework/set/resources/ipv6/rke2/createIPv6Cluster.go
+++ b/framework/set/resources/ipv6/rke2/createIPv6Cluster.go
@@ -9,7 +9,9 @@ import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	namegen "github.com/rancher/shepherd/pkg/namegenerator"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/keypath"
 	"github.com/rancher/tfp-automation/framework/set/defaults"
+	"github.com/rancher/tfp-automation/framework/set/resources/rancher2"
 	"github.com/rancher/tfp-automation/framework/set/resources/rke2"
 	"github.com/sirupsen/logrus"
 	"github.com/zclconf/go-cty/cty"
@@ -26,16 +28,7 @@ const (
 // CreateIPv6Cluster is a helper function that will create the IPv6 RKE2 cluster.
 func CreateIPv6Cluster(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
 	rke2BastionPublicDNS, rke2ServerOnePrivateIP, rke2ServerTwoPrivateIP, rke2ServerThreePrivateIP string) (*os.File, error) {
-	var err error
-	userDir := os.Getenv("GOROOT")
-	if userDir == "" {
-		userDir, err = os.UserHomeDir()
-		if err != nil {
-			return nil, err
-		}
-
-		userDir = filepath.Join(userDir, "go/")
-	}
+	userDir, _ := rancher2.SetKeyPath(keypath.IPv6KeyPath, terraformConfig.Provider)
 
 	bastionScriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/airgap/rke2/bastion.sh")
 	serverScriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/ipv6/rke2/init-server.sh")

--- a/framework/set/resources/k3s/createCluster.go
+++ b/framework/set/resources/k3s/createCluster.go
@@ -8,7 +8,9 @@ import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	namegen "github.com/rancher/shepherd/pkg/namegenerator"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/keypath"
 	"github.com/rancher/tfp-automation/framework/set/defaults"
+	"github.com/rancher/tfp-automation/framework/set/resources/rancher2"
 	"github.com/rancher/tfp-automation/framework/set/resources/rke2"
 	"github.com/sirupsen/logrus"
 	"github.com/zclconf/go-cty/cty"
@@ -24,16 +26,7 @@ const (
 // CreateK3SCluster is a helper function that will create the K3S cluster.
 func CreateK3SCluster(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
 	k3sServerOnePublicDNS, k3sServerOnePrivateIP, k3sServerTwoPublicDNS, k3sServerThreePublicDNS string) (*os.File, error) {
-	var err error
-	userDir := os.Getenv("GOROOT")
-	if userDir == "" {
-		userDir, err = os.UserHomeDir()
-		if err != nil {
-			return nil, err
-		}
-
-		userDir = filepath.Join(userDir, "go/")
-	}
+	userDir, _ := rancher2.SetKeyPath(keypath.K3sKeyPath, terraformConfig.Provider)
 
 	serverScriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/k3s/init-server.sh")
 	newServersScriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/k3s/add-servers.sh")

--- a/framework/set/resources/proxy/rancher/createRancher.go
+++ b/framework/set/resources/proxy/rancher/createRancher.go
@@ -6,8 +6,10 @@ import (
 
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/keypath"
 	"github.com/rancher/tfp-automation/defaults/providers"
 	"github.com/rancher/tfp-automation/framework/set/defaults"
+	"github.com/rancher/tfp-automation/framework/set/resources/rancher2"
 	"github.com/rancher/tfp-automation/framework/set/resources/rke2"
 	"github.com/sirupsen/logrus"
 	"github.com/zclconf/go-cty/cty"
@@ -20,17 +22,7 @@ const (
 // CreateProxiedRancher is a function that will set the Rancher configurations in the main.tf file.
 func CreateProxiedRancher(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
 	rke2BastionPublicDNS, rke2BastionPrivateIP, linodeNodeBalancerHostname string) (*os.File, error) {
-
-	var err error
-	userDir := os.Getenv("GOROOT")
-	if userDir == "" {
-		userDir, err = os.UserHomeDir()
-		if err != nil {
-			return nil, err
-		}
-
-		userDir = filepath.Join(userDir, "go/")
-	}
+	userDir, _ := rancher2.SetKeyPath(keypath.ProxyKeyPath, terraformConfig.Provider)
 
 	scriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/proxy/rancher/setup.sh")
 

--- a/framework/set/resources/proxy/rancher/upgradeRancher.go
+++ b/framework/set/resources/proxy/rancher/upgradeRancher.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/keypath"
 	"github.com/rancher/tfp-automation/framework/set/defaults"
+	"github.com/rancher/tfp-automation/framework/set/resources/rancher2"
 	"github.com/rancher/tfp-automation/framework/set/resources/rke2"
 	"github.com/sirupsen/logrus"
 	"github.com/zclconf/go-cty/cty"
@@ -19,16 +21,7 @@ const (
 // UpgradeProxiedRancher is a function that will upgrade the Rancher configurations in the main.tf file.
 func UpgradeProxiedRancher(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
 	proxyPrivateIP, proxyNode string) (*os.File, error) {
-	var err error
-	userDir := os.Getenv("GOROOT")
-	if userDir == "" {
-		userDir, err = os.UserHomeDir()
-		if err != nil {
-			return nil, err
-		}
-
-		userDir = filepath.Join(userDir, "go/")
-	}
+	userDir, _ := rancher2.SetKeyPath(keypath.ProxyKeyPath, terraformConfig.Provider)
 
 	scriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/proxy/rancher/upgrade.sh")
 

--- a/framework/set/resources/proxy/rke2/createCluster.go
+++ b/framework/set/resources/proxy/rke2/createCluster.go
@@ -8,7 +8,9 @@ import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	namegen "github.com/rancher/shepherd/pkg/namegenerator"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/keypath"
 	"github.com/rancher/tfp-automation/framework/set/defaults"
+	"github.com/rancher/tfp-automation/framework/set/resources/rancher2"
 	sanity "github.com/rancher/tfp-automation/framework/set/resources/rke2"
 	"github.com/sirupsen/logrus"
 	"github.com/zclconf/go-cty/cty"
@@ -24,16 +26,7 @@ const (
 // CreateRKE2Cluster is a helper function that will create the RKE2 cluster.
 func CreateRKE2Cluster(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
 	rke2BastionPublicDNS, rke2BastionPrivateIP, rke2ServerOnePrivateIP, rke2ServerTwoPrivateIP, rke2ServerThreePrivateIP string) (*os.File, error) {
-	var err error
-	userDir := os.Getenv("GOROOT")
-	if userDir == "" {
-		userDir, err = os.UserHomeDir()
-		if err != nil {
-			return nil, err
-		}
-
-		userDir = filepath.Join(userDir, "go/")
-	}
+	userDir, _ := rancher2.SetKeyPath(keypath.ProxyKeyPath, terraformConfig.Provider)
 
 	serverScriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/proxy/rke2/init-server.sh")
 	newServersScriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/proxy/rke2/add-servers.sh")

--- a/framework/set/resources/proxy/squid/createSquidProxy.go
+++ b/framework/set/resources/proxy/squid/createSquidProxy.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/keypath"
 	"github.com/rancher/tfp-automation/framework/set/defaults"
+	"github.com/rancher/tfp-automation/framework/set/resources/rancher2"
 	"github.com/rancher/tfp-automation/framework/set/resources/rke2"
 	"github.com/sirupsen/logrus"
 	"github.com/zclconf/go-cty/cty"
@@ -19,17 +21,7 @@ const (
 // CreateSquidProxy is a function that will set the squid proxy configurations in the main.tf file.
 func CreateSquidProxy(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
 	rke2BastionPublicDNS, rke2ServerOnePrivateIP, rke2ServerTwoPrivateIP, rke2ServerThreePrivateIP string) (*os.File, error) {
-
-	var err error
-	userDir := os.Getenv("GOROOT")
-	if userDir == "" {
-		userDir, err = os.UserHomeDir()
-		if err != nil {
-			return nil, err
-		}
-
-		userDir = filepath.Join(userDir, "go/")
-	}
+	userDir, _ := rancher2.SetKeyPath(keypath.ProxyKeyPath, terraformConfig.Provider)
 
 	scriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/proxy/squid/setup.sh")
 	squidConf := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/proxy/squid/squid.conf")

--- a/framework/set/resources/rancher2/initMainTF.go
+++ b/framework/set/resources/rancher2/initMainTF.go
@@ -13,7 +13,7 @@ func InitializeMainTF() (*hclwrite.File, *hclwrite.Body, *os.File) {
 	newFile := hclwrite.NewEmptyFile()
 	rootBody := newFile.Body()
 
-	keyPath := SetKeyPath(keypath.RancherKeyPath, "")
+	_, keyPath := SetKeyPath(keypath.RancherKeyPath, "")
 	file, err := os.Create(keyPath + configs.MainTF)
 	if err != nil {
 		return nil, nil, nil

--- a/framework/set/resources/rancher2/setKeyPath.go
+++ b/framework/set/resources/rancher2/setKeyPath.go
@@ -6,13 +6,13 @@ import (
 )
 
 // SetKeyPath is a function that will set the path to the key file.
-func SetKeyPath(keyPath, provider string) string {
+func SetKeyPath(keyPath, provider string) (string, string) {
 	var err error
-	userDir := os.Getenv("GOROOT")
+	userDir := os.Getenv("GOPATH")
 	if userDir == "" {
 		userDir, err = os.UserHomeDir()
 		if err != nil {
-			return ""
+			return "", ""
 		}
 
 		userDir = filepath.Join(userDir, "go/")
@@ -24,5 +24,5 @@ func SetKeyPath(keyPath, provider string) string {
 		keyPath = filepath.Join(keyPath, "/", provider)
 	}
 
-	return keyPath
+	return userDir, keyPath
 }

--- a/framework/set/resources/registries/createRegistry.go
+++ b/framework/set/resources/registries/createRegistry.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/keypath"
 	"github.com/rancher/tfp-automation/framework/set/defaults"
+	"github.com/rancher/tfp-automation/framework/set/resources/rancher2"
 	"github.com/rancher/tfp-automation/framework/set/resources/rke2"
 	"github.com/sirupsen/logrus"
 	"github.com/zclconf/go-cty/cty"
@@ -15,16 +17,7 @@ import (
 // CreateAuthenticatedRegistry is a helper function that will create an authenticated registry.
 func CreateAuthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
 	rke2AuthRegistryPublicDNS string) (*os.File, error) {
-	var err error
-	userDir := os.Getenv("GOROOT")
-	if userDir == "" {
-		userDir, err = os.UserHomeDir()
-		if err != nil {
-			return nil, err
-		}
-
-		userDir = filepath.Join(userDir, "go/")
-	}
+	userDir, _ := rancher2.SetKeyPath(keypath.RegistryKeyPath, terraformConfig.Provider)
 
 	registryScriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/registries/auth-registry.sh")
 
@@ -65,16 +58,7 @@ func CreateAuthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootBody
 // CreateNonAuthenticatedRegistry is a helper function that will create a non-authenticated registry.
 func CreateNonAuthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
 	rke2NonAuthRegistryPublicDNS, registryType string) (*os.File, error) {
-	var err error
-	userDir := os.Getenv("GOROOT")
-	if userDir == "" {
-		userDir, err = os.UserHomeDir()
-		if err != nil {
-			return nil, err
-		}
-
-		userDir = filepath.Join(userDir, "go/")
-	}
+	userDir, _ := rancher2.SetKeyPath(keypath.RegistryKeyPath, terraformConfig.Provider)
 
 	registryScriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/registries/non-auth-registry.sh")
 

--- a/framework/set/resources/registries/createRegistry/createRegistry.go
+++ b/framework/set/resources/registries/createRegistry/createRegistry.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/keypath"
 	"github.com/rancher/tfp-automation/framework/set/defaults"
+	"github.com/rancher/tfp-automation/framework/set/resources/rancher2"
 	"github.com/rancher/tfp-automation/framework/set/resources/rke2"
 	"github.com/sirupsen/logrus"
 	"github.com/zclconf/go-cty/cty"
@@ -20,16 +22,7 @@ const (
 // CreateAuthenticatedRegistry is a helper function that will create an authenticated registry.
 func CreateAuthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
 	rke2AuthRegistryPublicDNS string) (*os.File, error) {
-	var err error
-	userDir := os.Getenv("GOROOT")
-	if userDir == "" {
-		userDir, err = os.UserHomeDir()
-		if err != nil {
-			return nil, err
-		}
-
-		userDir = filepath.Join(userDir, "go/")
-	}
+	userDir, _ := rancher2.SetKeyPath(keypath.RegistryKeyPath, terraformConfig.Provider)
 
 	registryScriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/registries/createRegistry/auth-registry.sh")
 
@@ -70,16 +63,7 @@ func CreateAuthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootBody
 // CreateNonAuthenticatedRegistry is a helper function that will create a non-authenticated registry.
 func CreateNonAuthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
 	rke2NonAuthRegistryPublicDNS, registryType string) (*os.File, error) {
-	var err error
-	userDir := os.Getenv("GOROOT")
-	if userDir == "" {
-		userDir, err = os.UserHomeDir()
-		if err != nil {
-			return nil, err
-		}
-
-		userDir = filepath.Join(userDir, "go/")
-	}
+	userDir, _ := rancher2.SetKeyPath(keypath.RegistryKeyPath, terraformConfig.Provider)
 
 	registryScriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/registries/createRegistry/non-auth-registry.sh")
 

--- a/framework/set/resources/registries/rancher/createRancher.go
+++ b/framework/set/resources/registries/rancher/createRancher.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/keypath"
 	"github.com/rancher/tfp-automation/framework/set/defaults"
+	"github.com/rancher/tfp-automation/framework/set/resources/rancher2"
 	"github.com/rancher/tfp-automation/framework/set/resources/rke2"
 	"github.com/sirupsen/logrus"
 	"github.com/zclconf/go-cty/cty"
@@ -19,16 +21,7 @@ const (
 // CreateRancher is a function that will set the Rancher configurations in the main.tf file.
 func CreateRancher(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
 	rke2ServerOnePublicDNS, registryPublicDNS string) (*os.File, error) {
-	var err error
-	userDir := os.Getenv("GOROOT")
-	if userDir == "" {
-		userDir, err = os.UserHomeDir()
-		if err != nil {
-			return nil, err
-		}
-
-		userDir = filepath.Join(userDir, "go/")
-	}
+	userDir, _ := rancher2.SetKeyPath(keypath.RegistryKeyPath, terraformConfig.Provider)
 
 	scriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/registries/rancher/setup.sh")
 

--- a/framework/set/resources/registries/rke2/createCluster.go
+++ b/framework/set/resources/registries/rke2/createCluster.go
@@ -8,7 +8,9 @@ import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	namegen "github.com/rancher/shepherd/pkg/namegenerator"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/keypath"
 	"github.com/rancher/tfp-automation/framework/set/defaults"
+	"github.com/rancher/tfp-automation/framework/set/resources/rancher2"
 	"github.com/rancher/tfp-automation/framework/set/resources/rke2"
 	"github.com/sirupsen/logrus"
 	"github.com/zclconf/go-cty/cty"
@@ -25,16 +27,7 @@ const (
 func CreateRKE2Cluster(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
 	rke2ServerOnePublicDNS, rke2ServerOnePrivateIP, rke2ServerTwoPublicDNS, rke2ServerThreePublicDNS,
 	registryPublicDNS string) (*os.File, error) {
-	var err error
-	userDir := os.Getenv("GOROOT")
-	if userDir == "" {
-		userDir, err = os.UserHomeDir()
-		if err != nil {
-			return nil, err
-		}
-
-		userDir = filepath.Join(userDir, "go/")
-	}
+	userDir, _ := rancher2.SetKeyPath(keypath.RegistryKeyPath, terraformConfig.Provider)
 
 	serverScriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/registries/rke2/init-server.sh")
 	newServersScriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/registries/rke2/add-servers.sh")

--- a/framework/set/resources/rke/rke/clusterCheck.go
+++ b/framework/set/resources/rke/rke/clusterCheck.go
@@ -8,7 +8,9 @@ import (
 
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/keypath"
 	"github.com/rancher/tfp-automation/framework/set/defaults"
+	"github.com/rancher/tfp-automation/framework/set/resources/rancher2"
 	"github.com/rancher/tfp-automation/framework/set/resources/rke2"
 	"github.com/sirupsen/logrus"
 	"github.com/zclconf/go-cty/cty"
@@ -17,16 +19,7 @@ import (
 // CheckClusterStatus is a helper function that will check the status of the RKE1 cluster.
 func CheckClusterStatus(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
 	rkeServerOnePublicIP, kubeConfig string) (*os.File, error) {
-	var err error
-	userDir := os.Getenv("GOROOT")
-	if userDir == "" {
-		userDir, err = os.UserHomeDir()
-		if err != nil {
-			return nil, err
-		}
-
-		userDir = filepath.Join(userDir, "go/")
-	}
+	userDir, _ := rancher2.SetKeyPath(keypath.RKEKeyPath, terraformConfig.Provider)
 
 	scriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/rke/rke/cluster.sh")
 

--- a/framework/set/resources/rke2/createCluster.go
+++ b/framework/set/resources/rke2/createCluster.go
@@ -8,8 +8,10 @@ import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	namegen "github.com/rancher/shepherd/pkg/namegenerator"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/keypath"
 	"github.com/rancher/tfp-automation/defaults/resourceblocks/nodeproviders/linode"
 	"github.com/rancher/tfp-automation/framework/set/defaults"
+	"github.com/rancher/tfp-automation/framework/set/resources/rancher2"
 	"github.com/sirupsen/logrus"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -24,16 +26,7 @@ const (
 // CreateRKE2Cluster is a helper function that will create the RKE2 cluster.
 func CreateRKE2Cluster(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
 	rke2ServerOnePublicIP, rke2ServerOnePrivateIP, rke2ServerTwoPublicIP, rke2ServerThreePublicIP string) (*os.File, error) {
-	var err error
-	userDir := os.Getenv("GOROOT")
-	if userDir == "" {
-		userDir, err = os.UserHomeDir()
-		if err != nil {
-			return nil, err
-		}
-
-		userDir = filepath.Join(userDir, "go/")
-	}
+	userDir, _ := rancher2.SetKeyPath(keypath.RKE2KeyPath, terraformConfig.Provider)
 
 	serverScriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/rke2/init-server.sh")
 	newServersScriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/rke2/add-servers.sh")

--- a/framework/set/resources/sanity/rancher/createRancher.go
+++ b/framework/set/resources/sanity/rancher/createRancher.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/keypath"
 	"github.com/rancher/tfp-automation/framework/set/defaults"
+	"github.com/rancher/tfp-automation/framework/set/resources/rancher2"
 	"github.com/rancher/tfp-automation/framework/set/resources/rke2"
 	"github.com/sirupsen/logrus"
 	"github.com/zclconf/go-cty/cty"
@@ -19,16 +21,7 @@ const (
 // CreateRancher is a function that will set the Rancher configurations in the main.tf file.
 func CreateRancher(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
 	rke2ServerOnePublicIP, nodeBalancerHostname string) (*os.File, error) {
-	var err error
-	userDir := os.Getenv("GOROOT")
-	if userDir == "" {
-		userDir, err = os.UserHomeDir()
-		if err != nil {
-			return nil, err
-		}
-
-		userDir = filepath.Join(userDir, "go/")
-	}
+	userDir, _ := rancher2.SetKeyPath(keypath.SanityKeyPath, terraformConfig.Provider)
 
 	scriptPath := filepath.Join(userDir, "src/github.com/rancher/tfp-automation/framework/set/resources/sanity/rancher/setup.sh")
 

--- a/framework/set/setConfigTF.go
+++ b/framework/set/setConfigTF.go
@@ -176,7 +176,7 @@ func ConfigTF(client *rancher.Client, testUser, testPassword string, rbacRole co
 	}
 
 	// // This is needed to ensure there is no duplications in the main.tf file.
-	keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 	file, err = os.Create(keyPath + configs.MainTF)
 	if err != nil {
 		logrus.Infof("Failed to reset/overwrite main.tf file. Error: %v", err)

--- a/tests/airgap/airgap_provisioning_test.go
+++ b/tests/airgap/airgap_provisioning_test.go
@@ -41,7 +41,7 @@ type TfpAirgapProvisioningTestSuite struct {
 }
 
 func (a *TfpAirgapProvisioningTestSuite) TearDownSuite() {
-	keyPath := rancher2.SetKeyPath(keypath.AirgapKeyPath, a.terraformConfig.Provider)
+	_, keyPath := rancher2.SetKeyPath(keypath.AirgapKeyPath, a.terraformConfig.Provider)
 	cleanup.Cleanup(a.T(), a.standaloneTerraformOptions, keyPath)
 }
 
@@ -49,7 +49,7 @@ func (a *TfpAirgapProvisioningTestSuite) SetupSuite() {
 	a.cattleConfig = shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
 	a.rancherConfig, a.terraformConfig, a.terratestConfig = config.LoadTFPConfigs(a.cattleConfig)
 
-	keyPath := rancher2.SetKeyPath(keypath.AirgapKeyPath, a.terraformConfig.Provider)
+	_, keyPath := rancher2.SetKeyPath(keypath.AirgapKeyPath, a.terraformConfig.Provider)
 	standaloneTerraformOptions := framework.Setup(a.T(), a.terraformConfig, a.terratestConfig, keyPath)
 	a.standaloneTerraformOptions = standaloneTerraformOptions
 
@@ -99,7 +99,7 @@ func (a *TfpAirgapProvisioningTestSuite) TfpSetupSuite() map[string]any {
 
 	operations.ReplaceValue([]string{"rancher", "host"}, a.rancherConfig.Host, configMap[0])
 
-	keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 	terraformOptions := framework.Setup(a.T(), a.terraformConfig, a.terratestConfig, keyPath)
 	a.terraformOptions = terraformOptions
 
@@ -143,7 +143,7 @@ func (a *TfpAirgapProvisioningTestSuite) TestTfpAirgapProvisioning() {
 		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion
 
 		a.Run((tt.name), func() {
-			keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 			defer cleanup.Cleanup(a.T(), a.terraformOptions, keyPath)
 
 			clusterIDs, customClusterNames := provisioning.Provision(a.T(), a.client, rancher, terraform, testUser, testPassword, a.terraformOptions, configMap, newFile, rootBody, file, false, false, true, customClusterNames)
@@ -201,7 +201,7 @@ func (a *TfpAirgapProvisioningTestSuite) TestTfpAirgapUpgrading() {
 		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion
 
 		a.Run((tt.name), func() {
-			keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 			defer cleanup.Cleanup(a.T(), a.terraformOptions, keyPath)
 
 			clusterIDs, customClusterNames := provisioning.Provision(a.T(), a.client, rancher, terraform, testUser, testPassword, a.terraformOptions, configMap, newFile, rootBody, file, tt.isWindows, false, true, customClusterNames)

--- a/tests/airgap/airgap_upgrade_rancher_test.go
+++ b/tests/airgap/airgap_upgrade_rancher_test.go
@@ -44,10 +44,10 @@ type TfpAirgapUpgradeRancherTestSuite struct {
 }
 
 func (a *TfpAirgapUpgradeRancherTestSuite) TearDownSuite() {
-	keyPath := rancher2.SetKeyPath(keypath.AirgapKeyPath, a.terraformConfig.Provider)
+	_, keyPath := rancher2.SetKeyPath(keypath.AirgapKeyPath, a.terraformConfig.Provider)
 	cleanup.Cleanup(a.T(), a.standaloneTerraformOptions, keyPath)
 
-	keyPath = rancher2.SetKeyPath(keypath.UpgradeKeyPath, a.terraformConfig.Provider)
+	_, keyPath = rancher2.SetKeyPath(keypath.UpgradeKeyPath, a.terraformConfig.Provider)
 	cleanup.Cleanup(a.T(), a.upgradeTerraformOptions, keyPath)
 }
 
@@ -55,7 +55,7 @@ func (a *TfpAirgapUpgradeRancherTestSuite) SetupSuite() {
 	a.cattleConfig = shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
 	a.rancherConfig, a.terraformConfig, a.terratestConfig = config.LoadTFPConfigs(a.cattleConfig)
 
-	keyPath := rancher2.SetKeyPath(keypath.AirgapKeyPath, a.terraformConfig.Provider)
+	_, keyPath := rancher2.SetKeyPath(keypath.AirgapKeyPath, a.terraformConfig.Provider)
 	standaloneTerraformOptions := framework.Setup(a.T(), a.terraformConfig, a.terratestConfig, keyPath)
 	a.standaloneTerraformOptions = standaloneTerraformOptions
 
@@ -65,7 +65,7 @@ func (a *TfpAirgapUpgradeRancherTestSuite) SetupSuite() {
 	a.registry = registry
 	a.bastion = bastion
 
-	keyPath = rancher2.SetKeyPath(keypath.UpgradeKeyPath, a.terraformConfig.Provider)
+	_, keyPath = rancher2.SetKeyPath(keypath.UpgradeKeyPath, a.terraformConfig.Provider)
 	upgradeTerraformOptions := framework.Setup(a.T(), a.terraformConfig, a.terratestConfig, keyPath)
 
 	a.upgradeTerraformOptions = upgradeTerraformOptions
@@ -111,7 +111,7 @@ func (a *TfpAirgapUpgradeRancherTestSuite) TfpSetupSuite() map[string]any {
 
 	operations.ReplaceValue([]string{"rancher", "host"}, a.rancherConfig.Host, configMap[0])
 
-	keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 	terraformOptions := framework.Setup(a.T(), a.terraformConfig, a.terratestConfig, keyPath)
 	a.terraformOptions = terraformOptions
 
@@ -123,9 +123,9 @@ func (a *TfpAirgapUpgradeRancherTestSuite) TestTfpUpgradeAirgapRancher() {
 
 	a.provisionAndVerifyCluster("Pre-Upgrade Airgap ", clusterIDs, false)
 
-	a.terraformConfig.Standalone.UpgradeRancher = true
+	a.terraformConfig.Standalone.UpgradeAirgapRancher = true
 
-	keyPath := rancher2.SetKeyPath(keypath.UpgradeKeyPath, a.terraformConfig.Provider)
+	_, keyPath := rancher2.SetKeyPath(keypath.UpgradeKeyPath, a.terraformConfig.Provider)
 	err := upgrade.CreateMainTF(a.T(), a.upgradeTerraformOptions, keyPath, a.terraformConfig, a.terratestConfig, "", "", a.bastion, a.registry)
 	require.NoError(a.T(), err)
 
@@ -188,7 +188,7 @@ func (a *TfpAirgapUpgradeRancherTestSuite) provisionAndVerifyCluster(name string
 	}
 
 	if deleteClusters {
-		keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+		_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 		cleanup.Cleanup(a.T(), a.terraformOptions, keyPath)
 	}
 

--- a/tests/extensions/provisioning/buildModule.go
+++ b/tests/extensions/provisioning/buildModule.go
@@ -15,7 +15,7 @@ import (
 
 // BuildModule is a function that builds the Terraform module.
 func BuildModule(t *testing.T, rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig, configMap []map[string]any) error {
-	keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 
 	_, _, err := framework.ConfigTF(nil, "", "", "", configMap, nil, nil, nil, false, false, false, nil)
 	if err != nil {

--- a/tests/extensions/provisioning/forceCleanup.go
+++ b/tests/extensions/provisioning/forceCleanup.go
@@ -11,7 +11,7 @@ import (
 
 // ForceCleanup is a function that will forcibly run terraform destroy and cleanup Terraform resources.
 func ForceCleanup(t *testing.T) error {
-	keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: keyPath,

--- a/tests/infrastructure/setup_airgap_rancher_test.go
+++ b/tests/infrastructure/setup_airgap_rancher_test.go
@@ -31,7 +31,7 @@ func (i *AirgapRancherTestSuite) TestCreateAirgapRancher() {
 	i.terratestConfig = new(config.TerratestConfig)
 	ranchFrame.LoadConfig(config.TerratestConfigurationFileKey, i.terratestConfig)
 
-	keyPath := rancher2.SetKeyPath(keypath.AirgapKeyPath, i.terraformConfig.Provider)
+	_, keyPath := rancher2.SetKeyPath(keypath.AirgapKeyPath, i.terraformConfig.Provider)
 	terraformOptions := framework.Setup(i.T(), i.terraformConfig, i.terratestConfig, keyPath)
 	i.terraformOptions = terraformOptions
 

--- a/tests/infrastructure/setup_airgap_rke2_test.go
+++ b/tests/infrastructure/setup_airgap_rke2_test.go
@@ -34,7 +34,7 @@ func (i *CreateAirgappedRKE2ClusterTestSuite) TestCreateAirgappedRKE2Cluster() {
 	i.terratestConfig = new(config.TerratestConfig)
 	ranchFrame.LoadConfig(config.TerratestConfigurationFileKey, i.terratestConfig)
 
-	keyPath := rancher2.SetKeyPath(keypath.AirgapRKE2KeyPath, i.terraformConfig.Provider)
+	_, keyPath := rancher2.SetKeyPath(keypath.AirgapRKE2KeyPath, i.terraformConfig.Provider)
 	terraformOptions := framework.Setup(i.T(), i.terraformConfig, i.terratestConfig, keyPath)
 	i.terraformOptions = terraformOptions
 

--- a/tests/infrastructure/setup_k3s_test.go
+++ b/tests/infrastructure/setup_k3s_test.go
@@ -47,7 +47,7 @@ func (i *CreateK3SClusterTestSuite) TestCreateK3SCluster() {
 	i.terratestConfig = new(config.TerratestConfig)
 	ranchFrame.LoadConfig(config.TerratestConfigurationFileKey, i.terratestConfig)
 
-	keyPath := rancher2.SetKeyPath(keypath.K3sKeyPath, i.terraformConfig.Provider)
+	_, keyPath := rancher2.SetKeyPath(keypath.K3sKeyPath, i.terraformConfig.Provider)
 	terraformOptions := framework.Setup(i.T(), i.terraformConfig, i.terratestConfig, keyPath)
 	i.terraformOptions = terraformOptions
 

--- a/tests/infrastructure/setup_proxy_rancher_test.go
+++ b/tests/infrastructure/setup_proxy_rancher_test.go
@@ -31,7 +31,7 @@ func (i *ProxyRancherTestSuite) TestCreateProxyRancher() {
 	i.terratestConfig = new(config.TerratestConfig)
 	ranchFrame.LoadConfig(config.TerratestConfigurationFileKey, i.terratestConfig)
 
-	keyPath := rancher2.SetKeyPath(keypath.ProxyKeyPath, i.terraformConfig.Provider)
+	_, keyPath := rancher2.SetKeyPath(keypath.ProxyKeyPath, i.terraformConfig.Provider)
 	terraformOptions := framework.Setup(i.T(), i.terraformConfig, i.terratestConfig, keyPath)
 	i.terraformOptions = terraformOptions
 

--- a/tests/infrastructure/setup_rancher_ipv6_test.go
+++ b/tests/infrastructure/setup_rancher_ipv6_test.go
@@ -31,7 +31,7 @@ func (i *RancherIPv6TestSuite) TestCreateRancherIPv6() {
 	i.terratestConfig = new(config.TerratestConfig)
 	ranchFrame.LoadConfig(config.TerratestConfigurationFileKey, i.terratestConfig)
 
-	keyPath := rancher2.SetKeyPath(keypath.IPv6KeyPath, i.terraformConfig.Provider)
+	_, keyPath := rancher2.SetKeyPath(keypath.IPv6KeyPath, i.terraformConfig.Provider)
 	terraformOptions := framework.Setup(i.T(), i.terraformConfig, i.terratestConfig, keyPath)
 	i.terraformOptions = terraformOptions
 

--- a/tests/infrastructure/setup_rancher_test.go
+++ b/tests/infrastructure/setup_rancher_test.go
@@ -32,7 +32,7 @@ func (i *RancherTestSuite) TestCreateRancher() {
 	i.terratestConfig = new(config.TerratestConfig)
 	ranchFrame.LoadConfig(config.TerratestConfigurationFileKey, i.terratestConfig)
 
-	keyPath := rancher2.SetKeyPath(keypath.SanityKeyPath, i.terraformConfig.Provider)
+	_, keyPath := rancher2.SetKeyPath(keypath.SanityKeyPath, i.terraformConfig.Provider)
 	terraformOptions := framework.Setup(i.T(), i.terraformConfig, i.terratestConfig, keyPath)
 	i.terraformOptions = terraformOptions
 

--- a/tests/infrastructure/setup_rke1_test.go
+++ b/tests/infrastructure/setup_rke1_test.go
@@ -29,7 +29,7 @@ func (i *CreateRKE1ClusterTestSuite) TestCreateRKE1Cluster() {
 	i.terratestConfig = new(config.TerratestConfig)
 	ranchFrame.LoadConfig(config.TerratestConfigurationFileKey, i.terratestConfig)
 
-	keyPath := rancher2.SetKeyPath(keypath.RKEKeyPath, i.terraformConfig.Provider)
+	_, keyPath := rancher2.SetKeyPath(keypath.RKEKeyPath, i.terraformConfig.Provider)
 	terraformOptions := framework.Setup(i.T(), i.terraformConfig, i.terratestConfig, keyPath)
 	i.terraformOptions = terraformOptions
 

--- a/tests/infrastructure/setup_rke2_test.go
+++ b/tests/infrastructure/setup_rke2_test.go
@@ -52,7 +52,7 @@ func (i *CreateRKE2ClusterTestSuite) TestCreateRKE2Cluster() {
 
 	i.terratestConfig = new(config.TerratestConfig)
 	ranchFrame.LoadConfig(config.TerratestConfigurationFileKey, i.terratestConfig)
-	keyPath := rancher2.SetKeyPath(keypath.RKE2KeyPath, i.terraformConfig.Provider)
+	_, keyPath := rancher2.SetKeyPath(keypath.RKE2KeyPath, i.terraformConfig.Provider)
 	terraformOptions := framework.Setup(i.T(), i.terraformConfig, i.terratestConfig, keyPath)
 	i.terraformOptions = terraformOptions
 

--- a/tests/proxy/proxy_provisioning_test.go
+++ b/tests/proxy/proxy_provisioning_test.go
@@ -41,7 +41,7 @@ type TfpProxyProvisioningTestSuite struct {
 }
 
 func (p *TfpProxyProvisioningTestSuite) TearDownSuite() {
-	keyPath := rancher2.SetKeyPath(keypath.ProxyKeyPath, p.terraformConfig.Provider)
+	_, keyPath := rancher2.SetKeyPath(keypath.ProxyKeyPath, p.terraformConfig.Provider)
 	cleanup.Cleanup(p.T(), p.standaloneTerraformOptions, keyPath)
 }
 
@@ -49,7 +49,7 @@ func (p *TfpProxyProvisioningTestSuite) SetupSuite() {
 	p.cattleConfig = shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
 	p.rancherConfig, p.terraformConfig, p.terratestConfig = config.LoadTFPConfigs(p.cattleConfig)
 
-	keyPath := rancher2.SetKeyPath(keypath.ProxyKeyPath, p.terraformConfig.Provider)
+	_, keyPath := rancher2.SetKeyPath(keypath.ProxyKeyPath, p.terraformConfig.Provider)
 	standaloneTerraformOptions := framework.Setup(p.T(), p.terraformConfig, p.terratestConfig, keyPath)
 	p.standaloneTerraformOptions = standaloneTerraformOptions
 
@@ -95,7 +95,7 @@ func (p *TfpProxyProvisioningTestSuite) TfpSetupSuite() map[string]any {
 	err = pipeline.PostRancherInstall(p.client, p.client.RancherConfig.AdminPassword)
 	require.NoError(p.T(), err)
 
-	keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 	terraformOptions := framework.Setup(p.T(), p.terraformConfig, p.terratestConfig, keyPath)
 	p.terraformOptions = terraformOptions
 
@@ -142,7 +142,7 @@ func (p *TfpProxyProvisioningTestSuite) TestTfpNoProxyProvisioning() {
 		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion
 
 		p.Run((tt.name), func() {
-			keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 			defer cleanup.Cleanup(p.T(), p.terraformOptions, keyPath)
 
 			clusterIDs, customClusterNames := provisioning.Provision(p.T(), p.client, rancher, terraform, testUser, testPassword, p.terraformOptions, configMap, newFile, rootBody, file, false, false, true, customClusterNames)
@@ -200,14 +200,14 @@ func (p *TfpProxyProvisioningTestSuite) TestTfpProxyProvisioning() {
 		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion
 
 		p.Run((tt.name), func() {
-			keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 			defer cleanup.Cleanup(p.T(), p.terraformOptions, keyPath)
 
 			clusterIDs, _ := provisioning.Provision(p.T(), p.client, rancher, terraform, testUser, testPassword, p.terraformOptions, configMap, newFile, rootBody, file, false, false, true, customClusterNames)
 			provisioning.VerifyClustersState(p.T(), p.client, clusterIDs)
 
 			if strings.Contains(terraform.Module, modules.CustomEC2RKE2Windows) {
-				clusterIDs, _ := provisioning.Provision(p.T(), p.client, rancher, terraform, testUser, testPassword, p.terraformOptions, configMap, newFile, rootBody, file, true, false, true, customClusterNames)
+				clusterIDs, _ := provisioning.Provision(p.T(), p.client, rancher, terraform, testUser, testPassword, p.terraformOptions, configMap, newFile, rootBody, file, true, true, true, customClusterNames)
 				provisioning.VerifyClustersState(p.T(), p.client, clusterIDs)
 			}
 		})

--- a/tests/proxy/proxy_upgrade_rancher_test.go
+++ b/tests/proxy/proxy_upgrade_rancher_test.go
@@ -44,10 +44,10 @@ type TfpProxyUpgradeRancherTestSuite struct {
 }
 
 func (p *TfpProxyUpgradeRancherTestSuite) TearDownSuite() {
-	keyPath := rancher2.SetKeyPath(keypath.ProxyKeyPath, p.terraformConfig.Provider)
+	_, keyPath := rancher2.SetKeyPath(keypath.ProxyKeyPath, p.terraformConfig.Provider)
 	cleanup.Cleanup(p.T(), p.standaloneTerraformOptions, keyPath)
 
-	keyPath = rancher2.SetKeyPath(keypath.UpgradeKeyPath, p.terraformConfig.Provider)
+	_, keyPath = rancher2.SetKeyPath(keypath.UpgradeKeyPath, p.terraformConfig.Provider)
 	cleanup.Cleanup(p.T(), p.upgradeTerraformOptions, keyPath)
 }
 
@@ -55,7 +55,7 @@ func (p *TfpProxyUpgradeRancherTestSuite) SetupSuite() {
 	p.cattleConfig = shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
 	p.rancherConfig, p.terraformConfig, p.terratestConfig = config.LoadTFPConfigs(p.cattleConfig)
 
-	keyPath := rancher2.SetKeyPath(keypath.ProxyKeyPath, p.terraformConfig.Provider)
+	_, keyPath := rancher2.SetKeyPath(keypath.ProxyKeyPath, p.terraformConfig.Provider)
 	standaloneTerraformOptions := framework.Setup(p.T(), p.terraformConfig, p.terratestConfig, keyPath)
 	p.standaloneTerraformOptions = standaloneTerraformOptions
 
@@ -65,7 +65,7 @@ func (p *TfpProxyUpgradeRancherTestSuite) SetupSuite() {
 	p.proxyNode = proxyNode
 	p.proxyPrivateIP = proxyPrivateIP
 
-	keyPath = rancher2.SetKeyPath(keypath.UpgradeKeyPath, p.terraformConfig.Provider)
+	_, keyPath = rancher2.SetKeyPath(keypath.UpgradeKeyPath, p.terraformConfig.Provider)
 	upgradeTerraformOptions := framework.Setup(p.T(), p.terraformConfig, p.terratestConfig, keyPath)
 
 	p.upgradeTerraformOptions = upgradeTerraformOptions
@@ -107,7 +107,7 @@ func (p *TfpProxyUpgradeRancherTestSuite) TfpSetupSuite() map[string]any {
 	err = pipeline.PostRancherInstall(p.client, p.client.RancherConfig.AdminPassword)
 	require.NoError(p.T(), err)
 
-	keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 	terraformOptions := framework.Setup(p.T(), p.terraformConfig, p.terratestConfig, keyPath)
 	p.terraformOptions = terraformOptions
 
@@ -121,7 +121,7 @@ func (p *TfpProxyUpgradeRancherTestSuite) TestTfpUpgradeProxyRancher() {
 
 	p.terraformConfig.Standalone.UpgradeProxyRancher = true
 
-	keyPath := rancher2.SetKeyPath(keypath.UpgradeKeyPath, p.terraformConfig.Provider)
+	_, keyPath := rancher2.SetKeyPath(keypath.UpgradeKeyPath, p.terraformConfig.Provider)
 	err := upgrade.CreateMainTF(p.T(), p.upgradeTerraformOptions, keyPath, p.terraformConfig, p.terratestConfig, p.proxyPrivateIP, p.proxyNode, "", "")
 	require.NoError(p.T(), err)
 
@@ -185,7 +185,7 @@ func (p *TfpProxyUpgradeRancherTestSuite) provisionAndVerifyCluster(name string,
 	}
 
 	if deleteClusters {
-		keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+		_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 		cleanup.Cleanup(p.T(), p.terraformOptions, keyPath)
 	}
 

--- a/tests/rancher2/nodescaling/scale_hosted_test.go
+++ b/tests/rancher2/nodescaling/scale_hosted_test.go
@@ -49,7 +49,7 @@ func (s *ScaleHostedTestSuite) SetupSuite() {
 	s.cattleConfig = configMap[0]
 	s.rancherConfig, s.terraformConfig, s.terratestConfig = config.LoadTFPConfigs(s.cattleConfig)
 
-	keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 	terraformOptions := framework.Setup(s.T(), s.terraformConfig, s.terratestConfig, keyPath)
 	s.terraformOptions = terraformOptions
 }
@@ -71,7 +71,7 @@ func (s *ScaleHostedTestSuite) TestTfpScaleHosted() {
 		tt.name = tt.name + " Module: " + s.terraformConfig.Module + " Kubernetes version: " + s.terratestConfig.KubernetesVersion
 
 		s.Run((tt.name), func() {
-			keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 			defer cleanup.Cleanup(s.T(), s.terraformOptions, keyPath)
 
 			adminClient, err := provisioning.FetchAdminClient(s.T(), s.client)

--- a/tests/rancher2/nodescaling/scale_test.go
+++ b/tests/rancher2/nodescaling/scale_test.go
@@ -56,7 +56,7 @@ func (s *ScaleTestSuite) SetupSuite() {
 	s.cattleConfig = configMap[0]
 	s.rancherConfig, s.terraformConfig, s.terratestConfig = config.LoadTFPConfigs(s.cattleConfig)
 
-	keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 	terraformOptions := framework.Setup(s.T(), s.terraformConfig, s.terratestConfig, keyPath)
 	s.terraformOptions = terraformOptions
 
@@ -103,7 +103,7 @@ func (s *ScaleTestSuite) TestTfpScale() {
 		tt.name = tt.name + " Module: " + s.terraformConfig.Module + " Kubernetes version: " + terratest.KubernetesVersion
 
 		s.Run((tt.name), func() {
-			keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 			defer cleanup.Cleanup(s.T(), s.terraformOptions, keyPath)
 
 			adminClient, err := provisioning.FetchAdminClient(s.T(), s.client)
@@ -150,7 +150,7 @@ func (s *ScaleTestSuite) TestTfpScaleDynamicInput() {
 		tt.name = tt.name + " Module: " + s.terraformConfig.Module + " Kubernetes version: " + s.terratestConfig.KubernetesVersion
 
 		s.Run((tt.name), func() {
-			keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 			defer cleanup.Cleanup(s.T(), s.terraformOptions, keyPath)
 
 			adminClient, err := provisioning.FetchAdminClient(s.T(), s.client)

--- a/tests/rancher2/os/os_test.go
+++ b/tests/rancher2/os/os_test.go
@@ -87,7 +87,7 @@ func (p *OSValidationTestSuite) SetupSuite() {
 		DefaultRegion: terraformConfig.AWSConfig.Region,
 	}
 
-	keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 	terraformOptions := framework.Setup(p.T(), terraformConfig, terratestConfig, keyPath)
 	p.terraformOptions = terraformOptions
 }
@@ -106,7 +106,7 @@ func (p *OSValidationTestSuite) TestDynamicOSValidation() {
 	customClusterNames := []string{}
 
 	for ami, batch := range configBatches {
-		keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+		_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 		defer cleanup.Cleanup(p.T(), p.terraformOptions, keyPath)
 		testUser, testPassword := configs.CreateTestCredentials()
 

--- a/tests/rancher2/provisioning/provision_custom_test.go
+++ b/tests/rancher2/provisioning/provision_custom_test.go
@@ -50,7 +50,7 @@ func (p *ProvisionCustomTestSuite) SetupSuite() map[string]any {
 	p.cattleConfig = configMap[0]
 	p.rancherConfig, p.terraformConfig, p.terratestConfig = config.LoadTFPConfigs(p.cattleConfig)
 
-	keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 	terraformOptions := framework.Setup(p.T(), p.terraformConfig, p.terratestConfig, keyPath)
 	p.terraformOptions = terraformOptions
 
@@ -88,7 +88,7 @@ func (p *ProvisionCustomTestSuite) TestTfpProvisionCustom() {
 		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion
 
 		p.Run((tt.name), func() {
-			keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 			defer cleanup.Cleanup(p.T(), p.terraformOptions, keyPath)
 
 			adminClient, err := provisioning.FetchAdminClient(p.T(), p.client)

--- a/tests/rancher2/provisioning/provision_hosted_test.go
+++ b/tests/rancher2/provisioning/provision_hosted_test.go
@@ -47,7 +47,7 @@ func (p *ProvisionHostedTestSuite) SetupSuite() {
 	p.cattleConfig = configMap[0]
 	p.rancherConfig, p.terraformConfig, p.terratestConfig = config.LoadTFPConfigs(p.cattleConfig)
 
-	keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 	terraformOptions := framework.Setup(p.T(), p.terraformConfig, p.terratestConfig, keyPath)
 	p.terraformOptions = terraformOptions
 }
@@ -70,7 +70,7 @@ func (p *ProvisionHostedTestSuite) TestTfpProvisionHosted() {
 		testUser, testPassword := configs.CreateTestCredentials()
 
 		p.Run((tt.name), func() {
-			keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 			defer cleanup.Cleanup(p.T(), p.terraformOptions, keyPath)
 
 			adminClient, err := provisioning.FetchAdminClient(p.T(), p.client)

--- a/tests/rancher2/provisioning/provision_import_test.go
+++ b/tests/rancher2/provisioning/provision_import_test.go
@@ -49,7 +49,7 @@ func (p *ProvisionImportTestSuite) SetupSuite() map[string]any {
 	p.cattleConfig = configMap[0]
 	p.rancherConfig, p.terraformConfig, p.terratestConfig = config.LoadTFPConfigs(p.cattleConfig)
 
-	keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 	terraformOptions := framework.Setup(p.T(), p.terraformConfig, p.terratestConfig, keyPath)
 	p.terraformOptions = terraformOptions
 
@@ -82,7 +82,7 @@ func (p *ProvisionImportTestSuite) TestTfpProvisionImport() {
 		rancher, terraform, _ := config.LoadTFPConfigs(configMap[0])
 
 		p.Run((tt.name), func() {
-			keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 			defer cleanup.Cleanup(p.T(), p.terraformOptions, keyPath)
 
 			adminClient, err := provisioning.FetchAdminClient(p.T(), p.client)

--- a/tests/rancher2/provisioning/provision_test.go
+++ b/tests/rancher2/provisioning/provision_test.go
@@ -52,7 +52,7 @@ func (p *ProvisionTestSuite) SetupSuite() {
 	p.cattleConfig = configMap[0]
 	p.rancherConfig, p.terraformConfig, p.terratestConfig = config.LoadTFPConfigs(p.cattleConfig)
 
-	keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 	terraformOptions := framework.Setup(p.T(), p.terraformConfig, p.terratestConfig, keyPath)
 	p.terraformOptions = terraformOptions
 }
@@ -83,7 +83,7 @@ func (p *ProvisionTestSuite) TestTfpProvision() {
 		tt.name = tt.name + " Module: " + p.terraformConfig.Module + " Kubernetes version: " + terratest.KubernetesVersion
 
 		p.Run((tt.name), func() {
-			keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 			defer cleanup.Cleanup(p.T(), p.terraformOptions, keyPath)
 
 			adminClient, err := provisioning.FetchAdminClient(p.T(), p.client)
@@ -120,7 +120,7 @@ func (p *ProvisionTestSuite) TestTfpProvisionDynamicInput() {
 		testUser, testPassword := configs.CreateTestCredentials()
 
 		p.Run((tt.name), func() {
-			keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 			defer cleanup.Cleanup(p.T(), p.terraformOptions, keyPath)
 
 			adminClient, err := provisioning.FetchAdminClient(p.T(), p.client)

--- a/tests/rancher2/psact/psact_test.go
+++ b/tests/rancher2/psact/psact_test.go
@@ -52,7 +52,7 @@ func (p *PSACTTestSuite) SetupSuite() {
 	p.cattleConfig = configMap[0]
 	p.rancherConfig, p.terraformConfig, p.terratestConfig = config.LoadTFPConfigs(p.cattleConfig)
 
-	keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 	terraformOptions := framework.Setup(p.T(), p.terraformConfig, p.terratestConfig, keyPath)
 	p.terraformOptions = terraformOptions
 
@@ -92,7 +92,7 @@ func (p *PSACTTestSuite) TestTfpPSACT() {
 		tt.name = tt.name + " Module: " + p.terraformConfig.Module + " Kubernetes version: " + terratest.KubernetesVersion
 
 		p.Run((tt.name), func() {
-			keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 			defer cleanup.Cleanup(p.T(), p.terraformOptions, keyPath)
 
 			adminClient, err := provisioning.FetchAdminClient(p.T(), p.client)

--- a/tests/rancher2/rbac/auth_test.go
+++ b/tests/rancher2/rbac/auth_test.go
@@ -50,7 +50,7 @@ func (r *AuthConfigTestSuite) SetupSuite() {
 	r.cattleConfig = configMap[0]
 	r.rancherConfig, r.terraformConfig, r.terratestConfig = config.LoadTFPConfigs(r.cattleConfig)
 
-	keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 	terraformOptions := framework.Setup(r.T(), r.terraformConfig, r.terratestConfig, keyPath)
 	r.terraformOptions = terraformOptions
 }
@@ -78,7 +78,7 @@ func (r *AuthConfigTestSuite) TestTfpAuthConfig() {
 		_, terraform, _ := config.LoadTFPConfigs(configMap[0])
 
 		r.Run((tt.name), func() {
-			keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 			defer cleanup.Cleanup(r.T(), r.terraformOptions, keyPath)
 
 			rbac.AuthConfig(r.T(), terraform, r.terraformOptions, testUser, testPassword, configMap, newFile, rootBody, file)
@@ -113,7 +113,7 @@ func (r *AuthConfigTestSuite) TestTfpAuthConfigDynamicInput() {
 		testUser, testPassword := configs.CreateTestCredentials()
 
 		r.Run((tt.name), func() {
-			keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 			defer cleanup.Cleanup(r.T(), r.terraformOptions, keyPath)
 
 			rbac.AuthConfig(r.T(), r.terraformConfig, r.terraformOptions, testUser, testPassword, configMap, newFile, rootBody, file)

--- a/tests/rancher2/rbac/rbac_test.go
+++ b/tests/rancher2/rbac/rbac_test.go
@@ -53,7 +53,7 @@ func (r *RBACTestSuite) SetupSuite() {
 	r.cattleConfig = configMap[0]
 	r.rancherConfig, r.terraformConfig, r.terratestConfig = config.LoadTFPConfigs(r.cattleConfig)
 
-	keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 	terraformOptions := framework.Setup(r.T(), r.terraformConfig, r.terratestConfig, keyPath)
 	r.terraformOptions = terraformOptions
 }
@@ -86,7 +86,7 @@ func (r *RBACTestSuite) TestTfpRBAC() {
 		tt.name = tt.name + " Module: " + r.terraformConfig.Module
 
 		r.Run((tt.name), func() {
-			keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 			defer cleanup.Cleanup(r.T(), r.terraformOptions, keyPath)
 
 			adminClient, err := provisioning.FetchAdminClient(r.T(), r.client)

--- a/tests/rancher2/resources/build_module_test.go
+++ b/tests/rancher2/resources/build_module_test.go
@@ -24,7 +24,7 @@ type BuildModuleTestSuite struct {
 }
 
 func (r *BuildModuleTestSuite) TestBuildModule() {
-	keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 	defer cleanup.TFFilesCleanup(keyPath)
 
 	r.cattleConfig = shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))

--- a/tests/rancher2/snapshot/snapshot_restore_test.go
+++ b/tests/rancher2/snapshot/snapshot_restore_test.go
@@ -53,7 +53,7 @@ func (s *SnapshotRestoreTestSuite) SetupSuite() {
 	s.cattleConfig = configMap[0]
 	s.rancherConfig, s.terraformConfig, s.terratestConfig = config.LoadTFPConfigs(s.cattleConfig)
 
-	keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 	terraformOptions := framework.Setup(s.T(), s.terraformConfig, s.terratestConfig, keyPath)
 	s.terraformOptions = terraformOptions
 }
@@ -99,7 +99,7 @@ func (s *SnapshotRestoreTestSuite) TestTfpSnapshotRestore() {
 		}
 
 		s.Run(tt.name, func() {
-			keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 			defer cleanup.Cleanup(s.T(), s.terraformOptions, keyPath)
 
 			adminClient, err := provisioning.FetchAdminClient(s.T(), s.client)

--- a/tests/rancher2/upgrading/kubernetes_hosted_test.go
+++ b/tests/rancher2/upgrading/kubernetes_hosted_test.go
@@ -54,7 +54,7 @@ func (k *KubernetesUpgradeHostedTestSuite) SetupSuite() {
 	k.cattleConfig = configMap[0]
 	k.rancherConfig, k.terraformConfig, k.terratestConfig = config.LoadTFPConfigs(k.cattleConfig)
 
-	keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 	terraformOptions := framework.Setup(k.T(), k.terraformConfig, k.terratestConfig, keyPath)
 	k.terraformOptions = terraformOptions
 }
@@ -77,7 +77,7 @@ func (k *KubernetesUpgradeHostedTestSuite) TestTfpKubernetesUpgradeHosted() {
 		testUser, testPassword := configs.CreateTestCredentials()
 
 		k.Run((tt.name), func() {
-			keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 			defer cleanup.Cleanup(k.T(), k.terraformOptions, keyPath)
 
 			adminClient, err := provisioning.FetchAdminClient(k.T(), k.client)

--- a/tests/rancher2/upgrading/kubernetes_upgrade_test.go
+++ b/tests/rancher2/upgrading/kubernetes_upgrade_test.go
@@ -52,7 +52,7 @@ func (k *KubernetesUpgradeTestSuite) SetupSuite() {
 	k.cattleConfig = configMap[0]
 	k.rancherConfig, k.terraformConfig, k.terratestConfig = config.LoadTFPConfigs(k.cattleConfig)
 
-	keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 	terraformOptions := framework.Setup(k.T(), k.terraformConfig, k.terratestConfig, keyPath)
 	k.terraformOptions = terraformOptions
 }
@@ -84,7 +84,7 @@ func (k *KubernetesUpgradeTestSuite) TestTfpKubernetesUpgrade() {
 		tt.name = tt.name + " Module: " + k.terraformConfig.Module + " Kubernetes version: " + terratest.KubernetesVersion
 
 		k.Run((tt.name), func() {
-			keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 			defer cleanup.Cleanup(k.T(), k.terraformOptions, keyPath)
 
 			adminClient, err := provisioning.FetchAdminClient(k.T(), k.client)
@@ -123,7 +123,7 @@ func (k *KubernetesUpgradeTestSuite) TestTfpKubernetesUpgradeDynamicInput() {
 		tt.name = tt.name + " Module: " + k.terraformConfig.Module + " Kubernetes version: " + k.terratestConfig.KubernetesVersion
 
 		k.Run((tt.name), func() {
-			keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 			defer cleanup.Cleanup(k.T(), k.terraformOptions, keyPath)
 
 			adminClient, err := provisioning.FetchAdminClient(k.T(), k.client)

--- a/tests/registries/registries_test.go
+++ b/tests/registries/registries_test.go
@@ -42,7 +42,7 @@ type TfpRegistriesTestSuite struct {
 }
 
 func (r *TfpRegistriesTestSuite) TearDownSuite() {
-	keyPath := rancher2.SetKeyPath(keypath.RegistryKeyPath, r.terraformConfig.Provider)
+	_, keyPath := rancher2.SetKeyPath(keypath.RegistryKeyPath, r.terraformConfig.Provider)
 	cleanup.Cleanup(r.T(), r.standaloneTerraformOptions, keyPath)
 }
 
@@ -50,7 +50,7 @@ func (r *TfpRegistriesTestSuite) SetupSuite() {
 	r.cattleConfig = shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
 	r.rancherConfig, r.terraformConfig, r.terratestConfig = config.LoadTFPConfigs(r.cattleConfig)
 
-	keyPath := rancher2.SetKeyPath(keypath.RegistryKeyPath, r.terraformConfig.Provider)
+	_, keyPath := rancher2.SetKeyPath(keypath.RegistryKeyPath, r.terraformConfig.Provider)
 	standaloneTerraformOptions := framework.Setup(r.T(), r.terraformConfig, r.terratestConfig, keyPath)
 	r.standaloneTerraformOptions = standaloneTerraformOptions
 
@@ -98,7 +98,7 @@ func (r *TfpRegistriesTestSuite) TfpSetupSuite() map[string]any {
 	err = pipeline.PostRancherInstall(r.client, r.client.RancherConfig.AdminPassword)
 	require.NoError(r.T(), err)
 
-	keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 	terraformOptions := framework.Setup(r.T(), r.terraformConfig, r.terratestConfig, keyPath)
 	r.terraformOptions = terraformOptions
 
@@ -156,7 +156,7 @@ func (r *TfpRegistriesTestSuite) TestTfpGlobalRegistry() {
 		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion
 
 		r.Run((tt.name), func() {
-			keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 			defer cleanup.Cleanup(r.T(), r.terraformOptions, keyPath)
 
 			clusterIDs, _ := provisioning.Provision(r.T(), r.client, rancher, terraform, testUser, testPassword, r.terraformOptions, configMap, newFile, rootBody, file, false, false, true, nil)
@@ -215,7 +215,7 @@ func (r *TfpRegistriesTestSuite) TestTfpAuthenticatedRegistry() {
 		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion
 
 		r.Run((tt.name), func() {
-			keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 			defer cleanup.Cleanup(r.T(), r.terraformOptions, keyPath)
 
 			clusterIDs, _ := provisioning.Provision(r.T(), r.client, rancher, terraform, testUser, testPassword, r.terraformOptions, configMap, newFile, rootBody, file, false, false, true, nil)
@@ -280,7 +280,7 @@ func (r *TfpRegistriesTestSuite) TestTfpNonAuthenticatedRegistry() {
 		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion
 
 		r.Run((tt.name), func() {
-			keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 			defer cleanup.Cleanup(r.T(), r.terraformOptions, keyPath)
 
 			clusterIDs, _ := provisioning.Provision(r.T(), r.client, rancher, terraform, testUser, testPassword, r.terraformOptions, configMap, newFile, rootBody, file, false, false, true, nil)

--- a/tests/rke/rke_provider_test.go
+++ b/tests/rke/rke_provider_test.go
@@ -28,7 +28,7 @@ type RKEProviderTestSuite struct {
 }
 
 func (t *RKEProviderTestSuite) TearDownSuite() {
-	keyPath := rancher2.SetKeyPath(keypath.RKEKeyPath, t.terraformConfig.Provider)
+	_, keyPath := rancher2.SetKeyPath(keypath.RKEKeyPath, t.terraformConfig.Provider)
 	cleanup.Cleanup(t.T(), t.terraformOptions, keyPath)
 }
 
@@ -39,7 +39,7 @@ func (t *RKEProviderTestSuite) TestCreateRKECluster() {
 	t.terratestConfig = new(config.TerratestConfig)
 	ranchFrame.LoadConfig(config.TerratestConfigurationFileKey, t.terratestConfig)
 
-	keyPath := rancher2.SetKeyPath(keypath.RKEKeyPath, t.terraformConfig.Provider)
+	_, keyPath := rancher2.SetKeyPath(keypath.RKEKeyPath, t.terraformConfig.Provider)
 	terraformOptions := framework.Setup(t.T(), t.terraformConfig, t.terratestConfig, keyPath)
 	t.terraformOptions = terraformOptions
 

--- a/tests/sanity/sanity_provisioning_test.go
+++ b/tests/sanity/sanity_provisioning_test.go
@@ -40,7 +40,7 @@ type TfpSanityProvisioningTestSuite struct {
 }
 
 func (s *TfpSanityProvisioningTestSuite) TearDownSuite() {
-	keyPath := rancher2.SetKeyPath(keypath.SanityKeyPath, s.terraformConfig.Provider)
+	_, keyPath := rancher2.SetKeyPath(keypath.SanityKeyPath, s.terraformConfig.Provider)
 	cleanup.Cleanup(s.T(), s.standaloneTerraformOptions, keyPath)
 }
 
@@ -48,7 +48,7 @@ func (s *TfpSanityProvisioningTestSuite) SetupSuite() {
 	s.cattleConfig = shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
 	s.rancherConfig, s.terraformConfig, s.terratestConfig = config.LoadTFPConfigs(s.cattleConfig)
 
-	keyPath := rancher2.SetKeyPath(keypath.SanityKeyPath, s.terraformConfig.Provider)
+	_, keyPath := rancher2.SetKeyPath(keypath.SanityKeyPath, s.terraformConfig.Provider)
 	standaloneTerraformOptions := framework.Setup(s.T(), s.terraformConfig, s.terratestConfig, keyPath)
 	s.standaloneTerraformOptions = standaloneTerraformOptions
 
@@ -92,7 +92,7 @@ func (s *TfpSanityProvisioningTestSuite) TfpSetupSuite() map[string]any {
 	err = pipeline.PostRancherInstall(s.client, s.client.RancherConfig.AdminPassword)
 	require.NoError(s.T(), err)
 
-	keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 	terraformOptions := framework.Setup(s.T(), s.terraformConfig, s.terratestConfig, keyPath)
 	s.terraformOptions = terraformOptions
 
@@ -136,7 +136,7 @@ func (s *TfpSanityProvisioningTestSuite) TestTfpProvisioningSanity() {
 		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion
 
 		s.Run((tt.name), func() {
-			keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 			defer cleanup.Cleanup(s.T(), s.terraformOptions, keyPath)
 
 			clusterIDs, customClusterNames := provisioning.Provision(s.T(), s.client, rancher, terraform, testUser, testPassword, s.terraformOptions, configMap, newFile, rootBody, file, false, false, true, customClusterNames)

--- a/tests/sanity/sanity_upgrade_rancher_test.go
+++ b/tests/sanity/sanity_upgrade_rancher_test.go
@@ -43,10 +43,10 @@ type TfpSanityUpgradeRancherTestSuite struct {
 }
 
 func (s *TfpSanityUpgradeRancherTestSuite) TearDownSuite() {
-	keyPath := rancher2.SetKeyPath(keypath.SanityKeyPath, s.terraformConfig.Provider)
+	_, keyPath := rancher2.SetKeyPath(keypath.SanityKeyPath, s.terraformConfig.Provider)
 	cleanup.Cleanup(s.T(), s.standaloneTerraformOptions, keyPath)
 
-	keyPath = rancher2.SetKeyPath(keypath.UpgradeKeyPath, s.terraformConfig.Provider)
+	_, keyPath = rancher2.SetKeyPath(keypath.UpgradeKeyPath, s.terraformConfig.Provider)
 	cleanup.Cleanup(s.T(), s.upgradeTerraformOptions, keyPath)
 }
 
@@ -54,7 +54,7 @@ func (s *TfpSanityUpgradeRancherTestSuite) SetupSuite() {
 	s.cattleConfig = shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
 	s.rancherConfig, s.terraformConfig, s.terratestConfig = config.LoadTFPConfigs(s.cattleConfig)
 
-	keyPath := rancher2.SetKeyPath(keypath.SanityKeyPath, s.terraformConfig.Provider)
+	_, keyPath := rancher2.SetKeyPath(keypath.SanityKeyPath, s.terraformConfig.Provider)
 	standaloneTerraformOptions := framework.Setup(s.T(), s.terraformConfig, s.terratestConfig, keyPath)
 	s.standaloneTerraformOptions = standaloneTerraformOptions
 
@@ -63,7 +63,7 @@ func (s *TfpSanityUpgradeRancherTestSuite) SetupSuite() {
 
 	s.serverNodeOne = serverNodeOne
 
-	keyPath = rancher2.SetKeyPath(keypath.UpgradeKeyPath, s.terraformConfig.Provider)
+	_, keyPath = rancher2.SetKeyPath(keypath.UpgradeKeyPath, s.terraformConfig.Provider)
 	upgradeTerraformOptions := framework.Setup(s.T(), s.terraformConfig, s.terratestConfig, keyPath)
 
 	s.upgradeTerraformOptions = upgradeTerraformOptions
@@ -105,7 +105,7 @@ func (s *TfpSanityUpgradeRancherTestSuite) TfpSetupSuite() map[string]any {
 	err = pipeline.PostRancherInstall(s.client, s.client.RancherConfig.AdminPassword)
 	require.NoError(s.T(), err)
 
-	keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 	terraformOptions := framework.Setup(s.T(), s.terraformConfig, s.terratestConfig, keyPath)
 	s.terraformOptions = terraformOptions
 
@@ -119,7 +119,7 @@ func (s *TfpSanityUpgradeRancherTestSuite) TestTfpUpgradeRancher() {
 
 	s.terraformConfig.Standalone.UpgradeRancher = true
 
-	keyPath := rancher2.SetKeyPath(keypath.UpgradeKeyPath, s.terraformConfig.Provider)
+	_, keyPath := rancher2.SetKeyPath(keypath.UpgradeKeyPath, s.terraformConfig.Provider)
 	err := upgrade.CreateMainTF(s.T(), s.upgradeTerraformOptions, keyPath, s.terraformConfig, s.terratestConfig, s.serverNodeOne, "", "", "")
 	require.NoError(s.T(), err)
 
@@ -180,7 +180,7 @@ func (s *TfpSanityUpgradeRancherTestSuite) provisionAndVerifyCluster(name string
 	}
 
 	if deleteClusters {
-		keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+		_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 		cleanup.Cleanup(s.T(), s.terraformOptions, keyPath)
 	}
 


### PR DESCRIPTION
### Issue Description

### PR Description
Currently, `GOROOT` is being defined throughout the framework to get the current user directory. However, this should point to `GOPATH` instead and in fact, our Dockerfile shows this to be true. This PR updates all references as well as updates the `SetKeyPath` function to return userDir.

This is to reduce code duplication throughout the infrastructure based tests.