### PR TITLE
Restructure infra tests SetupSuite function + other changes

### DIFF
--- a/framework/set/provisioning/nodedriver/rke2k3s/setConfig.go
+++ b/framework/set/provisioning/nodedriver/rke2k3s/setConfig.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
-	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/defaults/modules"
 	"github.com/rancher/tfp-automation/framework/set/defaults"
@@ -59,8 +58,8 @@ const (
 )
 
 // SetRKE2K3s is a function that will set the RKE2/K3S configurations in the main.tf file.
-func SetRKE2K3s(client *rancher.Client, terraformConfig *config.TerraformConfig, k8sVersion, psact string,
-	nodePools []config.Nodepool, snapshots config.Snapshots, newFile *hclwrite.File, rootBody *hclwrite.Body,
+func SetRKE2K3s(terraformConfig *config.TerraformConfig, k8sVersion, psact string, nodePools []config.Nodepool,
+	snapshots config.Snapshots, newFile *hclwrite.File, rootBody *hclwrite.Body,
 	file *os.File, rbacRole config.Role) (*hclwrite.File, *os.File, error) {
 	switch {
 	case terraformConfig.Module == modules.EC2RKE2 || terraformConfig.Module == modules.EC2K3s:

--- a/framework/set/setAuthConfig.go
+++ b/framework/set/setAuthConfig.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/defaults/authproviders"
 	"github.com/rancher/tfp-automation/framework/set/authproviders/ad"
@@ -17,10 +18,10 @@ import (
 )
 
 // AuthConfig is a function that will set the main.tf file based on the auth provider.
-func AuthConfig(testUser, testPassword string, configMap []map[string]any, newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File) error {
+func AuthConfig(client *rancher.Client, testUser, testPassword string, configMap []map[string]any, newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File) error {
 	var err error
 
-	newFile, rootBody = resources.SetProvidersAndUsersTF(testUser, testPassword, true, newFile, rootBody, configMap, false)
+	newFile, rootBody = resources.SetProvidersAndUsersTF(client, testUser, testPassword, true, newFile, rootBody, configMap, false)
 
 	rancherConfig, terraform, _ := config.LoadTFPConfigs(configMap[0])
 	authProvider := terraform.AuthProvider

--- a/tests/airgap/airgap_upgrade_rancher_test.go
+++ b/tests/airgap/airgap_upgrade_rancher_test.go
@@ -7,12 +7,9 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/rancher/shepherd/clients/rancher"
-	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
-	"github.com/rancher/shepherd/extensions/token"
 	shepherdConfig "github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
-	"github.com/rancher/tests/actions/pipeline"
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/defaults/configs"
 	"github.com/rancher/tfp-automation/defaults/keypath"
@@ -24,6 +21,7 @@ import (
 	"github.com/rancher/tfp-automation/framework/set/resources/upgrade"
 	qase "github.com/rancher/tfp-automation/pipeline/qase/results"
 	"github.com/rancher/tfp-automation/tests/extensions/provisioning"
+	"github.com/rancher/tfp-automation/tests/infrastructure"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -69,53 +67,18 @@ func (a *TfpAirgapUpgradeRancherTestSuite) SetupSuite() {
 	upgradeTerraformOptions := framework.Setup(a.T(), a.terraformConfig, a.terratestConfig, keyPath)
 
 	a.upgradeTerraformOptions = upgradeTerraformOptions
-}
 
-func (a *TfpAirgapUpgradeRancherTestSuite) TfpSetupSuite() map[string]any {
 	testSession := session.NewSession()
 	a.session = testSession
 
-	a.cattleConfig = shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
-	configMap, err := provisioning.UniquifyTerraform([]map[string]any{a.cattleConfig})
-	require.NoError(a.T(), err)
-
-	a.cattleConfig = configMap[0]
-	a.rancherConfig, a.terraformConfig, a.terratestConfig = config.LoadTFPConfigs(a.cattleConfig)
-
-	adminUser := &management.User{
-		Username: "admin",
-		Password: a.rancherConfig.AdminPassword,
-	}
-
-	userToken, err := token.GenerateUserToken(adminUser, a.rancherConfig.Host)
-	require.NoError(a.T(), err)
-
-	a.rancherConfig.AdminToken = userToken.Token
-
-	client, err := rancher.NewClient(a.rancherConfig.AdminToken, testSession)
+	client, err := infrastructure.AcceptEULA(a.T(), testSession, a.terraformConfig.Standalone.AirgapInternalFQDN, false, true)
 	require.NoError(a.T(), err)
 
 	a.client = client
-	a.client.RancherConfig.AdminToken = a.rancherConfig.AdminToken
-	a.client.RancherConfig.AdminPassword = a.rancherConfig.AdminPassword
-	a.client.RancherConfig.Host = a.terraformConfig.Standalone.AirgapInternalFQDN
 
-	operations.ReplaceValue([]string{"rancher", "adminToken"}, a.rancherConfig.AdminToken, configMap[0])
-	operations.ReplaceValue([]string{"rancher", "adminPassword"}, a.rancherConfig.AdminPassword, configMap[0])
-	operations.ReplaceValue([]string{"rancher", "host"}, a.rancherConfig.Host, configMap[0])
-
-	err = pipeline.PostRancherInstall(a.client, a.client.RancherConfig.AdminPassword)
-	require.NoError(a.T(), err)
-
-	a.client.RancherConfig.Host = a.rancherConfig.Host
-
-	operations.ReplaceValue([]string{"rancher", "host"}, a.rancherConfig.Host, configMap[0])
-
-	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+	_, keyPath = rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 	terraformOptions := framework.Setup(a.T(), a.terraformConfig, a.terratestConfig, keyPath)
 	a.terraformOptions = terraformOptions
-
-	return a.cattleConfig
 }
 
 func (a *TfpAirgapUpgradeRancherTestSuite) TestTfpUpgradeAirgapRancher() {
@@ -129,7 +92,10 @@ func (a *TfpAirgapUpgradeRancherTestSuite) TestTfpUpgradeAirgapRancher() {
 	err := upgrade.CreateMainTF(a.T(), a.upgradeTerraformOptions, keyPath, a.terraformConfig, a.terratestConfig, "", "", a.bastion, a.registry)
 	require.NoError(a.T(), err)
 
-	provisioning.VerifyClustersState(a.T(), a.client, clusterIDs)
+	client, err := a.client.ReLogin()
+	require.NoError(a.T(), err)
+
+	provisioning.VerifyClustersState(a.T(), client, clusterIDs)
 
 	a.provisionAndVerifyCluster("Post-Upgrade Airgap ", clusterIDs, true)
 
@@ -143,7 +109,6 @@ func (a *TfpAirgapUpgradeRancherTestSuite) provisionAndVerifyCluster(name string
 		name   string
 		module string
 	}{
-		{"RKE1", modules.AirgapRKE1},
 		{"RKE2", modules.AirgapRKE2},
 		{"RKE2 Windows", modules.AirgapRKE2Windows},
 		{"K3S", modules.AirgapK3S},
@@ -156,10 +121,10 @@ func (a *TfpAirgapUpgradeRancherTestSuite) provisionAndVerifyCluster(name string
 	testUser, testPassword := configs.CreateTestCredentials()
 
 	for _, tt := range tests {
-		cattleConfig := a.TfpSetupSuite()
-		configMap := []map[string]any{cattleConfig}
+		configMap, err := provisioning.UniquifyTerraform([]map[string]any{a.cattleConfig})
+		require.NoError(a.T(), err)
 
-		_, err := operations.ReplaceValue([]string{"terraform", "module"}, tt.module, configMap[0])
+		_, err = operations.ReplaceValue([]string{"terraform", "module"}, tt.module, configMap[0])
 		require.NoError(a.T(), err)
 
 		_, err = operations.ReplaceValue([]string{"terraform", "privateRegistries", "systemDefaultRegistry"}, a.registry, configMap[0])
@@ -170,17 +135,17 @@ func (a *TfpAirgapUpgradeRancherTestSuite) provisionAndVerifyCluster(name string
 
 		provisioning.GetK8sVersion(a.T(), a.client, a.terratestConfig, a.terraformConfig, configs.DefaultK8sVersion, configMap)
 
-		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		_, terraform, terratest := config.LoadTFPConfigs(configMap[0])
 
 		tt.name = name + tt.name + " Kubernetes version: " + terratest.KubernetesVersion
 
 		a.Run((tt.name), func() {
-			clusterIDs, customClusterNames = provisioning.Provision(a.T(), a.client, rancher, terraform, testUser, testPassword, a.terraformOptions, configMap, newFile, rootBody, file, false, true, true, customClusterNames)
+			clusterIDs, customClusterNames = provisioning.Provision(a.T(), a.client, terraform, testUser, testPassword, a.terraformOptions, configMap, newFile, rootBody, file, false, true, true, customClusterNames)
 			provisioning.VerifyClustersState(a.T(), a.client, clusterIDs)
 			provisioning.VerifyRegistry(a.T(), a.client, clusterIDs[0], terraform)
 
 			if strings.Contains(terraform.Module, modules.AirgapRKE2Windows) {
-				clusterIDs, _ = provisioning.Provision(a.T(), a.client, rancher, terraform, testUser, testPassword, a.terraformOptions, configMap, newFile, rootBody, file, true, true, true, customClusterNames)
+				clusterIDs, _ = provisioning.Provision(a.T(), a.client, terraform, testUser, testPassword, a.terraformOptions, configMap, newFile, rootBody, file, true, true, true, customClusterNames)
 				provisioning.VerifyClustersState(a.T(), a.client, clusterIDs)
 				provisioning.VerifyRegistry(a.T(), a.client, clusterIDs[0], terraform)
 			}

--- a/tests/extensions/provisioning/defaultK8sVersion.go
+++ b/tests/extensions/provisioning/defaultK8sVersion.go
@@ -18,7 +18,8 @@ import (
 
 // GetK8sVersion is a function that will set the Kubernetes version if the user has not specified one. It
 // will get the latest version or the second latest version based on the versionType.
-func GetK8sVersion(t *testing.T, client *rancher.Client, terratestConfig *config.TerratestConfig, terraformConfig *config.TerraformConfig, versionType string, configMap []map[string]any) {
+func GetK8sVersion(t *testing.T, client *rancher.Client, terratestConfig *config.TerratestConfig, terraformConfig *config.TerraformConfig,
+	versionType string, configMap []map[string]any) {
 	var defaultVersion string
 
 	terraform := new(config.TerraformConfig)
@@ -81,7 +82,8 @@ func GetK8sVersion(t *testing.T, client *rancher.Client, terratestConfig *config
 
 // DefaultUpgradedK8sVersion is a function that will set the default Kubernetes upgrade version
 // if the user has not specified one.
-func DefaultUpgradedK8sVersion(t *testing.T, client *rancher.Client, terratestConfig *config.TerratestConfig, terraformConfig *config.TerraformConfig, configMap []map[string]any) {
+func DefaultUpgradedK8sVersion(t *testing.T, client *rancher.Client, terratestConfig *config.TerratestConfig, terraformConfig *config.TerraformConfig,
+	configMap []map[string]any) {
 	var defaultVersion string
 
 	if terratestConfig.UpgradedKubernetesVersion == "" {
@@ -104,6 +106,7 @@ func DefaultUpgradedK8sVersion(t *testing.T, client *rancher.Client, terratestCo
 	} else {
 		terratest := new(config.TerratestConfig)
 		operations.LoadObjectFromMap(config.TerratestConfigurationFileKey, configMap[0], terratest)
+
 		defaultVersion = terratest.UpgradedKubernetesVersion
 	}
 

--- a/tests/extensions/provisioning/kubernetesUpgrade.go
+++ b/tests/extensions/provisioning/kubernetesUpgrade.go
@@ -15,9 +15,9 @@ import (
 
 // KubernetesUpgrade is a function that will run terraform apply and uprade the
 // Kubernetes version of the provisioned cluster.
-func KubernetesUpgrade(t *testing.T, client *rancher.Client, rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig,
-	terratestConfig *config.TerratestConfig, testUser, testPassword string, terraformOptions *terraform.Options, configMap []map[string]any,
-	newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File, isWindows bool) ([]string, []string) {
+func KubernetesUpgrade(t *testing.T, client *rancher.Client, terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig,
+	testUser, testPassword string, terraformOptions *terraform.Options, configMap []map[string]any, newFile *hclwrite.File,
+	rootBody *hclwrite.Body, file *os.File, isWindows bool) ([]string, []string) {
 	var err error
 	var clusterNames []string
 	var clusterIDs []string

--- a/tests/extensions/provisioning/provision.go
+++ b/tests/extensions/provisioning/provision.go
@@ -14,9 +14,9 @@ import (
 )
 
 // Provision is a function that will run terraform init and apply Terraform resources to provision a cluster.
-func Provision(t *testing.T, client *rancher.Client, rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig,
-	testUser, testPassword string, terraformOptions *terraform.Options, configMap []map[string]any, newFile *hclwrite.File,
-	rootBody *hclwrite.Body, file *os.File, isWindows, persistClusters, containsCustomModule bool, customClusterNames []string) ([]string, []string) {
+func Provision(t *testing.T, client *rancher.Client, terraformConfig *config.TerraformConfig, testUser, testPassword string,
+	terraformOptions *terraform.Options, configMap []map[string]any, newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File,
+	isWindows, persistClusters, containsCustomModule bool, customClusterNames []string) ([]string, []string) {
 	var err error
 	var clusterNames []string
 	var clusterIDs []string

--- a/tests/extensions/provisioning/scale.go
+++ b/tests/extensions/provisioning/scale.go
@@ -14,9 +14,9 @@ import (
 
 // Scale is a function that will run terraform apply and scale the provisioned
 // cluster, according to user's desired amount.
-func Scale(t *testing.T, client *rancher.Client, rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig,
-	terratestConfig *config.TerratestConfig, testUser, testPassword string, terraformOptions *terraform.Options, configMap []map[string]any,
-	newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File) {
+func Scale(t *testing.T, client *rancher.Client, terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig,
+	testUser, testPassword string, terraformOptions *terraform.Options, configMap []map[string]any, newFile *hclwrite.File,
+	rootBody *hclwrite.Body, file *os.File) {
 	_, _, err := framework.ConfigTF(client, testUser, testPassword, "", configMap, newFile, rootBody, file, false, false, false, nil)
 	require.NoError(t, err)
 

--- a/tests/extensions/rbac/authConfig.go
+++ b/tests/extensions/rbac/authConfig.go
@@ -6,18 +6,19 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/tfp-automation/config"
 	framework "github.com/rancher/tfp-automation/framework/set"
 	"github.com/stretchr/testify/require"
 )
 
 // AuthConfig is a function that will run terraform apply to setup authentication providers.
-func AuthConfig(t *testing.T, terraformConfig *config.TerraformConfig, terraformOptions *terraform.Options, testUser, testPassword string,
+func AuthConfig(t *testing.T, client *rancher.Client, terraformConfig *config.TerraformConfig, terraformOptions *terraform.Options, testUser, testPassword string,
 	configMap []map[string]any, newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File) {
 	isSupported := SupportedAuthProviders(terraformConfig, terraformOptions)
 	require.True(t, isSupported)
 
-	err := framework.AuthConfig(testUser, testPassword, configMap, newFile, rootBody, file)
+	err := framework.AuthConfig(client, testUser, testPassword, configMap, newFile, rootBody, file)
 	require.NoError(t, err)
 
 	terraform.InitAndApply(t, terraformOptions)

--- a/tests/infrastructure/acceptEULA.go
+++ b/tests/infrastructure/acceptEULA.go
@@ -9,21 +9,15 @@ import (
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	"github.com/rancher/shepherd/extensions/token"
 	shepherdConfig "github.com/rancher/shepherd/pkg/config"
-	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/tfp-automation/config"
-	"github.com/rancher/tfp-automation/tests/extensions/provisioning"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
 // AcceptEULA accepts the EULA for the Rancher server post installation
-func AcceptEULA(t *testing.T, session *session.Session, host string) {
+func AcceptEULA(t *testing.T, session *session.Session, host string, showToken, isAirgap bool) (*rancher.Client, error) {
 	cattleConfig := shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
-	configMap, err := provisioning.UniquifyTerraform([]map[string]any{cattleConfig})
-	require.NoError(t, err)
-
-	cattleConfig = configMap[0]
 	rancherConfig, _, _ := config.LoadTFPConfigs(cattleConfig)
 
 	adminUser := &management.User{
@@ -31,10 +25,10 @@ func AcceptEULA(t *testing.T, session *session.Session, host string) {
 		Password: rancherConfig.AdminPassword,
 	}
 
-	userToken, err := token.GenerateUserToken(adminUser, rancherConfig.Host)
+	adminToken, err := token.GenerateUserToken(adminUser, rancherConfig.Host)
 	require.NoError(t, err)
 
-	rancherConfig.AdminToken = userToken.Token
+	rancherConfig.AdminToken = adminToken.Token
 
 	client, err := rancher.NewClient(rancherConfig.AdminToken, session)
 	require.NoError(t, err)
@@ -43,17 +37,17 @@ func AcceptEULA(t *testing.T, session *session.Session, host string) {
 	client.RancherConfig.AdminPassword = rancherConfig.AdminPassword
 	client.RancherConfig.Host = host
 
-	_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, rancherConfig.AdminToken, configMap[0])
-	require.NoError(t, err)
-
-	_, err = operations.ReplaceValue([]string{"rancher", "adminPassword"}, rancherConfig.AdminPassword, configMap[0])
-	require.NoError(t, err)
-
-	_, err = operations.ReplaceValue([]string{"rancher", "host"}, rancherConfig.Host, configMap[0])
-	require.NoError(t, err)
-
 	err = pipeline.PostRancherInstall(client, client.RancherConfig.AdminPassword)
 	require.NoError(t, err)
 
-	logrus.Infof("Admin bearer token: %s", client.RancherConfig.AdminToken)
+	// The FQDN needs to be set back to the Rancher host URL and not the internal FQDN
+	if isAirgap {
+		client.RancherConfig.Host = rancherConfig.Host
+	}
+
+	if showToken {
+		logrus.Infof("Admin bearer token: %s", client.RancherConfig.AdminToken)
+	}
+
+	return client, nil
 }

--- a/tests/infrastructure/setup_airgap_rancher_test.go
+++ b/tests/infrastructure/setup_airgap_rancher_test.go
@@ -45,7 +45,8 @@ func (i *AirgapRancherTestSuite) TestCreateAirgapRancher() {
 	testSession := session.NewSession()
 	i.session = testSession
 
-	AcceptEULA(i.T(), i.session, i.terraformConfig.Standalone.AirgapInternalFQDN)
+	_, err = AcceptEULA(i.T(), i.session, i.terraformConfig.Standalone.AirgapInternalFQDN, true, true)
+	require.NoError(i.T(), err)
 }
 
 func TestAirgapRancherTestSuite(t *testing.T) {

--- a/tests/infrastructure/setup_proxy_rancher_test.go
+++ b/tests/infrastructure/setup_proxy_rancher_test.go
@@ -45,7 +45,8 @@ func (i *ProxyRancherTestSuite) TestCreateProxyRancher() {
 	testSession := session.NewSession()
 	i.session = testSession
 
-	AcceptEULA(i.T(), i.session, i.terraformConfig.Standalone.RancherHostname)
+	_, err = AcceptEULA(i.T(), i.session, i.terraformConfig.Standalone.RancherHostname, true, false)
+	require.NoError(i.T(), err)
 }
 
 func TestProxyRancherTestSuite(t *testing.T) {

--- a/tests/infrastructure/setup_rancher_ipv6_test.go
+++ b/tests/infrastructure/setup_rancher_ipv6_test.go
@@ -44,7 +44,8 @@ func (i *RancherIPv6TestSuite) TestCreateRancherIPv6() {
 	testSession := session.NewSession()
 	i.session = testSession
 
-	AcceptEULA(i.T(), i.session, i.terraformConfig.Standalone.AirgapInternalFQDN)
+	_, err = AcceptEULA(i.T(), i.session, i.terraformConfig.Standalone.AirgapInternalFQDN, true, false)
+	require.NoError(i.T(), err)
 }
 
 func TestRancherIPv6TestSuite(t *testing.T) {

--- a/tests/infrastructure/setup_rancher_test.go
+++ b/tests/infrastructure/setup_rancher_test.go
@@ -46,7 +46,8 @@ func (i *RancherTestSuite) TestCreateRancher() {
 		testSession := session.NewSession()
 		i.session = testSession
 
-		AcceptEULA(i.T(), i.session, i.terraformConfig.Standalone.RancherHostname)
+		_, err = AcceptEULA(i.T(), i.session, i.terraformConfig.Standalone.RancherHostname, true, false)
+		require.NoError(i.T(), err)
 	}
 }
 

--- a/tests/rancher2/os/os_test.go
+++ b/tests/rancher2/os/os_test.go
@@ -126,7 +126,7 @@ func (p *OSValidationTestSuite) TestDynamicOSValidation() {
 				logrus.Infof("Provisioning Cluster Type: %s, "+"K8s Version: %s, "+"CNI: %s", terraformConfig.Module, terratestConfig.KubernetesVersion, terraformConfig.CNI)
 			}
 
-			clusterIDs, _ = provisioning.Provision(p.T(), p.client, p.rancherConfig, p.terraformConfig, testUser, testPassword, p.terraformOptions, batch, newFile, rootBody, file, false, false, true, customClusterNames)
+			clusterIDs, _ = provisioning.Provision(p.T(), p.client, p.terraformConfig, testUser, testPassword, p.terraformOptions, batch, newFile, rootBody, file, false, false, true, customClusterNames)
 			time.Sleep(2 * time.Minute)
 			provisioning.VerifyClustersState(p.T(), p.client, clusterIDs)
 		})

--- a/tests/rancher2/snapshot/snapshot.go
+++ b/tests/rancher2/snapshot/snapshot.go
@@ -129,7 +129,7 @@ func restoreV2Prov(t *testing.T, client *rancher.Client, terraformConfig *config
 	_, err = operations.ReplaceValue([]string{"terratest", "snapshotInput", "snapshotName"}, snapshotName, configMap[0])
 	require.NoError(t, err)
 
-	_, _, err = framework.ConfigTF(nil, testUser, testPassword, "", configMap, newFile, rootBody, file, false, false, false, nil)
+	_, _, err = framework.ConfigTF(client, testUser, testPassword, "", configMap, newFile, rootBody, file, false, false, false, nil)
 	require.NoError(t, err)
 
 	terraform.Apply(t, terraformOptions)

--- a/tests/registries/registries_test.go
+++ b/tests/registries/registries_test.go
@@ -6,12 +6,9 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/rancher/shepherd/clients/rancher"
-	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
-	"github.com/rancher/shepherd/extensions/token"
 	shepherdConfig "github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
-	"github.com/rancher/tests/actions/pipeline"
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/defaults/configs"
 	"github.com/rancher/tfp-automation/defaults/keypath"
@@ -22,6 +19,7 @@ import (
 	"github.com/rancher/tfp-automation/framework/set/resources/registries"
 	qase "github.com/rancher/tfp-automation/pipeline/qase/results"
 	"github.com/rancher/tfp-automation/tests/extensions/provisioning"
+	"github.com/rancher/tfp-automation/tests/infrastructure"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -60,49 +58,18 @@ func (r *TfpRegistriesTestSuite) SetupSuite() {
 	r.authRegistry = authRegistry
 	r.nonAuthRegistry = nonAuthRegistry
 	r.globalRegistry = globalRegistry
-}
 
-func (r *TfpRegistriesTestSuite) TfpSetupSuite() map[string]any {
 	testSession := session.NewSession()
 	r.session = testSession
 
-	r.cattleConfig = shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
-	configMap, err := provisioning.UniquifyTerraform([]map[string]any{r.cattleConfig})
-	require.NoError(r.T(), err)
-
-	r.cattleConfig = configMap[0]
-	r.rancherConfig, r.terraformConfig, r.terratestConfig = config.LoadTFPConfigs(r.cattleConfig)
-
-	adminUser := &management.User{
-		Username: "admin",
-		Password: r.rancherConfig.AdminPassword,
-	}
-
-	userToken, err := token.GenerateUserToken(adminUser, r.rancherConfig.Host)
-	require.NoError(r.T(), err)
-
-	r.rancherConfig.AdminToken = userToken.Token
-
-	client, err := rancher.NewClient(r.rancherConfig.AdminToken, testSession)
+	client, err := infrastructure.AcceptEULA(r.T(), testSession, r.terraformConfig.Standalone.RancherHostname, false, false)
 	require.NoError(r.T(), err)
 
 	r.client = client
-	r.client.RancherConfig.AdminToken = r.rancherConfig.AdminToken
-	r.client.RancherConfig.AdminPassword = r.rancherConfig.AdminPassword
-	r.client.RancherConfig.Host = r.rancherConfig.Host
 
-	operations.ReplaceValue([]string{"rancher", "adminToken"}, r.rancherConfig.AdminToken, configMap[0])
-	operations.ReplaceValue([]string{"rancher", "adminPassword"}, r.rancherConfig.AdminPassword, configMap[0])
-	operations.ReplaceValue([]string{"rancher", "host"}, r.rancherConfig.Host, configMap[0])
-
-	err = pipeline.PostRancherInstall(r.client, r.client.RancherConfig.AdminPassword)
-	require.NoError(r.T(), err)
-
-	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+	_, keyPath = rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 	terraformOptions := framework.Setup(r.T(), r.terraformConfig, r.terratestConfig, keyPath)
 	r.terraformOptions = terraformOptions
-
-	return r.cattleConfig
 }
 
 func (r *TfpRegistriesTestSuite) TestTfpGlobalRegistry() {
@@ -114,21 +81,20 @@ func (r *TfpRegistriesTestSuite) TestTfpGlobalRegistry() {
 		module    string
 		nodeRoles []config.Nodepool
 	}{
-		{"Global RKE1", modules.EC2RKE1, nodeRolesDedicated},
 		{"Global RKE2", modules.EC2RKE2, nodeRolesDedicated},
 		{"Global K3S", modules.EC2K3s, nodeRolesAll},
 	}
 
-	newFile, rootBody, file := rancher2.InitializeMainTF()
-	defer file.Close()
-
 	testUser, testPassword := configs.CreateTestCredentials()
 
 	for _, tt := range tests {
-		cattleConfig := r.TfpSetupSuite()
-		configMap := []map[string]any{cattleConfig}
+		newFile, rootBody, file := rancher2.InitializeMainTF()
+		defer file.Close()
 
-		_, err := operations.ReplaceValue([]string{"terratest", "nodepools"}, tt.nodeRoles, configMap[0])
+		configMap, err := provisioning.UniquifyTerraform([]map[string]any{r.cattleConfig})
+		require.NoError(r.T(), err)
+
+		_, err = operations.ReplaceValue([]string{"terratest", "nodepools"}, tt.nodeRoles, configMap[0])
 		require.NoError(r.T(), err)
 
 		_, err = operations.ReplaceValue([]string{"terraform", "module"}, tt.module, configMap[0])
@@ -151,7 +117,7 @@ func (r *TfpRegistriesTestSuite) TestTfpGlobalRegistry() {
 
 		provisioning.GetK8sVersion(r.T(), r.client, r.terratestConfig, r.terraformConfig, configs.DefaultK8sVersion, configMap)
 
-		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		_, terraform, terratest := config.LoadTFPConfigs(configMap[0])
 
 		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion
 
@@ -159,7 +125,7 @@ func (r *TfpRegistriesTestSuite) TestTfpGlobalRegistry() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 			defer cleanup.Cleanup(r.T(), r.terraformOptions, keyPath)
 
-			clusterIDs, _ := provisioning.Provision(r.T(), r.client, rancher, terraform, testUser, testPassword, r.terraformOptions, configMap, newFile, rootBody, file, false, false, true, nil)
+			clusterIDs, _ := provisioning.Provision(r.T(), r.client, terraform, testUser, testPassword, r.terraformOptions, configMap, newFile, rootBody, file, false, false, true, nil)
 			provisioning.VerifyClustersState(r.T(), r.client, clusterIDs)
 			provisioning.VerifyRegistry(r.T(), r.client, clusterIDs[0], terraform)
 		})
@@ -179,21 +145,20 @@ func (r *TfpRegistriesTestSuite) TestTfpAuthenticatedRegistry() {
 		module    string
 		nodeRoles []config.Nodepool
 	}{
-		{"Auth RKE1", modules.EC2RKE1, nodeRolesDedicated},
 		{"Auth RKE2", modules.EC2RKE2, nodeRolesDedicated},
 		{"Auth K3S", modules.EC2K3s, nodeRolesAll},
 	}
 
-	newFile, rootBody, file := rancher2.InitializeMainTF()
-	defer file.Close()
-
 	testUser, testPassword := configs.CreateTestCredentials()
 
 	for _, tt := range tests {
-		cattleConfig := r.TfpSetupSuite()
-		configMap := []map[string]any{cattleConfig}
+		newFile, rootBody, file := rancher2.InitializeMainTF()
+		defer file.Close()
 
-		_, err := operations.ReplaceValue([]string{"terratest", "nodepools"}, tt.nodeRoles, configMap[0])
+		configMap, err := provisioning.UniquifyTerraform([]map[string]any{r.cattleConfig})
+		require.NoError(r.T(), err)
+
+		_, err = operations.ReplaceValue([]string{"terratest", "nodepools"}, tt.nodeRoles, configMap[0])
 		require.NoError(r.T(), err)
 
 		_, err = operations.ReplaceValue([]string{"terraform", "module"}, tt.module, configMap[0])
@@ -210,7 +175,7 @@ func (r *TfpRegistriesTestSuite) TestTfpAuthenticatedRegistry() {
 
 		provisioning.GetK8sVersion(r.T(), r.client, r.terratestConfig, r.terraformConfig, configs.DefaultK8sVersion, configMap)
 
-		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		_, terraform, terratest := config.LoadTFPConfigs(configMap[0])
 
 		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion
 
@@ -218,7 +183,7 @@ func (r *TfpRegistriesTestSuite) TestTfpAuthenticatedRegistry() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 			defer cleanup.Cleanup(r.T(), r.terraformOptions, keyPath)
 
-			clusterIDs, _ := provisioning.Provision(r.T(), r.client, rancher, terraform, testUser, testPassword, r.terraformOptions, configMap, newFile, rootBody, file, false, false, true, nil)
+			clusterIDs, _ := provisioning.Provision(r.T(), r.client, terraform, testUser, testPassword, r.terraformOptions, configMap, newFile, rootBody, file, false, false, true, nil)
 			provisioning.VerifyClustersState(r.T(), r.client, clusterIDs)
 			provisioning.VerifyRegistry(r.T(), r.client, clusterIDs[0], terraform)
 		})
@@ -238,21 +203,20 @@ func (r *TfpRegistriesTestSuite) TestTfpNonAuthenticatedRegistry() {
 		module    string
 		nodeRoles []config.Nodepool
 	}{
-		{"Non Auth RKE1", modules.EC2RKE1, nodeRolesDedicated},
 		{"Non Auth RKE2", modules.EC2RKE2, nodeRolesDedicated},
 		{"Non Auth K3S", modules.EC2K3s, nodeRolesAll},
 	}
 
-	newFile, rootBody, file := rancher2.InitializeMainTF()
-	defer file.Close()
-
 	testUser, testPassword := configs.CreateTestCredentials()
 
 	for _, tt := range tests {
-		cattleConfig := r.TfpSetupSuite()
-		configMap := []map[string]any{cattleConfig}
+		newFile, rootBody, file := rancher2.InitializeMainTF()
+		defer file.Close()
 
-		_, err := operations.ReplaceValue([]string{"terratest", "nodepools"}, tt.nodeRoles, configMap[0])
+		configMap, err := provisioning.UniquifyTerraform([]map[string]any{r.cattleConfig})
+		require.NoError(r.T(), err)
+
+		_, err = operations.ReplaceValue([]string{"terratest", "nodepools"}, tt.nodeRoles, configMap[0])
 		require.NoError(r.T(), err)
 
 		_, err = operations.ReplaceValue([]string{"terraform", "module"}, tt.module, configMap[0])
@@ -275,7 +239,7 @@ func (r *TfpRegistriesTestSuite) TestTfpNonAuthenticatedRegistry() {
 
 		provisioning.GetK8sVersion(r.T(), r.client, r.terratestConfig, r.terraformConfig, configs.DefaultK8sVersion, configMap)
 
-		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		_, terraform, terratest := config.LoadTFPConfigs(configMap[0])
 
 		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion
 
@@ -283,7 +247,7 @@ func (r *TfpRegistriesTestSuite) TestTfpNonAuthenticatedRegistry() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 			defer cleanup.Cleanup(r.T(), r.terraformOptions, keyPath)
 
-			clusterIDs, _ := provisioning.Provision(r.T(), r.client, rancher, terraform, testUser, testPassword, r.terraformOptions, configMap, newFile, rootBody, file, false, false, true, nil)
+			clusterIDs, _ := provisioning.Provision(r.T(), r.client, terraform, testUser, testPassword, r.terraformOptions, configMap, newFile, rootBody, file, false, false, true, nil)
 			provisioning.VerifyClustersState(r.T(), r.client, clusterIDs)
 			provisioning.VerifyRegistry(r.T(), r.client, clusterIDs[0], terraform)
 		})
@@ -302,20 +266,19 @@ func (r *TfpRegistriesTestSuite) TestTfpECRRegistry() {
 		module    string
 		nodeRoles []config.Nodepool
 	}{
-		{"ECR RKE1", "ec2_rke1", nodeRolesDedicated},
 		{"ECR RKE2", "ec2_rke2", nodeRolesDedicated},
 	}
-
-	newFile, rootBody, file := rancher2.InitializeMainTF()
-	defer file.Close()
 
 	testUser, testPassword := configs.CreateTestCredentials()
 
 	for _, tt := range tests {
-		cattleConfig := r.TfpSetupSuite()
-		configMap := []map[string]any{cattleConfig}
+		newFile, rootBody, file := rancher2.InitializeMainTF()
+		defer file.Close()
 
-		_, err := operations.ReplaceValue([]string{"terratest", "nodepools"}, tt.nodeRoles, configMap[0])
+		configMap, err := provisioning.UniquifyTerraform([]map[string]any{r.cattleConfig})
+		require.NoError(r.T(), err)
+
+		_, err = operations.ReplaceValue([]string{"terratest", "nodepools"}, tt.nodeRoles, configMap[0])
 		require.NoError(r.T(), err)
 
 		_, err = operations.ReplaceValue([]string{"terraform", "module"}, tt.module, configMap[0])
@@ -341,7 +304,7 @@ func (r *TfpRegistriesTestSuite) TestTfpECRRegistry() {
 
 		provisioning.GetK8sVersion(r.T(), r.client, r.terratestConfig, r.terraformConfig, configs.DefaultK8sVersion, configMap)
 
-		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		_, terraform, terratest := config.LoadTFPConfigs(configMap[0])
 
 		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion
 
@@ -349,7 +312,7 @@ func (r *TfpRegistriesTestSuite) TestTfpECRRegistry() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 			defer cleanup.Cleanup(r.T(), r.terraformOptions, keyPath)
 
-			clusterIDs, _ := provisioning.Provision(r.T(), r.client, rancher, terraform, testUser, testPassword, r.terraformOptions, configMap, newFile, rootBody, file, false, false, true, nil)
+			clusterIDs, _ := provisioning.Provision(r.T(), r.client, terraform, testUser, testPassword, r.terraformOptions, configMap, newFile, rootBody, file, false, false, true, nil)
 			provisioning.VerifyClustersState(r.T(), r.client, clusterIDs)
 			provisioning.VerifyRegistry(r.T(), r.client, clusterIDs[0], terraform)
 		})

--- a/tests/sanity/sanity_provisioning_rke1_test.go
+++ b/tests/sanity/sanity_provisioning_rke1_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-type TfpSanityProvisioningTestSuite struct {
+type TfpSanityRKE1ProvisioningTestSuite struct {
 	suite.Suite
 	client                     *rancher.Client
 	session                    *session.Session
@@ -37,12 +37,12 @@ type TfpSanityProvisioningTestSuite struct {
 	terraformOptions           *terraform.Options
 }
 
-func (s *TfpSanityProvisioningTestSuite) TearDownSuite() {
+func (s *TfpSanityRKE1ProvisioningTestSuite) TearDownSuite() {
 	_, keyPath := rancher2.SetKeyPath(keypath.SanityKeyPath, s.terraformConfig.Provider)
 	cleanup.Cleanup(s.T(), s.standaloneTerraformOptions, keyPath)
 }
 
-func (s *TfpSanityProvisioningTestSuite) SetupSuite() {
+func (s *TfpSanityRKE1ProvisioningTestSuite) SetupSuite() {
 	s.cattleConfig = shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
 	s.rancherConfig, s.terraformConfig, s.terratestConfig = config.LoadTFPConfigs(s.cattleConfig)
 
@@ -66,7 +66,7 @@ func (s *TfpSanityProvisioningTestSuite) SetupSuite() {
 	s.terraformOptions = terraformOptions
 }
 
-func (s *TfpSanityProvisioningTestSuite) TestTfpProvisioningSanity() {
+func (s *TfpSanityRKE1ProvisioningTestSuite) TestTfpRKE1ProvisioningSanity() {
 	nodeRolesDedicated := []config.Nodepool{config.EtcdNodePool, config.ControlPlaneNodePool, config.WorkerNodePool}
 
 	tests := []struct {
@@ -74,9 +74,7 @@ func (s *TfpSanityProvisioningTestSuite) TestTfpProvisioningSanity() {
 		nodeRoles []config.Nodepool
 		module    string
 	}{
-		{"Sanity RKE2", nodeRolesDedicated, modules.EC2RKE2},
-		{"Sanity RKE2 Windows", nil, modules.CustomEC2RKE2Windows},
-		{"Sanity K3S", nodeRolesDedicated, modules.EC2K3s},
+		{"Sanity RKE1", nodeRolesDedicated, modules.EC2RKE1},
 	}
 
 	customClusterNames := []string{}
@@ -120,6 +118,6 @@ func (s *TfpSanityProvisioningTestSuite) TestTfpProvisioningSanity() {
 	}
 }
 
-func TestTfpSanityProvisioningTestSuite(t *testing.T) {
-	suite.Run(t, new(TfpSanityProvisioningTestSuite))
+func TestTfpSanityRKE1ProvisioningTestSuite(t *testing.T) {
+	suite.Run(t, new(TfpSanityRKE1ProvisioningTestSuite))
 }

--- a/tests/sanity/sanity_upgrade_rancher_test.go
+++ b/tests/sanity/sanity_upgrade_rancher_test.go
@@ -6,10 +6,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
-	"github.com/rancher/rancher/tests/v2/actions/pipeline"
 	"github.com/rancher/shepherd/clients/rancher"
-	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
-	"github.com/rancher/shepherd/extensions/token"
 	shepherdConfig "github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
@@ -24,6 +21,7 @@ import (
 	"github.com/rancher/tfp-automation/framework/set/resources/upgrade"
 	qase "github.com/rancher/tfp-automation/pipeline/qase/results"
 	"github.com/rancher/tfp-automation/tests/extensions/provisioning"
+	"github.com/rancher/tfp-automation/tests/infrastructure"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -67,49 +65,18 @@ func (s *TfpSanityUpgradeRancherTestSuite) SetupSuite() {
 	upgradeTerraformOptions := framework.Setup(s.T(), s.terraformConfig, s.terratestConfig, keyPath)
 
 	s.upgradeTerraformOptions = upgradeTerraformOptions
-}
 
-func (s *TfpSanityUpgradeRancherTestSuite) TfpSetupSuite() map[string]any {
 	testSession := session.NewSession()
 	s.session = testSession
 
-	s.cattleConfig = shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
-	configMap, err := provisioning.UniquifyTerraform([]map[string]any{s.cattleConfig})
-	require.NoError(s.T(), err)
-
-	s.cattleConfig = configMap[0]
-	s.rancherConfig, s.terraformConfig, s.terratestConfig = config.LoadTFPConfigs(s.cattleConfig)
-
-	adminUser := &management.User{
-		Username: "admin",
-		Password: s.rancherConfig.AdminPassword,
-	}
-
-	userToken, err := token.GenerateUserToken(adminUser, s.rancherConfig.Host)
-	require.NoError(s.T(), err)
-
-	s.rancherConfig.AdminToken = userToken.Token
-
-	client, err := rancher.NewClient(s.rancherConfig.AdminToken, testSession)
+	client, err := infrastructure.AcceptEULA(s.T(), testSession, s.terraformConfig.Standalone.RancherHostname, false, false)
 	require.NoError(s.T(), err)
 
 	s.client = client
-	s.client.RancherConfig.AdminToken = s.rancherConfig.AdminToken
-	s.client.RancherConfig.AdminPassword = s.rancherConfig.AdminPassword
-	s.client.RancherConfig.Host = s.rancherConfig.Host
 
-	operations.ReplaceValue([]string{"rancher", "adminToken"}, s.rancherConfig.AdminToken, configMap[0])
-	operations.ReplaceValue([]string{"rancher", "adminPassword"}, s.rancherConfig.AdminPassword, configMap[0])
-	operations.ReplaceValue([]string{"rancher", "host"}, s.rancherConfig.Host, configMap[0])
-
-	err = pipeline.PostRancherInstall(s.client, s.client.RancherConfig.AdminPassword)
-	require.NoError(s.T(), err)
-
-	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
+	_, keyPath = rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 	terraformOptions := framework.Setup(s.T(), s.terraformConfig, s.terratestConfig, keyPath)
 	s.terraformOptions = terraformOptions
-
-	return s.cattleConfig
 }
 
 func (s *TfpSanityUpgradeRancherTestSuite) TestTfpUpgradeRancher() {
@@ -123,7 +90,10 @@ func (s *TfpSanityUpgradeRancherTestSuite) TestTfpUpgradeRancher() {
 	err := upgrade.CreateMainTF(s.T(), s.upgradeTerraformOptions, keyPath, s.terraformConfig, s.terratestConfig, s.serverNodeOne, "", "", "")
 	require.NoError(s.T(), err)
 
-	provisioning.VerifyClustersState(s.T(), s.client, clusterIDs)
+	client, err := s.client.ReLogin()
+	require.NoError(s.T(), err)
+
+	provisioning.VerifyClustersState(s.T(), client, clusterIDs)
 
 	s.provisionAndVerifyCluster("Post-Upgrade Sanity ", clusterIDs, true)
 
@@ -140,7 +110,6 @@ func (s *TfpSanityUpgradeRancherTestSuite) provisionAndVerifyCluster(name string
 		nodeRoles []config.Nodepool
 		module    string
 	}{
-		{"RKE1", nodeRolesDedicated, modules.EC2RKE1},
 		{"RKE2", nodeRolesDedicated, modules.EC2RKE2},
 		{"RKE2 Windows", nil, modules.CustomEC2RKE2Windows},
 		{"K3S", nodeRolesDedicated, modules.EC2K3s},
@@ -153,10 +122,10 @@ func (s *TfpSanityUpgradeRancherTestSuite) provisionAndVerifyCluster(name string
 	testUser, testPassword := configs.CreateTestCredentials()
 
 	for _, tt := range tests {
-		cattleConfig := s.TfpSetupSuite()
-		configMap := []map[string]any{cattleConfig}
+		configMap, err := provisioning.UniquifyTerraform([]map[string]any{s.cattleConfig})
+		require.NoError(s.T(), err)
 
-		_, err := operations.ReplaceValue([]string{"terratest", "nodepools"}, tt.nodeRoles, configMap[0])
+		_, err = operations.ReplaceValue([]string{"terratest", "nodepools"}, tt.nodeRoles, configMap[0])
 		require.NoError(s.T(), err)
 
 		_, err = operations.ReplaceValue([]string{"terraform", "module"}, tt.module, configMap[0])
@@ -164,16 +133,16 @@ func (s *TfpSanityUpgradeRancherTestSuite) provisionAndVerifyCluster(name string
 
 		provisioning.GetK8sVersion(s.T(), s.client, s.terratestConfig, s.terraformConfig, configs.DefaultK8sVersion, configMap)
 
-		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		_, terraform, terratest := config.LoadTFPConfigs(configMap[0])
 
 		tt.name = name + tt.name + " Kubernetes version: " + terratest.KubernetesVersion
 
 		s.Run((tt.name), func() {
-			clusterIDs, customClusterNames = provisioning.Provision(s.T(), s.client, rancher, terraform, testUser, testPassword, s.terraformOptions, configMap, newFile, rootBody, file, false, true, true, customClusterNames)
+			clusterIDs, customClusterNames = provisioning.Provision(s.T(), s.client, terraform, testUser, testPassword, s.terraformOptions, configMap, newFile, rootBody, file, false, true, true, customClusterNames)
 			provisioning.VerifyClustersState(s.T(), s.client, clusterIDs)
 
 			if strings.Contains(terraform.Module, modules.CustomEC2RKE2Windows) {
-				clusterIDs, _ = provisioning.Provision(s.T(), s.client, rancher, terraform, testUser, testPassword, s.terraformOptions, configMap, newFile, rootBody, file, true, true, true, customClusterNames)
+				clusterIDs, _ = provisioning.Provision(s.T(), s.client, terraform, testUser, testPassword, s.terraformOptions, configMap, newFile, rootBody, file, true, true, true, customClusterNames)
 				provisioning.VerifyClustersState(s.T(), s.client, clusterIDs)
 			}
 		})


### PR DESCRIPTION
### Issue: N/A

### PR Description
This is an encompassing QOL PR that ultimately is meant to unblock GHA pipelines from being created in this repo. See below what is occurring in the PR:
- Restructure the infra tests to remove `TfpSetupSuite` and have `AcceptEULA` be called in each of the tests
- Cleaned up configMap code in infra tests / rancher2 tests to be properly used
- Removed RKE1 tests and created `sanity_provisioning_rke1_test.go` based on offline discussion