### PR TITLE
Add vSphere support for imported clusters

### DIFF
--- a/.github/workflows/verify-changes.yaml
+++ b/.github/workflows/verify-changes.yaml
@@ -17,7 +17,7 @@ jobs:
           submodules: recursive
 
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version-file: './go.mod'
 
@@ -37,5 +37,5 @@ jobs:
       - name: Golangci Lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.60.1
+          version: v1.64.3
           skip-cache: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/golang:1.23
+FROM registry.suse.com/bci/golang:1.24
 
 ENV GOPATH /root/go
 ENV PATH ${PATH}:/root/go/bin

--- a/defaults/clustertypes/clustertypes.go
+++ b/defaults/clustertypes/clustertypes.go
@@ -10,4 +10,5 @@ const (
 	K3S     = "k3s"
 	RANCHER = "-rancher"
 	CUSTOM  = "custom"
+	WINDOWS = "windows"
 )

--- a/defaults/modules/modules.go
+++ b/defaults/modules/modules.go
@@ -28,6 +28,10 @@ const (
 	ImportEC2RKE2Windows = "ec2_rke2_windows_import"
 	ImportEC2K3s         = "ec2_k3s_import"
 
+	ImportVsphereRKE1 = "vsphere_rke1_import"
+	ImportVsphereRKE2 = "vsphere_rke2_import"
+	ImportVsphereK3s  = "vsphere_k3s_import"
+
 	LinodeRKE1 = "linode_rke1"
 	LinodeRKE2 = "linode_rke2"
 	LinodeK3s  = "linode_k3s"

--- a/framework/set/defaults/defaults.go
+++ b/framework/set/defaults/defaults.go
@@ -108,7 +108,7 @@ const (
 	VsphereComputeCluster         = "vsphere_compute_cluster"
 	VsphereNetwork                = "vsphere_network"
 	VsphereServer                 = "vsphere_server"
-	VsphereVirutalMachine         = "vsphere_virtual_machine"
+	VsphereVirtualMachine         = "vsphere_virtual_machine"
 	VsphereVirtualMachineTemplate = "vsphere_virtual_machine_template"
 	CDROM                         = "cdrom"
 	Customize                     = "customize"

--- a/framework/set/provisioning/custom/nullresource/customNullResource.go
+++ b/framework/set/provisioning/custom/nullresource/customNullResource.go
@@ -22,7 +22,7 @@ func CustomNullResource(rootBody *hclwrite.Body, terraformConfig *config.Terrafo
 	if strings.Contains(terraformConfig.Provider, defaults.Aws) {
 		countExpression = defaults.Length + `(` + defaults.AwsInstance + `.` + terraformConfig.ResourcePrefix + `)`
 	} else if strings.Contains(terraformConfig.Provider, defaults.Vsphere) {
-		countExpression = defaults.Length + `(` + defaults.VsphereVirutalMachine + `.` + terraformConfig.ResourcePrefix + `)`
+		countExpression = defaults.Length + `(` + defaults.VsphereVirtualMachine + `.` + terraformConfig.ResourcePrefix + `)`
 	}
 
 	nullResourceBlockBody.SetAttributeRaw(defaults.Count, hclwrite.TokensForIdentifier(countExpression))
@@ -64,7 +64,7 @@ func CustomNullResource(rootBody *hclwrite.Body, terraformConfig *config.Terrafo
 		hostExpression = fmt.Sprintf(`"${%s.%s[%s.%s].%s}"`, defaults.AwsInstance, terraformConfig.ResourcePrefix, defaults.Count, defaults.Index, defaults.PublicIp)
 	} else if terraformConfig.Provider == defaults.Vsphere {
 		connectionBlockBody.SetAttributeValue(defaults.User, cty.StringVal(terraformConfig.VsphereConfig.VsphereUser))
-		hostExpression = fmt.Sprintf(`"${%s.%s[%s.%s].%s}"`, defaults.VsphereVirutalMachine, terraformConfig.ResourcePrefix, defaults.Count, defaults.Index, defaults.DefaultIPAddress)
+		hostExpression = fmt.Sprintf(`"${%s.%s[%s.%s].%s}"`, defaults.VsphereVirtualMachine, terraformConfig.ResourcePrefix, defaults.Count, defaults.Index, defaults.DefaultIPAddress)
 	}
 
 	host := hclwrite.Tokens{

--- a/framework/set/provisioning/custom/rke2k3s/setConfig.go
+++ b/framework/set/provisioning/custom/rke2k3s/setConfig.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/rancher/tfp-automation/config"
-	"github.com/rancher/tfp-automation/defaults/clustertypes"
 	"github.com/rancher/tfp-automation/defaults/modules"
 	"github.com/rancher/tfp-automation/framework/set/defaults"
 	"github.com/rancher/tfp-automation/framework/set/provisioning/custom/nullresource"
@@ -20,9 +19,9 @@ import (
 // SetCustomRKE2K3s is a function that will set the custom RKE2/K3s cluster configurations in the main.tf file.
 func SetCustomRKE2K3s(terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig, configMap []map[string]any,
 	newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File) (*hclwrite.File, *os.File, error) {
-	if strings.Contains(terraformConfig.Module, defaults.Custom) && !strings.Contains(terraformConfig.Module, clustertypes.RKE1) {
+	if terraformConfig.Provider == defaults.Aws {
 		aws.CreateAWSInstances(rootBody, terraformConfig, terratestConfig, terraformConfig.ResourcePrefix)
-	} else if strings.Contains(terraformConfig.Module, modules.CustomVsphereRKE2) || strings.Contains(terraformConfig.Module, modules.CustomVsphereK3s) {
+	} else if terraformConfig.Provider == defaults.Vsphere {
 		dataCenterExpression := fmt.Sprintf(defaults.Data + `.` + defaults.VsphereDatacenter + `.` + defaults.VsphereDatacenter + `.id`)
 		dataCenterValue := hclwrite.Tokens{
 			{Type: hclsyntax.TokenIdent, Bytes: []byte(dataCenterExpression)},

--- a/framework/set/provisioning/imported/importNodes.go
+++ b/framework/set/provisioning/imported/importNodes.go
@@ -4,10 +4,12 @@ import (
 	"encoding/base64"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/clustertypes"
 	"github.com/rancher/tfp-automation/defaults/modules"
 	"github.com/rancher/tfp-automation/framework/set/defaults"
 	"github.com/rancher/tfp-automation/framework/set/provisioning/imported/nullresource"
@@ -41,7 +43,7 @@ func importNodes(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfi
 	command := "bash -c '/tmp/import-nodes.sh " + encodedPEMFile + " " + terraformConfig.Standalone.OSUser + " " +
 		terraformConfig.Standalone.OSGroup + " " + nodeOnePublicDNS + " " + importCommand
 
-	if terraformConfig.Module == modules.ImportEC2RKE1 {
+	if strings.Contains(terraformConfig.Module, clustertypes.RKE1) && strings.Contains(terraformConfig.Module, defaults.Import) {
 		command += " " + kubeConfig
 	}
 
@@ -58,7 +60,8 @@ func importNodes(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfi
 
 	var dependsOnServer string
 
-	if terraformConfig.Module == modules.ImportEC2K3s || terraformConfig.Module == modules.ImportEC2RKE2 {
+	if strings.Contains(terraformConfig.Module, defaults.Import) && !strings.Contains(terraformConfig.Module, clustertypes.RKE1) &&
+		!strings.Contains(terraformConfig.Module, clustertypes.WINDOWS) {
 		addServerTwoName := addServer + terraformConfig.ResourcePrefix + `_` + serverTwo
 		addServerThreeName := addServer + terraformConfig.ResourcePrefix + `_` + serverThree
 		dependsOnServer = `[` + defaults.NullResource + `.` + addServerTwoName + `, ` + defaults.NullResource + `.` + addServerThreeName + `]`

--- a/framework/set/provisioning/imported/importedRKE1Config.go
+++ b/framework/set/provisioning/imported/importedRKE1Config.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/framework/set/defaults"
 	"github.com/rancher/tfp-automation/framework/set/resources/providers/aws"
+	"github.com/rancher/tfp-automation/framework/set/resources/providers/vsphere"
 	"github.com/sirupsen/logrus"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -25,7 +26,14 @@ func SetImportedRKE1(terraformConfig *config.TerraformConfig, terratestConfig *c
 	importCommand := getImportCommand(terraformConfig.ResourcePrefix)
 
 	serverOneName := terraformConfig.ResourcePrefix + `_` + serverOne
-	nodeOnePublicDNS := fmt.Sprintf("${%s.%s.public_dns}", defaults.AwsInstance, serverOneName)
+
+	var nodeOnePublicDNS string
+	if terraformConfig.Provider == defaults.Aws {
+		nodeOnePublicDNS = fmt.Sprintf("${%s.%s.public_dns}", defaults.AwsInstance, serverOneName)
+	} else if terraformConfig.Provider == defaults.Vsphere {
+		nodeOnePublicDNS = fmt.Sprintf("${%s.%s.default_ip_address}", defaults.VsphereVirtualMachine, serverOneName)
+	}
+
 	kubeConfig := fmt.Sprintf("${%s.%s.kube_config_yaml}", defaults.RKECluster, terraformConfig.ResourcePrefix)
 
 	err := importNodes(rootBody, terraformConfig, nodeOnePublicDNS, kubeConfig, importCommand[serverOneName])
@@ -49,9 +57,36 @@ func createRKE1Cluster(rootBody *hclwrite.Body, terraformConfig *config.Terrafor
 	serverThreeName := terraformConfig.ResourcePrefix + `_` + serverThree
 	instances := []string{serverOneName, serverTwoName, serverThreeName}
 
-	for _, instance := range instances {
-		aws.CreateAWSInstances(rootBody, terraformConfig, terratestConfig, instance)
+	if terraformConfig.Provider == defaults.Vsphere {
+		dataCenterExpression := fmt.Sprintf(defaults.Data + `.` + defaults.VsphereDatacenter + `.` + defaults.VsphereDatacenter + `.id`)
+		dataCenterValue := hclwrite.Tokens{
+			{Type: hclsyntax.TokenIdent, Bytes: []byte(dataCenterExpression)},
+		}
+
+		vsphere.CreateVsphereDatacenter(rootBody, terraformConfig)
 		rootBody.AppendNewline()
+
+		vsphere.CreateVsphereComputeCluster(rootBody, terraformConfig, dataCenterValue)
+		rootBody.AppendNewline()
+
+		vsphere.CreateVsphereNetwork(rootBody, terraformConfig, dataCenterValue)
+		rootBody.AppendNewline()
+
+		vsphere.CreateVsphereDatastore(rootBody, terraformConfig, dataCenterValue)
+		rootBody.AppendNewline()
+
+		vsphere.CreateVsphereVirtualMachineTemplate(rootBody, terraformConfig, dataCenterValue)
+		rootBody.AppendNewline()
+	}
+
+	for _, instance := range instances {
+		if terraformConfig.Provider == defaults.Aws {
+			aws.CreateAWSInstances(rootBody, terraformConfig, terratestConfig, instance)
+			rootBody.AppendNewline()
+		} else if terraformConfig.Provider == defaults.Vsphere {
+			vsphere.CreateVsphereVirtualMachine(rootBody, terraformConfig, terratestConfig, instance)
+			rootBody.AppendNewline()
+		}
 	}
 
 	rkeBlock := rootBody.AppendNewBlock(defaults.Resource, []string{defaults.RKECluster, terraformConfig.ResourcePrefix})
@@ -61,7 +96,13 @@ func createRKE1Cluster(rootBody *hclwrite.Body, terraformConfig *config.Terrafor
 		nodesBlock := rkeBlockBody.AppendNewBlock(defaults.Nodes, nil)
 		nodesBlockBody := nodesBlock.Body()
 
-		addressExpression := `"${` + defaults.AwsInstance + "." + instance + ".public_ip" + `}"`
+		var addressExpression string
+		if terraformConfig.Provider == defaults.Aws {
+			addressExpression = `"${` + defaults.AwsInstance + "." + instance + ".public_ip" + `}"`
+		} else if terraformConfig.Provider == defaults.Vsphere {
+			addressExpression = `"${` + defaults.VsphereVirtualMachine + "." + instance + ".default_ip_address" + `}"`
+		}
+
 		values := hclwrite.Tokens{
 			{Type: hclsyntax.TokenIdent, Bytes: []byte(addressExpression)},
 		}
@@ -87,8 +128,11 @@ func createRKE1Cluster(rootBody *hclwrite.Body, terraformConfig *config.Terrafor
 	rkeBlockBody.SetAttributeValue(enableCriDockerD, cty.BoolVal(true))
 
 	var dependsOnServer string
-
-	dependsOnServer = `[` + defaults.AwsInstance + `.` + serverOneName + `, ` + defaults.AwsInstance + `.` + serverTwoName + `, ` + defaults.AwsInstance + `.` + serverThreeName + `]`
+	if terraformConfig.Provider == defaults.Aws {
+		dependsOnServer = `[` + defaults.AwsInstance + `.` + serverOneName + `, ` + defaults.AwsInstance + `.` + serverTwoName + `, ` + defaults.AwsInstance + `.` + serverThreeName + `]`
+	} else if terraformConfig.Provider == defaults.Vsphere {
+		dependsOnServer = `[` + defaults.VsphereVirtualMachine + `.` + serverOneName + `, ` + defaults.VsphereVirtualMachine + `.` + serverTwoName + `, ` + defaults.VsphereVirtualMachine + `.` + serverThreeName + `]`
+	}
 
 	server := hclwrite.Tokens{
 		{Type: hclsyntax.TokenIdent, Bytes: []byte(dependsOnServer)},

--- a/framework/set/provisioning/imported/importedRKE2K3SConfig.go
+++ b/framework/set/provisioning/imported/importedRKE2K3SConfig.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	namegen "github.com/rancher/shepherd/pkg/namegenerator"
 	"github.com/rancher/tfp-automation/config"
@@ -12,6 +13,7 @@ import (
 	"github.com/rancher/tfp-automation/framework/set/provisioning/custom/sleep"
 	"github.com/rancher/tfp-automation/framework/set/resources/imported"
 	"github.com/rancher/tfp-automation/framework/set/resources/providers/aws"
+	"github.com/rancher/tfp-automation/framework/set/resources/providers/vsphere"
 	"github.com/sirupsen/logrus"
 )
 
@@ -34,32 +36,16 @@ const (
 func SetImportedRKE2K3s(terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig, newFile *hclwrite.File,
 	rootBody *hclwrite.Body, file *os.File) (*hclwrite.File, *os.File, error) {
 	SetImportedCluster(rootBody, terraformConfig.ResourcePrefix)
-
 	rootBody.AppendNewline()
 
 	serverOneName := terraformConfig.ResourcePrefix + `_` + serverOne
-	serverTwoName := terraformConfig.ResourcePrefix + `_` + serverTwo
-	serverThreeName := terraformConfig.ResourcePrefix + `_` + serverThree
 	windowsNodeName := terraformConfig.ResourcePrefix + `-` + windows
 
-	instances := []string{serverOneName, serverTwoName, serverThreeName}
-
-	for _, instance := range instances {
-		aws.CreateAWSInstances(rootBody, terraformConfig, terratestConfig, instance)
-		rootBody.AppendNewline()
-	}
-
-	var nodeOnePublicIP, nodeOnePrivateIP, nodeTwoPublicIP, nodeThreePublicIP string
-
-	nodeOnePrivateIP = fmt.Sprintf("${%s.%s.private_ip}", defaults.AwsInstance, serverOneName)
-	nodeOnePublicIP = fmt.Sprintf("${%s.%s.public_ip}", defaults.AwsInstance, serverOneName)
-	nodeTwoPublicIP = fmt.Sprintf("${%s.%s.public_ip}", defaults.AwsInstance, serverTwoName)
-	nodeThreePublicIP = fmt.Sprintf("${%s.%s.public_ip}", defaults.AwsInstance, serverThreeName)
+	nodeOnePublicIP, nodeOnePrivateIP, nodeTwoPublicIP, nodeThreePublicIP := getProviderIPAddresses(terraformConfig, terratestConfig, rootBody, serverOneName)
 
 	token := namegen.AppendRandomString(defaults.Import)
 
 	imported.CreateRKE2K3SImportedCluster(rootBody, terraformConfig, nodeOnePublicIP, nodeOnePrivateIP, nodeTwoPublicIP, nodeThreePublicIP, token)
-
 	rootBody.AppendNewline()
 
 	if terraformConfig.Module == modules.ImportEC2RKE2Windows {
@@ -102,4 +88,59 @@ func getImportCommand(clusterName string) map[string]string {
 	command[serverOneName] = importCommand
 
 	return command
+}
+
+// getProvider is a helper function that returns the IP addresses of the nodes
+func getProviderIPAddresses(terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig, rootBody *hclwrite.Body,
+	serverOneName string) (string, string, string, string) {
+	var nodeOnePublicIP, nodeOnePrivateIP, nodeTwoPublicIP, nodeThreePublicIP string
+
+	serverTwoName := terraformConfig.ResourcePrefix + `_` + serverTwo
+	serverThreeName := terraformConfig.ResourcePrefix + `_` + serverThree
+
+	instances := []string{serverOneName, serverTwoName, serverThreeName}
+
+	if terraformConfig.Provider == defaults.Vsphere {
+		dataCenterExpression := fmt.Sprintf(defaults.Data + `.` + defaults.VsphereDatacenter + `.` + defaults.VsphereDatacenter + `.id`)
+		dataCenterValue := hclwrite.Tokens{
+			{Type: hclsyntax.TokenIdent, Bytes: []byte(dataCenterExpression)},
+		}
+
+		vsphere.CreateVsphereDatacenter(rootBody, terraformConfig)
+		rootBody.AppendNewline()
+
+		vsphere.CreateVsphereComputeCluster(rootBody, terraformConfig, dataCenterValue)
+		rootBody.AppendNewline()
+
+		vsphere.CreateVsphereNetwork(rootBody, terraformConfig, dataCenterValue)
+		rootBody.AppendNewline()
+
+		vsphere.CreateVsphereDatastore(rootBody, terraformConfig, dataCenterValue)
+		rootBody.AppendNewline()
+
+		vsphere.CreateVsphereVirtualMachineTemplate(rootBody, terraformConfig, dataCenterValue)
+		rootBody.AppendNewline()
+	}
+
+	for _, instance := range instances {
+		if terraformConfig.Provider == defaults.Aws {
+			aws.CreateAWSInstances(rootBody, terraformConfig, terratestConfig, instance)
+			rootBody.AppendNewline()
+
+			nodeOnePrivateIP = fmt.Sprintf("${%s.%s.private_ip}", defaults.AwsInstance, serverOneName)
+			nodeOnePublicIP = fmt.Sprintf("${%s.%s.public_ip}", defaults.AwsInstance, serverOneName)
+			nodeTwoPublicIP = fmt.Sprintf("${%s.%s.public_ip}", defaults.AwsInstance, serverTwoName)
+			nodeThreePublicIP = fmt.Sprintf("${%s.%s.public_ip}", defaults.AwsInstance, serverThreeName)
+		} else if terraformConfig.Provider == defaults.Vsphere {
+			vsphere.CreateVsphereVirtualMachine(rootBody, terraformConfig, terratestConfig, instance)
+			rootBody.AppendNewline()
+
+			nodeOnePrivateIP = fmt.Sprintf("${%s.%s.default_ip_address}", defaults.VsphereVirtualMachine, serverOneName)
+			nodeOnePublicIP = fmt.Sprintf("${%s.%s.default_ip_address}", defaults.VsphereVirtualMachine, serverOneName)
+			nodeTwoPublicIP = fmt.Sprintf("${%s.%s.default_ip_address}", defaults.VsphereVirtualMachine, serverTwoName)
+			nodeThreePublicIP = fmt.Sprintf("${%s.%s.default_ip_address}", defaults.VsphereVirtualMachine, serverThreeName)
+		}
+	}
+
+	return nodeOnePublicIP, nodeOnePrivateIP, nodeTwoPublicIP, nodeThreePublicIP
 }

--- a/framework/set/provisioning/imported/nullresource/importNullResource.go
+++ b/framework/set/provisioning/imported/nullresource/importNullResource.go
@@ -34,7 +34,12 @@ func CreateImportedNullResource(rootBody *hclwrite.Body, terraformConfig *config
 	connectionBlockBody.SetAttributeRaw(defaults.Host, newHost)
 
 	connectionBlockBody.SetAttributeValue(defaults.Type, cty.StringVal(defaults.Ssh))
-	connectionBlockBody.SetAttributeValue(defaults.User, cty.StringVal(terraformConfig.AWSConfig.AWSUser))
+
+	if terraformConfig.Provider == defaults.Aws {
+		connectionBlockBody.SetAttributeValue(defaults.User, cty.StringVal(terraformConfig.AWSConfig.AWSUser))
+	} else if terraformConfig.Provider == defaults.Vsphere {
+		connectionBlockBody.SetAttributeValue(defaults.User, cty.StringVal(terraformConfig.VsphereConfig.VsphereUser))
+	}
 
 	keyPathExpression := defaults.File + `("` + terraformConfig.PrivateKeyPath + `")`
 	keyPath := hclwrite.Tokens{
@@ -47,7 +52,13 @@ func CreateImportedNullResource(rootBody *hclwrite.Body, terraformConfig *config
 	serverTwoName := terraformConfig.ResourcePrefix + `_` + serverTwo
 	serverThreeName := terraformConfig.ResourcePrefix + `_` + serverThree
 
-	dependsOnServer := `[` + defaults.AwsInstance + `.` + serverOneName + `, ` + defaults.AwsInstance + `.` + serverTwoName + `, ` + defaults.AwsInstance + `.` + serverThreeName + `]`
+	var dependsOnServer string
+	if terraformConfig.Provider == defaults.Aws {
+		dependsOnServer = `[` + defaults.AwsInstance + `.` + serverOneName + `, ` + defaults.AwsInstance + `.` + serverTwoName + `, ` + defaults.AwsInstance + `.` + serverThreeName + `]`
+	} else if terraformConfig.Provider == defaults.Vsphere {
+		dependsOnServer = `[` + defaults.VsphereVirtualMachine + `.` + serverOneName + `, ` + defaults.VsphereVirtualMachine + `.` + serverTwoName + `, ` + defaults.VsphereVirtualMachine + `.` + serverThreeName + `]`
+	}
+
 	server := hclwrite.Tokens{
 		{Type: hclsyntax.TokenIdent, Bytes: []byte(dependsOnServer)},
 	}

--- a/framework/set/resources/k3s/add-servers.sh
+++ b/framework/set/resources/k3s/add-servers.sh
@@ -4,8 +4,11 @@ USER=$1
 GROUP=$2
 K8S_VERSION=$3
 K3S_SERVER_IP=$4
-K3S_TOKEN=$5
+K3S_NEW_SERVER_IP=$5
+K3S_TOKEN=$6
 
 set -e
+
+sudo hostnamectl set-hostname ${K3S_NEW_SERVER_IP}
 
 curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=${K8S_VERSION} K3S_TOKEN=${K3S_TOKEN} sh -s - server --server https://${K3S_SERVER_IP}:6443

--- a/framework/set/resources/k3s/createCluster.go
+++ b/framework/set/resources/k3s/createCluster.go
@@ -81,7 +81,7 @@ func AddK3SServerNodes(rootBody *hclwrite.Body, terraformConfig *config.Terrafor
 		nullResourceBlockBody, provisionerBlockBody := rke2.SSHNullResource(rootBody, terraformConfig, instance, host)
 
 		command := "bash -c '/tmp/add-servers.sh " + terraformConfig.Standalone.OSUser + " " + terraformConfig.Standalone.OSGroup + " " +
-			terraformConfig.Standalone.K3SVersion + " " + k3sServerOnePrivateIP + " " + k3sToken + "'"
+			terraformConfig.Standalone.K3SVersion + " " + k3sServerOnePrivateIP + " " + instance + " " + k3sToken + "'"
 
 		provisionerBlockBody.SetAttributeValue(defaults.Inline, cty.ListVal([]cty.Value{
 			cty.StringVal("printf '" + string(script) + "' > /tmp/add-servers.sh"),

--- a/framework/set/resources/k3s/init-server.sh
+++ b/framework/set/resources/k3s/init-server.sh
@@ -8,6 +8,8 @@ K3S_TOKEN=$5
 
 set -e
 
+sudo hostnamectl set-hostname ${K3S_SERVER_IP}
+
 curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=${K8S_VERSION} K3S_TOKEN=${K3S_TOKEN} sh -s - server --cluster-init
 
 sudo mkdir -p /home/${USER}/.kube

--- a/framework/set/resources/providers/vsphere/provider.go
+++ b/framework/set/resources/providers/vsphere/provider.go
@@ -54,15 +54,15 @@ func CreateVsphereLocalBlock(rootBody *hclwrite.Body, terraformConfig *config.Te
 	var instanceIds map[string]any
 	if terraformConfig.Standalone.RKE2Version != "" {
 		instanceIds = map[string]any{
-			rke2ServerOne:   defaults.VsphereVirutalMachine + "." + rke2ServerOne + ".id",
-			rke2ServerTwo:   defaults.VsphereVirutalMachine + "." + rke2ServerTwo + ".id",
-			rke2ServerThree: defaults.VsphereVirutalMachine + "." + rke2ServerThree + ".id",
+			rke2ServerOne:   defaults.VsphereVirtualMachine + "." + rke2ServerOne + ".id",
+			rke2ServerTwo:   defaults.VsphereVirtualMachine + "." + rke2ServerTwo + ".id",
+			rke2ServerThree: defaults.VsphereVirtualMachine + "." + rke2ServerThree + ".id",
 		}
 	} else if terraformConfig.Standalone.K3SVersion != "" {
 		instanceIds = map[string]any{
-			k3sServerOne:   defaults.VsphereVirutalMachine + "." + k3sServerOne + ".id",
-			k3sServerTwo:   defaults.VsphereVirutalMachine + "." + k3sServerTwo + ".id",
-			k3sServerThree: defaults.VsphereVirutalMachine + "." + k3sServerThree + ".id",
+			k3sServerOne:   defaults.VsphereVirtualMachine + "." + k3sServerOne + ".id",
+			k3sServerTwo:   defaults.VsphereVirtualMachine + "." + k3sServerTwo + ".id",
+			k3sServerThree: defaults.VsphereVirtualMachine + "." + k3sServerThree + ".id",
 		}
 	}
 

--- a/framework/set/resources/providers/vsphere/virtualMachine.go
+++ b/framework/set/resources/providers/vsphere/virtualMachine.go
@@ -15,7 +15,7 @@ import (
 // CreateVsphereVirtualMachine is a function that will set the vSphere virtual machine configuration in the main.tf file.
 func CreateVsphereVirtualMachine(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig,
 	hostnamePrefix string) {
-	vmBlock := rootBody.AppendNewBlock(defaults.Resource, []string{defaults.VsphereVirutalMachine, hostnamePrefix})
+	vmBlock := rootBody.AppendNewBlock(defaults.Resource, []string{defaults.VsphereVirtualMachine, hostnamePrefix})
 	vmBlockBody := vmBlock.Body()
 
 	if strings.Contains(terraformConfig.Module, defaults.Custom) {
@@ -105,7 +105,7 @@ func CreateVsphereVirtualMachine(rootBody *hclwrite.Body, terraformConfig *confi
 	cloneBlock := vmBlockBody.AppendNewBlock(clone, nil)
 	cloneBlockBody := cloneBlock.Body()
 
-	templateUUIDExpression := fmt.Sprintf(defaults.Data + `.` + defaults.VsphereVirutalMachine + `.` + defaults.VsphereVirtualMachineTemplate + `.id`)
+	templateUUIDExpression := fmt.Sprintf(defaults.Data + `.` + defaults.VsphereVirtualMachine + `.` + defaults.VsphereVirtualMachineTemplate + `.id`)
 	templateUUIDValue := hclwrite.Tokens{
 		{Type: hclsyntax.TokenIdent, Bytes: []byte(templateUUIDExpression)},
 	}

--- a/framework/set/resources/providers/vsphere/virtualMachineTemplate.go
+++ b/framework/set/resources/providers/vsphere/virtualMachineTemplate.go
@@ -9,7 +9,7 @@ import (
 
 // CreateVsphereVirtualMachineTemplate is a function that will set the vSphere virtual machine template configuration in the main.tf file.
 func CreateVsphereVirtualMachineTemplate(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, dataCenterValue hclwrite.Tokens) {
-	vmTemplateBlock := rootBody.AppendNewBlock(defaults.Data, []string{defaults.VsphereVirutalMachine, defaults.VsphereVirtualMachineTemplate})
+	vmTemplateBlock := rootBody.AppendNewBlock(defaults.Data, []string{defaults.VsphereVirtualMachine, defaults.VsphereVirtualMachineTemplate})
 	vmTemplateBlockBody := vmTemplateBlock.Body()
 
 	vmTemplateBlockBody.SetAttributeValue(defaults.ResourceName, cty.StringVal(terraformConfig.VsphereConfig.CloneFrom))

--- a/framework/set/resources/rancher2/setProvidersAndUsersTF.go
+++ b/framework/set/resources/rancher2/setProvidersAndUsersTF.go
@@ -9,8 +9,8 @@ import (
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/clustertypes"
 	"github.com/rancher/tfp-automation/defaults/configs"
-	"github.com/rancher/tfp-automation/defaults/modules"
 	"github.com/rancher/tfp-automation/framework/set/defaults"
 	"github.com/sirupsen/logrus"
 	"github.com/zclconf/go-cty/cty"
@@ -223,7 +223,7 @@ func getRequiredProviderVersions(configMap []map[string]any) (source, rancherPro
 			source = "terraform.local/local/rancher2"
 		}
 
-		if module == modules.ImportEC2RKE1 {
+		if strings.Contains(module, defaults.Import) && strings.Contains(module, clustertypes.RKE1) {
 			rkeProviderVersion = os.Getenv(rkeEnvVar)
 			if rkeProviderVersion == "" {
 				logrus.Fatalf("Expected env var not set %s", rkeEnvVar)

--- a/framework/set/setConfigTF.go
+++ b/framework/set/setConfigTF.go
@@ -145,12 +145,12 @@ func ConfigTF(client *rancher.Client, testUser, testPassword string, rbacRole co
 					return clusterNames, customClusterNames, err
 				}
 			}
-		case module == modules.ImportEC2RKE1:
+		case strings.Contains(module, clustertypes.RKE1) && strings.Contains(module, defaults.Import):
 			_, _, err = imported.SetImportedRKE1(terraform, terratest, newFile, rootBody, file)
 			if err != nil {
 				return clusterNames, nil, err
 			}
-		case module == modules.ImportEC2RKE2 || module == modules.ImportEC2RKE2Windows || module == modules.ImportEC2K3s:
+		case (strings.Contains(module, clustertypes.RKE2) || strings.Contains(module, clustertypes.K3S)) && strings.Contains(module, defaults.Import):
 			_, _, err = imported.SetImportedRKE2K3s(terraform, terratest, newFile, rootBody, file)
 			if err != nil {
 				return clusterNames, nil, err

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/tfp-automation
 
-go 1.23.4
+go 1.24.2
 
 replace (
 	github.com/containerd/containerd => github.com/containerd/containerd v1.6.27 // for compatibilty with docker 20.10.x

--- a/tests/extensions/provisioning/supportedModules.go
+++ b/tests/extensions/provisioning/supportedModules.go
@@ -58,6 +58,9 @@ func verifyModule(module string) bool {
 		modules.ImportEC2RKE2,
 		modules.ImportEC2RKE2Windows,
 		modules.ImportEC2K3s,
+		modules.ImportVsphereRKE1,
+		modules.ImportVsphereRKE2,
+		modules.ImportVsphereK3s,
 	}
 
 	return slices.Contains(supportedModules, module)

--- a/tests/rancher2/provisioning/README.md
+++ b/tests/rancher2/provisioning/README.md
@@ -103,12 +103,16 @@ terraform:
   cni: ""
   defaultClusterRoleForProjectMembers: "true"
   enableNetworkPolicy: false
-  provider: "aws"
+  module:                          # ec2_rke1_import, ec2_rke2_import, ec2_k3s_import, vsphere_rke1_import, vsphere_rke2_import, vsphere_k3s_import
   privateKeyPath: ""
+  provider: ""                     # aws or vsphere
   windowsPrivateKeyPath: ""
+
+  # Set if provider: aws
   awsCredentials:
     awsAccessKey: ""
     awsSecretKey: ""
+
   awsConfig:
     ami: ""
     awsKeyName: ""
@@ -128,18 +132,40 @@ terraform:
     windowsAWSPassword: ""
     windowsInstanceType: ""
     windowsKeyName: ""
+
+  # Set if provider: vsphere
+  vsphereCredentials:
+    password: ""
+    username: ""
+    vcenter: ""
+
+  vsphereConfig:  
+    cloneFrom: ""
+    cpuCount: ""
+    datacenter: ""
+    datastore: ""
+    datastoreCluster: ""
+    diskSize: ""
+    guestID: ""
+    folder: ""
+    hostSystem: ""
+    memorySize: ""
+    standaloneNetwork: ""
+    vsphereUser: ""
+
   standalone:
-    k3sVersion: ""                      # Ensure k3s1 suffix is appended (i.e. v1.30.9+k3s1)
+    k3sVersion: ""                      # Ensure k3s1 suffix is appended (i.e. v1.xx.x+k3s1)
     osGroup: ""
     osUser: ""
-    rke2Version: ""                     # Ensure rke2r1 suffix is appended (i.e. v1.30.9+rke2r1)
+    rke2Version: ""                     # Ensure rke2r1 suffix is appended (i.e. v1.xx.x+rke2r1)
+
 terratest:
   tfLogging: true
   nodeCount: 3
   windowsNodeCount: 1
 ```
 
-In addition, when running locally, you will need to ensure that you have `export RKE_PROVIDER_VERSION=x.xx.x` defined for the RKE1 portion of the test.
+In addition, when running locally, you will need to ensure that you have `export RKE_PROVIDER_VERSION=x.x.x` defined for the RKE1 portion of the test.
 
 See the below examples on how to run the tests:
 
@@ -149,11 +175,13 @@ See the below examples on how to run the tests:
 `gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/rancher2/provisioning --junitfile results.xml --jsonfile results.json -- -timeout=60m -v -run "TestTfpProvisionTestSuite/TestTfpProvisionDynamicInput$"`
 
 ### Custom
-`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/rancher2/provisioning --junitfile results.xml --jsonfile results.json -- -timeout=60m -v -run "TestTfpProvisionCustomTestSuite/TestTfpProvisionCustom$"`
+`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/rancher2/provisioning --junitfile results.xml --jsonfile results.json -- -timeout=60m -v -run "TestTfpProvisionCustomTestSuite/TestTfpProvisionCustom$"` \
+`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/rancher2/provisioning --junitfile results.xml --jsonfile results.json -- -timeout=60m -v -run "TestTfpProvisionCustomTestSuite/TestTfpProvisionCustomDynamicInput$"`
 
 ### Imported
 
-`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/rancher2/provisioning --junitfile results.xml --jsonfile results.json -- -timeout=60m -v -run "TestTfpProvisionImportTestSuite/TestTfpProvisionImport$"`
+`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/rancher2/provisioning --junitfile results.xml --jsonfile results.json -- -timeout=60m -v -run "TestTfpProvisionImportTestSuite/TestTfpProvisionImport$"` \
+`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/rancher2/provisioning --junitfile results.xml --jsonfile results.json -- -timeout=60m -v -run "TestTfpProvisionImportTestSuite/TestTfpProvisionImportDynamicInput$"`
 
 ### Hosted
 


### PR DESCRIPTION
### Issue: [Add vSphere support for imported clusters in tfp-automation](https://github.com/rancher/qa-tasks/issues/1823)

### Description
This PR allows vSphere to be an option when creating an imported cluster (RKE1/RKE2/K3S). For release testing purposes, EC2 will still be used, but the DynamicInput function will allow you to specify EC2 or vSphere. Additionally, this PR bumps Go version to `1.24`.