### PR TITLE
Fix admin token not working post Rancher upgrade + fixing issue in ECR script

### DIFF
--- a/framework/set/resources/rancher2/setProvidersAndUsersTF.go
+++ b/framework/set/resources/rancher2/setProvidersAndUsersTF.go
@@ -45,13 +45,13 @@ const (
 )
 
 // SetProvidersAndUsersTF is a helper function that will set the general Terraform configurations in the main.tf file.
-func SetProvidersAndUsersTF(client *rancher.Client, testUser, testPassword string, authProvider bool, newFile *hclwrite.File, rootBody *hclwrite.Body,
+func SetProvidersAndUsersTF(rancherConfig *rancher.Config, testUser, testPassword string, authProvider bool, newFile *hclwrite.File, rootBody *hclwrite.Body,
 	configMap []map[string]any, customModule bool) (*hclwrite.File, *hclwrite.Body) {
 	createRequiredProviders(rootBody, configMap, customModule)
 
 	rootBody.AppendNewline()
 
-	createProvider(client, rootBody, configMap, customModule)
+	createProvider(rancherConfig, rootBody, configMap, customModule)
 
 	createUser(rootBody, testUser, testPassword)
 
@@ -119,7 +119,7 @@ func createRequiredProviders(rootBody *hclwrite.Body, configMap []map[string]any
 }
 
 // createProvider creates a provider block for the given rancher config.
-func createProvider(client *rancher.Client, rootBody *hclwrite.Body, configMap []map[string]any, customModule bool) {
+func createProvider(rancherConfig *rancher.Config, rootBody *hclwrite.Body, configMap []map[string]any, customModule bool) {
 	_, _, cloudProviderVersion, _, _ := getRequiredProviderVersions(configMap)
 
 	terraformConfig := new(config.TerraformConfig)
@@ -166,9 +166,9 @@ func createProvider(client *rancher.Client, rootBody *hclwrite.Body, configMap [
 	rancher2ProvBlock := rootBody.AppendNewBlock(provider, []string{rancher2})
 	rancher2ProvBlockBody := rancher2ProvBlock.Body()
 
-	rancher2ProvBlockBody.SetAttributeValue(apiURL, cty.StringVal("https://"+client.RancherConfig.Host))
-	rancher2ProvBlockBody.SetAttributeValue(tokenKey, cty.StringVal(client.RancherConfig.AdminToken))
-	rancher2ProvBlockBody.SetAttributeValue(insecure, cty.BoolVal(*client.RancherConfig.Insecure))
+	rancher2ProvBlockBody.SetAttributeValue(apiURL, cty.StringVal("https://"+rancherConfig.Host))
+	rancher2ProvBlockBody.SetAttributeValue(tokenKey, cty.StringVal(rancherConfig.AdminToken))
+	rancher2ProvBlockBody.SetAttributeValue(insecure, cty.BoolVal(*rancherConfig.Insecure))
 
 	rootBody.AppendNewline()
 }

--- a/framework/set/resources/registries/rancher/setup.sh
+++ b/framework/set/resources/registries/rancher/setup.sh
@@ -8,8 +8,7 @@ RANCHER_TAG_VERSION=$5
 BOOTSTRAP_PASSWORD=$6
 RANCHER_IMAGE=$7
 REGISTRY=$8
-STAGING_RANCHER_AGENT_IMAGE=${9:-""}
-PRIME_RANCHER_AGENT_IMAGE=${10}
+RANCHER_AGENT_IMAGE=${9}
 
 set -ex
 
@@ -40,24 +39,14 @@ echo "Waiting 1 minute for Rancher"
 sleep 60
 
 echo "Installing Rancher"
-if [ -n "$STAGING_RANCHER_AGENT_IMAGE" ]; then
+if [ -n "$RANCHER_AGENT_IMAGE" ]; then
     helm upgrade --install rancher rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
                                                                                  --set hostname=${HOSTNAME} \
                                                                                  --set rancherImageTag=${RANCHER_TAG_VERSION} \
                                                                                  --set rancherImage=${REGISTRY}/${RANCHER_IMAGE} \
                                                                                  --set 'extraEnv[0].name=CATTLE_AGENT_IMAGE' \
-                                                                                 --set "extraEnv[0].value=${STAGING_RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}" \
+                                                                                 --set "extraEnv[0].value=${RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}" \
                                                                                  --set systemDefaultRegistry=${REGISTRY} \
-                                                                                 --set bootstrapPassword=${BOOTSTRAP_PASSWORD} --devel
-
-elif [ -n "$PRIME_RANCHER_AGENT_IMAGE" ]; then
-    helm upgrade --install rancher rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
-                                                                                 --set hostname=${HOSTNAME} \
-                                                                                 --set rancherImage=${REGISTRY}/${PRIME_RANCHER_IMAGE} \
-                                                                                 --set rancherImageTag=${RANCHER_TAG_VERSION} \
-                                                                                 --set systemDefaultRegistry=${REGISTRY} \
-                                                                                 --set 'extraEnv[0].name=CATTLE_AGENT_IMAGE' \
-                                                                                 --set "extraEnv[0].value=${PRIME_RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}" \
                                                                                  --set bootstrapPassword=${BOOTSTRAP_PASSWORD} --devel
 
 else

--- a/framework/set/resources/registries/rke2/add-servers.sh
+++ b/framework/set/resources/registries/rke2/add-servers.sh
@@ -8,8 +8,7 @@ RKE2_TOKEN=$5
 RANCHER_IMAGE=$6
 RANCHER_TAG_VERSION=$7
 REGISTRY=$8
-STAGING_RANCHER_AGENT_IMAGE=${9:-}
-PRIME_RANCHER_AGENT_IMAGE=${10:-}
+RANCHER_AGENT_IMAGE=${9}
 
 set -e
 
@@ -47,16 +46,8 @@ EOF
 
 sudo systemctl restart docker && sudo systemctl daemon-reload
 
-if [ -n "$STAGING_RANCHER_AGENT_IMAGE" ] || [ -n "$PRIME_RANCHER_AGENT_IMAGE" ]; then
+if [ -n "$RANCHER_AGENT_IMAGE" ]; then
   sudo docker pull ${REGISTRY}/${RANCHER_IMAGE}:${RANCHER_TAG_VERSION}
-
-  if [ -n "$STAGING_RANCHER_AGENT_IMAGE" ]; then
-    sudo docker pull ${REGISTRY}/${STAGING_RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}
-  fi
-
-  if [ -n "$PRIME_RANCHER_AGENT_IMAGE" ]; then
-    sudo docker pull ${REGISTRY}/${PRIME_RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}
-  fi
-
+  sudo docker pull ${REGISTRY}/${RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}
   sudo systemctl restart rke2-server
 fi

--- a/framework/set/resources/registries/rke2/init-server.sh
+++ b/framework/set/resources/registries/rke2/init-server.sh
@@ -8,8 +8,7 @@ RKE2_TOKEN=$5
 RANCHER_IMAGE=$6
 RANCHER_TAG_VERSION=$7
 REGISTRY=$8
-STAGING_RANCHER_AGENT_IMAGE=${9:-}
-PRIME_RANCHER_AGENT_IMAGE=${10:-}
+RANCHER_AGENT_IMAGE=${9}
 
 set -e
 
@@ -46,17 +45,9 @@ EOF
 
 sudo systemctl restart docker && sudo systemctl daemon-reload
 
-if [ -n "$STAGING_RANCHER_AGENT_IMAGE" ] || [ -n "$PRIME_RANCHER_AGENT_IMAGE" ]; then
+if [ -n "$RANCHER_AGENT_IMAGE" ]; then
   sudo docker pull ${REGISTRY}/${RANCHER_IMAGE}:${RANCHER_TAG_VERSION}
-
-  if [ -n "$STAGING_RANCHER_AGENT_IMAGE" ]; then
-    sudo docker pull ${REGISTRY}/${STAGING_RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}
-  fi
-
-  if [ -n "$PRIME_RANCHER_AGENT_IMAGE" ]; then
-    sudo docker pull ${REGISTRY}/${PRIME_RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}
-  fi
-
+  sudo docker pull ${REGISTRY}/${RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}
   sudo systemctl restart rke2-server
 fi
 

--- a/framework/set/resources/sanity/rancher/setup.sh
+++ b/framework/set/resources/sanity/rancher/setup.sh
@@ -7,7 +7,7 @@ HOSTNAME=$4
 RANCHER_TAG_VERSION=$5
 BOOTSTRAP_PASSWORD=$6
 RANCHER_IMAGE=$7
-STAGING_RANCHER_AGENT_IMAGE=${8}
+RANCHER_AGENT_IMAGE=${8}
 
 set -ex
 
@@ -38,13 +38,13 @@ echo "Waiting 1 minute for Rancher"
 sleep 60
 
 echo "Installing Rancher"
-if [ -n "$STAGING_RANCHER_AGENT_IMAGE" ]; then
+if [ -n "$RANCHER_AGENT_IMAGE" ]; then
     helm upgrade --install rancher rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
                                                                                  --set hostname=${HOSTNAME} \
                                                                                  --set rancherImageTag=${RANCHER_TAG_VERSION} \
                                                                                  --set rancherImage=${RANCHER_IMAGE} \
                                                                                  --set 'extraEnv[0].name=CATTLE_AGENT_IMAGE' \
-                                                                                 --set "extraEnv[0].value=${STAGING_RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}" \
+                                                                                 --set "extraEnv[0].value=${RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}" \
                                                                                  --set bootstrapPassword=${BOOTSTRAP_PASSWORD} --devel
 
 else

--- a/framework/set/setAuthConfig.go
+++ b/framework/set/setAuthConfig.go
@@ -18,10 +18,10 @@ import (
 )
 
 // AuthConfig is a function that will set the main.tf file based on the auth provider.
-func AuthConfig(client *rancher.Client, testUser, testPassword string, configMap []map[string]any, newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File) error {
+func AuthConfig(rancherConfig *rancher.Config, testUser, testPassword string, configMap []map[string]any, newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File) error {
 	var err error
 
-	newFile, rootBody = resources.SetProvidersAndUsersTF(client, testUser, testPassword, true, newFile, rootBody, configMap, false)
+	newFile, rootBody = resources.SetProvidersAndUsersTF(rancherConfig, testUser, testPassword, true, newFile, rootBody, configMap, false)
 
 	rancherConfig, terraform, _ := config.LoadTFPConfigs(configMap[0])
 	authProvider := terraform.AuthProvider

--- a/framework/set/setConfigTF.go
+++ b/framework/set/setConfigTF.go
@@ -28,7 +28,7 @@ import (
 )
 
 // ConfigTF is a function that will set the main.tf file based on the module type.
-func ConfigTF(client *rancher.Client, testUser, testPassword string, rbacRole configuration.Role,
+func ConfigTF(client *rancher.Client, rancherConfig *rancher.Config, testUser, testPassword string, rbacRole configuration.Role,
 	configMap []map[string]any, newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File, isWindows, persistClusters, customModule bool,
 	customClusterNames []string) ([]string, []string, error) {
 	var err error
@@ -38,7 +38,7 @@ func ConfigTF(client *rancher.Client, testUser, testPassword string, rbacRole co
 	}
 
 	if !strings.Contains(string(newFile.Bytes()), defaults.RequiredProviders) {
-		newFile, rootBody = resources.SetProvidersAndUsersTF(client, testUser, testPassword, false, newFile, rootBody, configMap, customModule)
+		newFile, rootBody = resources.SetProvidersAndUsersTF(rancherConfig, testUser, testPassword, false, newFile, rootBody, configMap, customModule)
 	}
 
 	rootBody.AppendNewline()

--- a/tests/extensions/provisioning/buildModule.go
+++ b/tests/extensions/provisioning/buildModule.go
@@ -17,7 +17,7 @@ import (
 func BuildModule(t *testing.T, rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig, configMap []map[string]any) error {
 	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 
-	_, _, err := framework.ConfigTF(nil, "", "", "", configMap, nil, nil, nil, false, false, false, nil)
+	_, _, err := framework.ConfigTF(nil, rancherConfig, "", "", "", configMap, nil, nil, nil, false, false, false, nil)
 	if err != nil {
 		return err
 	}

--- a/tests/extensions/provisioning/kubernetesUpgrade.go
+++ b/tests/extensions/provisioning/kubernetesUpgrade.go
@@ -15,16 +15,16 @@ import (
 
 // KubernetesUpgrade is a function that will run terraform apply and uprade the
 // Kubernetes version of the provisioned cluster.
-func KubernetesUpgrade(t *testing.T, client *rancher.Client, terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig,
-	testUser, testPassword string, terraformOptions *terraform.Options, configMap []map[string]any, newFile *hclwrite.File,
-	rootBody *hclwrite.Body, file *os.File, isWindows bool) ([]string, []string) {
+func KubernetesUpgrade(t *testing.T, client *rancher.Client, rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig,
+	terratestConfig *config.TerratestConfig, testUser, testPassword string, terraformOptions *terraform.Options, configMap []map[string]any,
+	newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File, isWindows bool) ([]string, []string) {
 	var err error
 	var clusterNames []string
 	var clusterIDs []string
 
 	DefaultUpgradedK8sVersion(t, client, terratestConfig, terraformConfig, configMap)
 
-	clusterNames, customClusterNames, err := framework.ConfigTF(client, testUser, testPassword, "", configMap, newFile, rootBody, file, isWindows, false, false, nil)
+	clusterNames, customClusterNames, err := framework.ConfigTF(client, rancherConfig, testUser, testPassword, "", configMap, newFile, rootBody, file, isWindows, false, false, nil)
 	require.NoError(t, err)
 
 	terraform.Apply(t, terraformOptions)

--- a/tests/extensions/provisioning/provision.go
+++ b/tests/extensions/provisioning/provision.go
@@ -14,9 +14,9 @@ import (
 )
 
 // Provision is a function that will run terraform init and apply Terraform resources to provision a cluster.
-func Provision(t *testing.T, client *rancher.Client, terraformConfig *config.TerraformConfig, testUser, testPassword string,
-	terraformOptions *terraform.Options, configMap []map[string]any, newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File,
-	isWindows, persistClusters, containsCustomModule bool, customClusterNames []string) ([]string, []string) {
+func Provision(t *testing.T, client *rancher.Client, rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig, testUser,
+	testPassword string, terraformOptions *terraform.Options, configMap []map[string]any, newFile *hclwrite.File, rootBody *hclwrite.Body,
+	file *os.File, isWindows, persistClusters, containsCustomModule bool, customClusterNames []string) ([]string, []string) {
 	var err error
 	var clusterNames []string
 	var clusterIDs []string
@@ -24,7 +24,7 @@ func Provision(t *testing.T, client *rancher.Client, terraformConfig *config.Ter
 	isSupported := SupportedModules(terraformOptions, configMap)
 	require.True(t, isSupported)
 
-	clusterNames, customClusterNames, err = framework.ConfigTF(client, testUser, testPassword, "", configMap, newFile, rootBody, file, isWindows, persistClusters, containsCustomModule, customClusterNames)
+	clusterNames, customClusterNames, err = framework.ConfigTF(client, rancherConfig, testUser, testPassword, "", configMap, newFile, rootBody, file, isWindows, persistClusters, containsCustomModule, customClusterNames)
 	require.NoError(t, err)
 
 	terraform.InitAndApply(t, terraformOptions)

--- a/tests/extensions/provisioning/scale.go
+++ b/tests/extensions/provisioning/scale.go
@@ -14,10 +14,10 @@ import (
 
 // Scale is a function that will run terraform apply and scale the provisioned
 // cluster, according to user's desired amount.
-func Scale(t *testing.T, client *rancher.Client, terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig,
-	testUser, testPassword string, terraformOptions *terraform.Options, configMap []map[string]any, newFile *hclwrite.File,
-	rootBody *hclwrite.Body, file *os.File) {
-	_, _, err := framework.ConfigTF(client, testUser, testPassword, "", configMap, newFile, rootBody, file, false, false, false, nil)
+func Scale(t *testing.T, client *rancher.Client, rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig,
+	terratestConfig *config.TerratestConfig, testUser, testPassword string, terraformOptions *terraform.Options, configMap []map[string]any,
+	newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File) {
+	_, _, err := framework.ConfigTF(client, rancherConfig, testUser, testPassword, "", configMap, newFile, rootBody, file, false, false, false, nil)
 	require.NoError(t, err)
 
 	terraform.Apply(t, terraformOptions)

--- a/tests/extensions/rbac/authConfig.go
+++ b/tests/extensions/rbac/authConfig.go
@@ -13,12 +13,12 @@ import (
 )
 
 // AuthConfig is a function that will run terraform apply to setup authentication providers.
-func AuthConfig(t *testing.T, client *rancher.Client, terraformConfig *config.TerraformConfig, terraformOptions *terraform.Options, testUser, testPassword string,
+func AuthConfig(t *testing.T, rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig, terraformOptions *terraform.Options, testUser, testPassword string,
 	configMap []map[string]any, newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File) {
 	isSupported := SupportedAuthProviders(terraformConfig, terraformOptions)
 	require.True(t, isSupported)
 
-	err := framework.AuthConfig(client, testUser, testPassword, configMap, newFile, rootBody, file)
+	err := framework.AuthConfig(rancherConfig, testUser, testPassword, configMap, newFile, rootBody, file)
 	require.NoError(t, err)
 
 	terraform.InitAndApply(t, terraformOptions)

--- a/tests/extensions/rbac/rbac.go
+++ b/tests/extensions/rbac/rbac.go
@@ -16,7 +16,7 @@ import (
 func RBAC(t *testing.T, client *rancher.Client, rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig,
 	terratestConfig *config.TerratestConfig, testUser, testPassword string, terraformOptions *terraform.Options,
 	configMap []map[string]any, rbacRole config.Role, newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File) {
-	_, _, err := framework.ConfigTF(client, testUser, testPassword, rbacRole, configMap, newFile, rootBody, file, false, false, false, nil)
+	_, _, err := framework.ConfigTF(client, rancherConfig, testUser, testPassword, rbacRole, configMap, newFile, rootBody, file, false, false, false, nil)
 	require.NoError(t, err)
 
 	terraform.Apply(t, terraformOptions)

--- a/tests/infrastructure/README.md
+++ b/tests/infrastructure/README.md
@@ -81,7 +81,7 @@ terraform:
     repo: ""                                      # REQUIRED - fill with desired value
     rke2Group: ""                                 # REQUIRED - fill with group of the instance created
     rke2User: ""                                  # REQUIRED - fill with username of the instance created
-    stagingRancherAgentImage: ""                  # OPTIONAL - fill out only if you are using staging registry
+    rancherAgentImage: ""                         # OPTIONAL - fill out only if you are using staging registry
     rke2Version: ""                               # REQUIRED - fill with desired RKE2 k8s value (i.e. v1.30.6+rke2r1)
 ```
 
@@ -161,7 +161,7 @@ terraform:
     repo: ""                                      # REQUIRED - fill with desired value
     rke2Group: ""                                 # REQUIRED - fill with group of the instance created
     rke2User: ""                                  # REQUIRED - fill with username of the instance created
-    stagingRancherAgentImage: ""                  # OPTIONAL - fill out only if you are using staging registry
+    rancherAgentImage: ""                         # OPTIONAL - fill out only if you are using staging registry
     rke2Version: ""                               # REQUIRED - fill with desired RKE2 k8s value (i.e. v1.32.3)
 ```
 

--- a/tests/infrastructure/acceptEULA.go
+++ b/tests/infrastructure/acceptEULA.go
@@ -15,8 +15,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// AcceptEULA accepts the EULA for the Rancher server post installation
-func AcceptEULA(t *testing.T, session *session.Session, host string, showToken, isAirgap bool) (*rancher.Client, error) {
+// PostRancherSetup is a helper function that creates a Rancher client and accepts the EULA, if needed
+func PostRancherSetup(t *testing.T, session *session.Session, host string, showToken, isAirgap bool) (*rancher.Client, error) {
 	cattleConfig := shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
 	rancherConfig, _, _ := config.LoadTFPConfigs(cattleConfig)
 

--- a/tests/infrastructure/setup_airgap_rancher_test.go
+++ b/tests/infrastructure/setup_airgap_rancher_test.go
@@ -45,7 +45,7 @@ func (i *AirgapRancherTestSuite) TestCreateAirgapRancher() {
 	testSession := session.NewSession()
 	i.session = testSession
 
-	_, err = AcceptEULA(i.T(), i.session, i.terraformConfig.Standalone.AirgapInternalFQDN, true, true)
+	_, err = PostRancherSetup(i.T(), i.session, i.terraformConfig.Standalone.AirgapInternalFQDN, true, true)
 	require.NoError(i.T(), err)
 }
 

--- a/tests/infrastructure/setup_proxy_rancher_test.go
+++ b/tests/infrastructure/setup_proxy_rancher_test.go
@@ -45,7 +45,7 @@ func (i *ProxyRancherTestSuite) TestCreateProxyRancher() {
 	testSession := session.NewSession()
 	i.session = testSession
 
-	_, err = AcceptEULA(i.T(), i.session, i.terraformConfig.Standalone.RancherHostname, true, false)
+	_, err = PostRancherSetup(i.T(), i.session, i.terraformConfig.Standalone.RancherHostname, true, false)
 	require.NoError(i.T(), err)
 }
 

--- a/tests/infrastructure/setup_rancher_ipv6_test.go
+++ b/tests/infrastructure/setup_rancher_ipv6_test.go
@@ -44,7 +44,7 @@ func (i *RancherIPv6TestSuite) TestCreateRancherIPv6() {
 	testSession := session.NewSession()
 	i.session = testSession
 
-	_, err = AcceptEULA(i.T(), i.session, i.terraformConfig.Standalone.AirgapInternalFQDN, true, false)
+	_, err = PostRancherSetup(i.T(), i.session, i.terraformConfig.Standalone.AirgapInternalFQDN, true, false)
 	require.NoError(i.T(), err)
 }
 

--- a/tests/infrastructure/setup_rancher_test.go
+++ b/tests/infrastructure/setup_rancher_test.go
@@ -46,7 +46,7 @@ func (i *RancherTestSuite) TestCreateRancher() {
 		testSession := session.NewSession()
 		i.session = testSession
 
-		_, err = AcceptEULA(i.T(), i.session, i.terraformConfig.Standalone.RancherHostname, true, false)
+		_, err = PostRancherSetup(i.T(), i.session, i.terraformConfig.Standalone.RancherHostname, true, false)
 		require.NoError(i.T(), err)
 	}
 }

--- a/tests/rancher2/nodescaling/scale_hosted_test.go
+++ b/tests/rancher2/nodescaling/scale_hosted_test.go
@@ -75,13 +75,13 @@ func (s *ScaleHostedTestSuite) TestTfpScaleHosted() {
 			adminClient, err := provisioning.FetchAdminClient(s.T(), s.client)
 			require.NoError(s.T(), err)
 
-			clusterIDs, _ := provisioning.Provision(s.T(), s.client, s.terraformConfig, testUser, testPassword, s.terraformOptions, configMap, newFile, rootBody, file, false, false, false, nil)
+			clusterIDs, _ := provisioning.Provision(s.T(), s.client, s.rancherConfig, s.terraformConfig, testUser, testPassword, s.terraformOptions, configMap, newFile, rootBody, file, false, false, false, nil)
 			provisioning.VerifyClustersState(s.T(), adminClient, clusterIDs)
 
 			_, err = operations.ReplaceValue([]string{"terratest", "nodepools"}, s.terratestConfig.ScalingInput.ScaledUpNodepools, configMap[0])
 			require.NoError(s.T(), err)
 
-			provisioning.Scale(s.T(), s.client, s.terraformConfig, s.terratestConfig, testUser, testPassword, s.terraformOptions, configMap, newFile, rootBody, file)
+			provisioning.Scale(s.T(), s.client, s.rancherConfig, s.terraformConfig, s.terratestConfig, testUser, testPassword, s.terraformOptions, configMap, newFile, rootBody, file)
 
 			time.Sleep(4 * time.Minute)
 
@@ -91,7 +91,7 @@ func (s *ScaleHostedTestSuite) TestTfpScaleHosted() {
 			_, err = operations.ReplaceValue([]string{"terratest", "nodepools"}, s.terratestConfig.ScalingInput.ScaledDownNodepools, configMap[0])
 			require.NoError(s.T(), err)
 
-			provisioning.Scale(s.T(), s.client, s.terraformConfig, s.terratestConfig, testUser, testPassword, s.terraformOptions, configMap, newFile, rootBody, file)
+			provisioning.Scale(s.T(), s.client, s.rancherConfig, s.terraformConfig, s.terratestConfig, testUser, testPassword, s.terraformOptions, configMap, newFile, rootBody, file)
 
 			time.Sleep(4 * time.Minute)
 

--- a/tests/rancher2/os/os_test.go
+++ b/tests/rancher2/os/os_test.go
@@ -126,7 +126,7 @@ func (p *OSValidationTestSuite) TestDynamicOSValidation() {
 				logrus.Infof("Provisioning Cluster Type: %s, "+"K8s Version: %s, "+"CNI: %s", terraformConfig.Module, terratestConfig.KubernetesVersion, terraformConfig.CNI)
 			}
 
-			clusterIDs, _ = provisioning.Provision(p.T(), p.client, p.terraformConfig, testUser, testPassword, p.terraformOptions, batch, newFile, rootBody, file, false, false, true, customClusterNames)
+			clusterIDs, _ = provisioning.Provision(p.T(), p.client, p.rancherConfig, p.terraformConfig, testUser, testPassword, p.terraformOptions, batch, newFile, rootBody, file, false, false, true, customClusterNames)
 			time.Sleep(2 * time.Minute)
 			provisioning.VerifyClustersState(p.T(), p.client, clusterIDs)
 		})

--- a/tests/rancher2/provisioning/provision_custom_test.go
+++ b/tests/rancher2/provisioning/provision_custom_test.go
@@ -76,7 +76,7 @@ func (p *ProvisionCustomTestSuite) TestTfpProvisionCustom() {
 
 		provisioning.GetK8sVersion(p.T(), p.client, p.terratestConfig, p.terraformConfig, configs.DefaultK8sVersion, configMap)
 
-		_, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
 
 		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion
 
@@ -87,11 +87,11 @@ func (p *ProvisionCustomTestSuite) TestTfpProvisionCustom() {
 			adminClient, err := provisioning.FetchAdminClient(p.T(), p.client)
 			require.NoError(p.T(), err)
 
-			clusterIDs, customClusterNames := provisioning.Provision(p.T(), p.client, terraform, testUser, testPassword, p.terraformOptions, configMap, newFile, rootBody, file, false, false, true, customClusterNames)
+			clusterIDs, customClusterNames := provisioning.Provision(p.T(), p.client, rancher, terraform, testUser, testPassword, p.terraformOptions, configMap, newFile, rootBody, file, false, false, true, customClusterNames)
 			provisioning.VerifyClustersState(p.T(), adminClient, clusterIDs)
 
 			if strings.Contains(terraform.Module, modules.CustomEC2RKE2Windows) {
-				clusterIDs, _ = provisioning.Provision(p.T(), p.client, terraform, testUser, testPassword, p.terraformOptions, configMap, newFile, rootBody, file, true, true, true, customClusterNames)
+				clusterIDs, _ = provisioning.Provision(p.T(), p.client, rancher, terraform, testUser, testPassword, p.terraformOptions, configMap, newFile, rootBody, file, true, true, true, customClusterNames)
 				provisioning.VerifyClustersState(p.T(), adminClient, clusterIDs)
 			}
 		})
@@ -121,6 +121,8 @@ func (p *ProvisionCustomTestSuite) TestTfpProvisionCustomDynamicInput() {
 
 		provisioning.GetK8sVersion(p.T(), p.client, p.terratestConfig, p.terraformConfig, configs.DefaultK8sVersion, configMap)
 
+		rancher, terraform, _ := config.LoadTFPConfigs(configMap[0])
+
 		tt.name = tt.name + " Module: " + p.terraformConfig.Module + " Kubernetes version: " + p.terratestConfig.KubernetesVersion
 
 		p.Run((tt.name), func() {
@@ -130,11 +132,11 @@ func (p *ProvisionCustomTestSuite) TestTfpProvisionCustomDynamicInput() {
 			adminClient, err := provisioning.FetchAdminClient(p.T(), p.client)
 			require.NoError(p.T(), err)
 
-			clusterIDs, customClusterNames := provisioning.Provision(p.T(), p.client, p.terraformConfig, testUser, testPassword, p.terraformOptions, configMap, newFile, rootBody, file, false, false, true, customClusterNames)
+			clusterIDs, customClusterNames := provisioning.Provision(p.T(), p.client, rancher, terraform, testUser, testPassword, p.terraformOptions, configMap, newFile, rootBody, file, false, false, true, customClusterNames)
 			provisioning.VerifyClustersState(p.T(), adminClient, clusterIDs)
 
 			if strings.Contains(p.terraformConfig.Module, modules.CustomEC2RKE2Windows) {
-				clusterIDs, _ = provisioning.Provision(p.T(), p.client, p.terraformConfig, testUser, testPassword, p.terraformOptions, configMap, newFile, rootBody, file, true, true, true, customClusterNames)
+				clusterIDs, _ = provisioning.Provision(p.T(), p.client, rancher, terraform, testUser, testPassword, p.terraformOptions, configMap, newFile, rootBody, file, true, true, true, customClusterNames)
 				provisioning.VerifyClustersState(p.T(), adminClient, clusterIDs)
 			}
 		})

--- a/tests/rancher2/provisioning/provision_hosted_test.go
+++ b/tests/rancher2/provisioning/provision_hosted_test.go
@@ -73,7 +73,7 @@ func (p *ProvisionHostedTestSuite) TestTfpProvisionHosted() {
 			adminClient, err := provisioning.FetchAdminClient(p.T(), p.client)
 			require.NoError(p.T(), err)
 
-			clusterIDs, _ := provisioning.Provision(p.T(), p.client, p.terraformConfig, testUser, testPassword, p.terraformOptions, configMap, newFile, rootBody, file, false, false, false, nil)
+			clusterIDs, _ := provisioning.Provision(p.T(), p.client, p.rancherConfig, p.terraformConfig, testUser, testPassword, p.terraformOptions, configMap, newFile, rootBody, file, false, false, false, nil)
 			provisioning.VerifyClustersState(p.T(), adminClient, clusterIDs)
 			provisioning.VerifyKubernetesVersion(p.T(), adminClient, clusterIDs[0], p.terratestConfig.KubernetesVersion, p.terraformConfig.Module)
 		})

--- a/tests/rancher2/provisioning/provision_import_test.go
+++ b/tests/rancher2/provisioning/provision_import_test.go
@@ -72,7 +72,7 @@ func (p *ProvisionImportTestSuite) TestTfpProvisionImport() {
 		_, err = operations.ReplaceValue([]string{"terraform", "module"}, tt.module, configMap[0])
 		require.NoError(p.T(), err)
 
-		_, terraform, _ := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, _ := config.LoadTFPConfigs(configMap[0])
 
 		p.Run((tt.name), func() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
@@ -81,7 +81,7 @@ func (p *ProvisionImportTestSuite) TestTfpProvisionImport() {
 			adminClient, err := provisioning.FetchAdminClient(p.T(), p.client)
 			require.NoError(p.T(), err)
 
-			clusterIDs, _ := provisioning.Provision(p.T(), p.client, terraform, testUser, testPassword, p.terraformOptions, configMap, newFile, rootBody, file, false, false, true, nil)
+			clusterIDs, _ := provisioning.Provision(p.T(), p.client, rancher, terraform, testUser, testPassword, p.terraformOptions, configMap, newFile, rootBody, file, false, false, true, nil)
 			provisioning.VerifyClustersState(p.T(), adminClient, clusterIDs)
 		})
 	}
@@ -109,6 +109,8 @@ func (p *ProvisionImportTestSuite) TestTfpProvisionImportDynamicInput() {
 
 		provisioning.GetK8sVersion(p.T(), p.client, p.terratestConfig, p.terraformConfig, configs.DefaultK8sVersion, configMap)
 
+		rancher, terraform, _ := config.LoadTFPConfigs(configMap[0])
+
 		tt.name = tt.name + " Module: " + p.terraformConfig.Module + " Kubernetes version: " + p.terratestConfig.KubernetesVersion
 
 		p.Run((tt.name), func() {
@@ -118,7 +120,7 @@ func (p *ProvisionImportTestSuite) TestTfpProvisionImportDynamicInput() {
 			adminClient, err := provisioning.FetchAdminClient(p.T(), p.client)
 			require.NoError(p.T(), err)
 
-			clusterIDs, _ := provisioning.Provision(p.T(), p.client, p.terraformConfig, testUser, testPassword, p.terraformOptions, configMap, newFile, rootBody, file, false, false, true, nil)
+			clusterIDs, _ := provisioning.Provision(p.T(), p.client, rancher, terraform, testUser, testPassword, p.terraformOptions, configMap, newFile, rootBody, file, false, false, true, nil)
 			provisioning.VerifyClustersState(p.T(), adminClient, clusterIDs)
 		})
 	}

--- a/tests/rancher2/provisioning/provision_test.go
+++ b/tests/rancher2/provisioning/provision_test.go
@@ -73,7 +73,7 @@ func (p *ProvisionTestSuite) TestTfpProvision() {
 
 		provisioning.GetK8sVersion(p.T(), p.client, p.terratestConfig, p.terraformConfig, configs.DefaultK8sVersion, configMap)
 
-		_, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
 
 		tt.name = tt.name + " Module: " + p.terraformConfig.Module + " Kubernetes version: " + terratest.KubernetesVersion
 
@@ -84,7 +84,7 @@ func (p *ProvisionTestSuite) TestTfpProvision() {
 			adminClient, err := provisioning.FetchAdminClient(p.T(), p.client)
 			require.NoError(p.T(), err)
 
-			clusterIDs, _ := provisioning.Provision(p.T(), p.client, terraform, testUser, testPassword, p.terraformOptions, configMap, newFile, rootBody, file, false, false, false, nil)
+			clusterIDs, _ := provisioning.Provision(p.T(), p.client, rancher, terraform, testUser, testPassword, p.terraformOptions, configMap, newFile, rootBody, file, false, false, false, nil)
 			provisioning.VerifyClustersState(p.T(), adminClient, clusterIDs)
 		})
 	}
@@ -112,7 +112,7 @@ func (p *ProvisionTestSuite) TestTfpProvisionDynamicInput() {
 
 		provisioning.GetK8sVersion(p.T(), p.client, p.terratestConfig, p.terraformConfig, configs.DefaultK8sVersion, configMap)
 
-		_, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
 
 		tt.name = tt.name + " Module: " + p.terraformConfig.Module + " Kubernetes version: " + terratest.KubernetesVersion
 
@@ -123,7 +123,7 @@ func (p *ProvisionTestSuite) TestTfpProvisionDynamicInput() {
 			adminClient, err := provisioning.FetchAdminClient(p.T(), p.client)
 			require.NoError(p.T(), err)
 
-			clusterIDs, _ := provisioning.Provision(p.T(), p.client, terraform, testUser, testPassword, p.terraformOptions, configMap, newFile, rootBody, file, false, false, false, nil)
+			clusterIDs, _ := provisioning.Provision(p.T(), p.client, rancher, terraform, testUser, testPassword, p.terraformOptions, configMap, newFile, rootBody, file, false, false, false, nil)
 			provisioning.VerifyClustersState(p.T(), adminClient, clusterIDs)
 		})
 	}

--- a/tests/rancher2/psact/psact_test.go
+++ b/tests/rancher2/psact/psact_test.go
@@ -79,7 +79,7 @@ func (p *PSACTTestSuite) TestTfpPSACT() {
 
 		provisioning.GetK8sVersion(p.T(), p.client, p.terratestConfig, p.terraformConfig, configs.DefaultK8sVersion, configMap)
 
-		_, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
 
 		tt.name = tt.name + " Module: " + p.terraformConfig.Module + " Kubernetes version: " + terratest.KubernetesVersion
 
@@ -90,7 +90,7 @@ func (p *PSACTTestSuite) TestTfpPSACT() {
 			adminClient, err := provisioning.FetchAdminClient(p.T(), p.client)
 			require.NoError(p.T(), err)
 
-			clusterIDs, _ := provisioning.Provision(p.T(), p.client, terraform, testUser, testPassword, p.terraformOptions, configMap, newFile, rootBody, file, false, false, false, nil)
+			clusterIDs, _ := provisioning.Provision(p.T(), p.client, rancher, terraform, testUser, testPassword, p.terraformOptions, configMap, newFile, rootBody, file, false, false, false, nil)
 			provisioning.VerifyClustersState(p.T(), adminClient, clusterIDs)
 			provisioning.VerifyClusterPSACT(p.T(), p.client, clusterIDs)
 		})

--- a/tests/rancher2/rbac/auth_test.go
+++ b/tests/rancher2/rbac/auth_test.go
@@ -74,13 +74,13 @@ func (r *AuthConfigTestSuite) TestTfpAuthConfig() {
 		_, err = operations.ReplaceValue([]string{"terraform", "authProvider"}, tt.authProvider, configMap[0])
 		require.NoError(r.T(), err)
 
-		_, terraform, _ := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, _ := config.LoadTFPConfigs(configMap[0])
 
 		r.Run((tt.name), func() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 			defer cleanup.Cleanup(r.T(), r.terraformOptions, keyPath)
 
-			rbac.AuthConfig(r.T(), r.client, terraform, r.terraformOptions, testUser, testPassword, configMap, newFile, rootBody, file)
+			rbac.AuthConfig(r.T(), rancher, terraform, r.terraformOptions, testUser, testPassword, configMap, newFile, rootBody, file)
 		})
 	}
 
@@ -112,13 +112,13 @@ func (r *AuthConfigTestSuite) TestTfpAuthConfigDynamicInput() {
 		_, err = operations.ReplaceValue([]string{"terraform", "authProvider"}, r.terraformConfig.AuthProvider, configMap[0])
 		require.NoError(r.T(), err)
 
-		_, terraform, _ := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, _ := config.LoadTFPConfigs(configMap[0])
 
 		r.Run((tt.name), func() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 			defer cleanup.Cleanup(r.T(), r.terraformOptions, keyPath)
 
-			rbac.AuthConfig(r.T(), r.client, terraform, r.terraformOptions, testUser, testPassword, configMap, newFile, rootBody, file)
+			rbac.AuthConfig(r.T(), rancher, terraform, r.terraformOptions, testUser, testPassword, configMap, newFile, rootBody, file)
 		})
 	}
 

--- a/tests/rancher2/rbac/rbac_test.go
+++ b/tests/rancher2/rbac/rbac_test.go
@@ -75,7 +75,7 @@ func (r *RBACTestSuite) TestTfpRBAC() {
 
 		provisioning.GetK8sVersion(r.T(), r.client, r.terratestConfig, r.terraformConfig, configs.DefaultK8sVersion, configMap)
 
-		_, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
 
 		tt.name = tt.name + " Module: " + r.terraformConfig.Module
 
@@ -86,9 +86,9 @@ func (r *RBACTestSuite) TestTfpRBAC() {
 			adminClient, err := provisioning.FetchAdminClient(r.T(), r.client)
 			require.NoError(r.T(), err)
 
-			clusterIDs, _ := provisioning.Provision(r.T(), adminClient, terraform, testUser, testPassword, r.terraformOptions, configMap, newFile, rootBody, file, false, false, false, nil)
+			clusterIDs, _ := provisioning.Provision(r.T(), adminClient, rancher, terraform, testUser, testPassword, r.terraformOptions, configMap, newFile, rootBody, file, false, false, false, nil)
 			provisioning.VerifyClustersState(r.T(), adminClient, clusterIDs)
-			rb.RBAC(r.T(), r.client, r.rancherConfig, terraform, terratest, testUser, testPassword, r.terraformOptions, configMap, tt.rbacRole, newFile, rootBody, file)
+			rb.RBAC(r.T(), r.client, rancher, terraform, terratest, testUser, testPassword, r.terraformOptions, configMap, tt.rbacRole, newFile, rootBody, file)
 		})
 	}
 

--- a/tests/rancher2/snapshot/snapshot.go
+++ b/tests/rancher2/snapshot/snapshot.go
@@ -55,8 +55,9 @@ const (
 
 // snapshotRestore creates workloads, takes a snapshot of the cluster, restores the cluster and verifies the workloads created after
 // a snapshot no longer are present in the cluster
-func snapshotRestore(t *testing.T, client *rancher.Client, terraformConfig *config.TerraformConfig, testUser, testPassword string, terraformOptions *terraform.Options,
-	configMap []map[string]any, newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File) {
+func snapshotRestore(t *testing.T, client *rancher.Client, rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig, testUser,
+	testPassword string, terraformOptions *terraform.Options, configMap []map[string]any, newFile *hclwrite.File, rootBody *hclwrite.Body,
+	file *os.File) {
 	initialWorkloadName := namegen.AppendRandomString(initialWorkload)
 
 	clusterID, err := clusters.GetClusterIDByName(client, terraformConfig.ResourcePrefix)
@@ -70,10 +71,10 @@ func snapshotRestore(t *testing.T, client *rancher.Client, terraformConfig *conf
 
 	deploymentResp, serviceResp := createWorkloads(t, client, clusterID, podTemplate, initialWorkloadName, isCattleLabeled, DeploymentSteveType)
 
-	snapshotName, postDeploymentResp, postServiceResp, err := snapshotV2Prov(t, client, terraformConfig, podTemplate, testUser, testPassword, clusterID, terraformOptions, configMap, newFile, rootBody, file)
+	snapshotName, postDeploymentResp, postServiceResp, err := snapshotV2Prov(t, client, rancherConfig, terraformConfig, podTemplate, testUser, testPassword, clusterID, terraformOptions, configMap, newFile, rootBody, file)
 	require.NoError(t, err)
 
-	restoreV2Prov(t, client, terraformConfig, snapshotName, testUser, testPassword, clusterID, terraformOptions, configMap, newFile, rootBody, file)
+	restoreV2Prov(t, client, rancherConfig, terraformConfig, snapshotName, testUser, testPassword, clusterID, terraformOptions, configMap, newFile, rootBody, file)
 
 	_, err = steveclient.SteveType(DeploymentSteveType).ByID(postDeploymentResp.ID)
 	require.Error(t, err)
@@ -90,13 +91,13 @@ func snapshotRestore(t *testing.T, client *rancher.Client, terraformConfig *conf
 }
 
 // snapshotV2Prov takes a snapshot of the cluster and creates a deployment and service in the cluster.
-func snapshotV2Prov(t *testing.T, client *rancher.Client, terraformConfig *config.TerraformConfig, podTemplate corev1.PodTemplateSpec,
-	testUser, testPassword, clusterID string, terraformOptions *terraform.Options, configMap []map[string]any, newFile *hclwrite.File,
-	rootBody *hclwrite.Body, file *os.File) (string, *steveV1.SteveAPIObject, *steveV1.SteveAPIObject, error) {
+func snapshotV2Prov(t *testing.T, client *rancher.Client, rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig,
+	podTemplate corev1.PodTemplateSpec, testUser, testPassword, clusterID string, terraformOptions *terraform.Options, configMap []map[string]any,
+	newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File) (string, *steveV1.SteveAPIObject, *steveV1.SteveAPIObject, error) {
 	_, err := operations.ReplaceValue([]string{"terratest", "snapshotInput", "createSnapshot"}, true, configMap[0])
 	require.NoError(t, err)
 
-	_, _, err = framework.ConfigTF(client, testUser, testPassword, "", configMap, newFile, rootBody, file, false, false, false, nil)
+	_, _, err = framework.ConfigTF(client, rancherConfig, testUser, testPassword, "", configMap, newFile, rootBody, file, false, false, false, nil)
 	require.NoError(t, err)
 
 	terraform.Apply(t, terraformOptions)
@@ -117,9 +118,9 @@ func snapshotV2Prov(t *testing.T, client *rancher.Client, terraformConfig *confi
 }
 
 // restoreV2Prov restores the cluster to the previous state after a snapshot is taken.
-func restoreV2Prov(t *testing.T, client *rancher.Client, terraformConfig *config.TerraformConfig, snapshotName, testUser, testPassword string,
-	clusterID string, terraformOptions *terraform.Options, configMap []map[string]any, newFile *hclwrite.File, rootBody *hclwrite.Body,
-	file *os.File) {
+func restoreV2Prov(t *testing.T, client *rancher.Client, rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig, snapshotName,
+	testUser, testPassword string, clusterID string, terraformOptions *terraform.Options, configMap []map[string]any, newFile *hclwrite.File,
+	rootBody *hclwrite.Body, file *os.File) {
 	_, err := operations.ReplaceValue([]string{"terratest", "snapshotInput", "createSnapshot"}, false, configMap[0])
 	require.NoError(t, err)
 
@@ -129,7 +130,7 @@ func restoreV2Prov(t *testing.T, client *rancher.Client, terraformConfig *config
 	_, err = operations.ReplaceValue([]string{"terratest", "snapshotInput", "snapshotName"}, snapshotName, configMap[0])
 	require.NoError(t, err)
 
-	_, _, err = framework.ConfigTF(client, testUser, testPassword, "", configMap, newFile, rootBody, file, false, false, false, nil)
+	_, _, err = framework.ConfigTF(client, rancherConfig, testUser, testPassword, "", configMap, newFile, rootBody, file, false, false, false, nil)
 	require.NoError(t, err)
 
 	terraform.Apply(t, terraformOptions)

--- a/tests/rancher2/snapshot/snapshot_restore_test.go
+++ b/tests/rancher2/snapshot/snapshot_restore_test.go
@@ -85,7 +85,7 @@ func (s *SnapshotRestoreTestSuite) TestTfpSnapshotRestore() {
 
 		provisioning.GetK8sVersion(s.T(), s.client, s.terratestConfig, s.terraformConfig, configs.DefaultK8sVersion, configMap)
 
-		_, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
 
 		tt.name = tt.name + " Module: " + s.terraformConfig.Module + " Kubernetes version: " + terratest.KubernetesVersion
 
@@ -100,10 +100,10 @@ func (s *SnapshotRestoreTestSuite) TestTfpSnapshotRestore() {
 			adminClient, err := provisioning.FetchAdminClient(s.T(), s.client)
 			require.NoError(s.T(), err)
 
-			clusterIDs, _ := provisioning.Provision(s.T(), s.client, terraform, testUser, testPassword, s.terraformOptions, configMap, newFile, rootBody, file, false, false, false, nil)
+			clusterIDs, _ := provisioning.Provision(s.T(), s.client, rancher, terraform, testUser, testPassword, s.terraformOptions, configMap, newFile, rootBody, file, false, false, false, nil)
 			provisioning.VerifyClustersState(s.T(), adminClient, clusterIDs)
 
-			snapshotRestore(s.T(), s.client, terraform, testUser, testPassword, s.terraformOptions, configMap, newFile, rootBody, file)
+			snapshotRestore(s.T(), s.client, rancher, terraform, testUser, testPassword, s.terraformOptions, configMap, newFile, rootBody, file)
 			provisioning.VerifyClustersState(s.T(), adminClient, clusterIDs)
 		})
 	}

--- a/tests/rancher2/upgrading/kubernetes_hosted_test.go
+++ b/tests/rancher2/upgrading/kubernetes_hosted_test.go
@@ -74,10 +74,10 @@ func (k *KubernetesUpgradeHostedTestSuite) TestTfpKubernetesUpgradeHosted() {
 			adminClient, err := provisioning.FetchAdminClient(k.T(), k.client)
 			require.NoError(k.T(), err)
 
-			clusterIDs, _ := provisioning.Provision(k.T(), k.client, k.terraformConfig, testUser, testPassword, k.terraformOptions, configMap, newFile, rootBody, file, false, false, false, nil)
+			clusterIDs, _ := provisioning.Provision(k.T(), k.client, k.rancherConfig, k.terraformConfig, testUser, testPassword, k.terraformOptions, configMap, newFile, rootBody, file, false, false, false, nil)
 			provisioning.VerifyClustersState(k.T(), adminClient, clusterIDs)
 
-			provisioning.KubernetesUpgrade(k.T(), k.client, k.terraformConfig, k.terratestConfig, testUser, testPassword, k.terraformOptions, configMap, newFile, rootBody, file, false)
+			provisioning.KubernetesUpgrade(k.T(), k.client, k.rancherConfig, k.terraformConfig, k.terratestConfig, testUser, testPassword, k.terraformOptions, configMap, newFile, rootBody, file, false)
 
 			time.Sleep(4 * time.Minute)
 

--- a/tests/rancher2/upgrading/kubernetes_upgrade_test.go
+++ b/tests/rancher2/upgrading/kubernetes_upgrade_test.go
@@ -73,7 +73,7 @@ func (k *KubernetesUpgradeTestSuite) TestTfpKubernetesUpgrade() {
 
 		provisioning.GetK8sVersion(k.T(), k.client, k.terratestConfig, k.terraformConfig, configs.SecondHighestVersion, configMap)
 
-		_, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
 
 		tt.name = tt.name + " Module: " + k.terraformConfig.Module + " Kubernetes version: " + terratest.KubernetesVersion
 
@@ -84,10 +84,10 @@ func (k *KubernetesUpgradeTestSuite) TestTfpKubernetesUpgrade() {
 			adminClient, err := provisioning.FetchAdminClient(k.T(), k.client)
 			require.NoError(k.T(), err)
 
-			clusterIDs, _ := provisioning.Provision(k.T(), k.client, terraform, testUser, testPassword, k.terraformOptions, configMap, newFile, rootBody, file, false, false, false, nil)
+			clusterIDs, _ := provisioning.Provision(k.T(), k.client, rancher, terraform, testUser, testPassword, k.terraformOptions, configMap, newFile, rootBody, file, false, false, false, nil)
 			provisioning.VerifyClustersState(k.T(), adminClient, clusterIDs)
 
-			provisioning.KubernetesUpgrade(k.T(), k.client, terraform, terratest, testUser, testPassword, k.terraformOptions, configMap, newFile, rootBody, file, false)
+			provisioning.KubernetesUpgrade(k.T(), k.client, rancher, terraform, terratest, testUser, testPassword, k.terraformOptions, configMap, newFile, rootBody, file, false)
 			provisioning.VerifyClustersState(k.T(), adminClient, clusterIDs)
 			provisioning.VerifyKubernetesVersion(k.T(), k.client, clusterIDs[0], terratest.KubernetesVersion, k.terraformConfig.Module)
 		})
@@ -116,7 +116,7 @@ func (k *KubernetesUpgradeTestSuite) TestTfpKubernetesUpgradeDynamicInput() {
 
 		provisioning.GetK8sVersion(k.T(), k.client, k.terratestConfig, k.terraformConfig, configs.DefaultK8sVersion, configMap)
 
-		_, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
 
 		tt.name = tt.name + " Module: " + k.terraformConfig.Module + " Kubernetes version: " + terratest.KubernetesVersion
 
@@ -127,10 +127,10 @@ func (k *KubernetesUpgradeTestSuite) TestTfpKubernetesUpgradeDynamicInput() {
 			adminClient, err := provisioning.FetchAdminClient(k.T(), k.client)
 			require.NoError(k.T(), err)
 
-			clusterIDs, _ := provisioning.Provision(k.T(), k.client, terraform, testUser, testPassword, k.terraformOptions, configMap, newFile, rootBody, file, false, false, false, nil)
+			clusterIDs, _ := provisioning.Provision(k.T(), k.client, rancher, terraform, testUser, testPassword, k.terraformOptions, configMap, newFile, rootBody, file, false, false, false, nil)
 			provisioning.VerifyClustersState(k.T(), adminClient, clusterIDs)
 
-			provisioning.KubernetesUpgrade(k.T(), k.client, terraform, terratest, testUser, testPassword, k.terraformOptions, configMap, newFile, rootBody, file, false)
+			provisioning.KubernetesUpgrade(k.T(), k.client, rancher, terraform, terratest, testUser, testPassword, k.terraformOptions, configMap, newFile, rootBody, file, false)
 			provisioning.VerifyClustersState(k.T(), adminClient, clusterIDs)
 			provisioning.VerifyKubernetesVersion(k.T(), k.client, clusterIDs[0], terratest.KubernetesVersion, k.terraformConfig.Module)
 		})

--- a/tests/registries/README.md
+++ b/tests/registries/README.md
@@ -100,7 +100,7 @@ Before running, be sure to run the following commands:
 
 ```yaml
 export RANCHER2_PROVIDER_VERSION=""
-'export CATTLE_TEST_CONFIG=<path/to/yaml>
+export CATTLE_TEST_CONFIG=<path/to/yaml>
 export LOCALS_PROVIDER_VERSION=""
 export CLOUD_PROVIDER_VERSION=""`
 ```

--- a/tests/registries/registries_test.go
+++ b/tests/registries/registries_test.go
@@ -62,7 +62,7 @@ func (r *TfpRegistriesTestSuite) SetupSuite() {
 	testSession := session.NewSession()
 	r.session = testSession
 
-	client, err := infrastructure.AcceptEULA(r.T(), testSession, r.terraformConfig.Standalone.RancherHostname, false, false)
+	client, err := infrastructure.PostRancherSetup(r.T(), testSession, r.terraformConfig.Standalone.RancherHostname, false, false)
 	require.NoError(r.T(), err)
 
 	r.client = client
@@ -94,6 +94,9 @@ func (r *TfpRegistriesTestSuite) TestTfpGlobalRegistry() {
 		configMap, err := provisioning.UniquifyTerraform([]map[string]any{r.cattleConfig})
 		require.NoError(r.T(), err)
 
+		_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, r.client.RancherConfig.AdminToken, configMap[0])
+		require.NoError(r.T(), err)
+
 		_, err = operations.ReplaceValue([]string{"terratest", "nodepools"}, tt.nodeRoles, configMap[0])
 		require.NoError(r.T(), err)
 
@@ -117,7 +120,7 @@ func (r *TfpRegistriesTestSuite) TestTfpGlobalRegistry() {
 
 		provisioning.GetK8sVersion(r.T(), r.client, r.terratestConfig, r.terraformConfig, configs.DefaultK8sVersion, configMap)
 
-		_, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
 
 		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion
 
@@ -125,7 +128,7 @@ func (r *TfpRegistriesTestSuite) TestTfpGlobalRegistry() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 			defer cleanup.Cleanup(r.T(), r.terraformOptions, keyPath)
 
-			clusterIDs, _ := provisioning.Provision(r.T(), r.client, terraform, testUser, testPassword, r.terraformOptions, configMap, newFile, rootBody, file, false, false, true, nil)
+			clusterIDs, _ := provisioning.Provision(r.T(), r.client, rancher, terraform, testUser, testPassword, r.terraformOptions, configMap, newFile, rootBody, file, false, false, true, nil)
 			provisioning.VerifyClustersState(r.T(), r.client, clusterIDs)
 			provisioning.VerifyRegistry(r.T(), r.client, clusterIDs[0], terraform)
 		})
@@ -158,6 +161,9 @@ func (r *TfpRegistriesTestSuite) TestTfpAuthenticatedRegistry() {
 		configMap, err := provisioning.UniquifyTerraform([]map[string]any{r.cattleConfig})
 		require.NoError(r.T(), err)
 
+		_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, r.client.RancherConfig.AdminToken, configMap[0])
+		require.NoError(r.T(), err)
+
 		_, err = operations.ReplaceValue([]string{"terratest", "nodepools"}, tt.nodeRoles, configMap[0])
 		require.NoError(r.T(), err)
 
@@ -175,7 +181,7 @@ func (r *TfpRegistriesTestSuite) TestTfpAuthenticatedRegistry() {
 
 		provisioning.GetK8sVersion(r.T(), r.client, r.terratestConfig, r.terraformConfig, configs.DefaultK8sVersion, configMap)
 
-		_, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
 
 		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion
 
@@ -183,7 +189,7 @@ func (r *TfpRegistriesTestSuite) TestTfpAuthenticatedRegistry() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 			defer cleanup.Cleanup(r.T(), r.terraformOptions, keyPath)
 
-			clusterIDs, _ := provisioning.Provision(r.T(), r.client, terraform, testUser, testPassword, r.terraformOptions, configMap, newFile, rootBody, file, false, false, true, nil)
+			clusterIDs, _ := provisioning.Provision(r.T(), r.client, rancher, terraform, testUser, testPassword, r.terraformOptions, configMap, newFile, rootBody, file, false, false, true, nil)
 			provisioning.VerifyClustersState(r.T(), r.client, clusterIDs)
 			provisioning.VerifyRegistry(r.T(), r.client, clusterIDs[0], terraform)
 		})
@@ -216,6 +222,9 @@ func (r *TfpRegistriesTestSuite) TestTfpNonAuthenticatedRegistry() {
 		configMap, err := provisioning.UniquifyTerraform([]map[string]any{r.cattleConfig})
 		require.NoError(r.T(), err)
 
+		_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, r.client.RancherConfig.AdminToken, configMap[0])
+		require.NoError(r.T(), err)
+
 		_, err = operations.ReplaceValue([]string{"terratest", "nodepools"}, tt.nodeRoles, configMap[0])
 		require.NoError(r.T(), err)
 
@@ -239,7 +248,7 @@ func (r *TfpRegistriesTestSuite) TestTfpNonAuthenticatedRegistry() {
 
 		provisioning.GetK8sVersion(r.T(), r.client, r.terratestConfig, r.terraformConfig, configs.DefaultK8sVersion, configMap)
 
-		_, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
 
 		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion
 
@@ -247,7 +256,7 @@ func (r *TfpRegistriesTestSuite) TestTfpNonAuthenticatedRegistry() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 			defer cleanup.Cleanup(r.T(), r.terraformOptions, keyPath)
 
-			clusterIDs, _ := provisioning.Provision(r.T(), r.client, terraform, testUser, testPassword, r.terraformOptions, configMap, newFile, rootBody, file, false, false, true, nil)
+			clusterIDs, _ := provisioning.Provision(r.T(), r.client, rancher, terraform, testUser, testPassword, r.terraformOptions, configMap, newFile, rootBody, file, false, false, true, nil)
 			provisioning.VerifyClustersState(r.T(), r.client, clusterIDs)
 			provisioning.VerifyRegistry(r.T(), r.client, clusterIDs[0], terraform)
 		})
@@ -278,6 +287,9 @@ func (r *TfpRegistriesTestSuite) TestTfpECRRegistry() {
 		configMap, err := provisioning.UniquifyTerraform([]map[string]any{r.cattleConfig})
 		require.NoError(r.T(), err)
 
+		_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, r.client.RancherConfig.AdminToken, configMap[0])
+		require.NoError(r.T(), err)
+
 		_, err = operations.ReplaceValue([]string{"terratest", "nodepools"}, tt.nodeRoles, configMap[0])
 		require.NoError(r.T(), err)
 
@@ -304,7 +316,7 @@ func (r *TfpRegistriesTestSuite) TestTfpECRRegistry() {
 
 		provisioning.GetK8sVersion(r.T(), r.client, r.terratestConfig, r.terraformConfig, configs.DefaultK8sVersion, configMap)
 
-		_, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
 
 		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion
 
@@ -312,7 +324,7 @@ func (r *TfpRegistriesTestSuite) TestTfpECRRegistry() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 			defer cleanup.Cleanup(r.T(), r.terraformOptions, keyPath)
 
-			clusterIDs, _ := provisioning.Provision(r.T(), r.client, terraform, testUser, testPassword, r.terraformOptions, configMap, newFile, rootBody, file, false, false, true, nil)
+			clusterIDs, _ := provisioning.Provision(r.T(), r.client, rancher, terraform, testUser, testPassword, r.terraformOptions, configMap, newFile, rootBody, file, false, false, true, nil)
 			provisioning.VerifyClustersState(r.T(), r.client, clusterIDs)
 			provisioning.VerifyRegistry(r.T(), r.client, clusterIDs[0], terraform)
 		})

--- a/tests/sanity/sanity_provisioning_test.go
+++ b/tests/sanity/sanity_provisioning_test.go
@@ -56,7 +56,7 @@ func (s *TfpSanityProvisioningTestSuite) SetupSuite() {
 	testSession := session.NewSession()
 	s.session = testSession
 
-	client, err := infrastructure.AcceptEULA(s.T(), testSession, s.terraformConfig.Standalone.RancherHostname, false, false)
+	client, err := infrastructure.PostRancherSetup(s.T(), testSession, s.terraformConfig.Standalone.RancherHostname, false, false)
 	require.NoError(s.T(), err)
 
 	s.client = client
@@ -89,6 +89,9 @@ func (s *TfpSanityProvisioningTestSuite) TestTfpProvisioningSanity() {
 		configMap, err := provisioning.UniquifyTerraform([]map[string]any{s.cattleConfig})
 		require.NoError(s.T(), err)
 
+		_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, s.client.RancherConfig.AdminToken, configMap[0])
+		require.NoError(s.T(), err)
+
 		_, err = operations.ReplaceValue([]string{"terratest", "nodepools"}, tt.nodeRoles, configMap[0])
 		require.NoError(s.T(), err)
 
@@ -97,7 +100,7 @@ func (s *TfpSanityProvisioningTestSuite) TestTfpProvisioningSanity() {
 
 		provisioning.GetK8sVersion(s.T(), s.client, s.terratestConfig, s.terraformConfig, configs.DefaultK8sVersion, configMap)
 
-		_, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
 
 		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion
 
@@ -105,11 +108,11 @@ func (s *TfpSanityProvisioningTestSuite) TestTfpProvisioningSanity() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, "")
 			defer cleanup.Cleanup(s.T(), s.terraformOptions, keyPath)
 
-			clusterIDs, customClusterNames := provisioning.Provision(s.T(), s.client, terraform, testUser, testPassword, s.terraformOptions, configMap, newFile, rootBody, file, false, false, true, customClusterNames)
+			clusterIDs, customClusterNames := provisioning.Provision(s.T(), s.client, rancher, terraform, testUser, testPassword, s.terraformOptions, configMap, newFile, rootBody, file, false, false, true, customClusterNames)
 			provisioning.VerifyClustersState(s.T(), s.client, clusterIDs)
 
 			if strings.Contains(terraform.Module, modules.CustomEC2RKE2Windows) {
-				clusterIDs, _ := provisioning.Provision(s.T(), s.client, terraform, testUser, testPassword, s.terraformOptions, configMap, newFile, rootBody, file, true, true, true, customClusterNames)
+				clusterIDs, _ := provisioning.Provision(s.T(), s.client, rancher, terraform, testUser, testPassword, s.terraformOptions, configMap, newFile, rootBody, file, true, true, true, customClusterNames)
 				provisioning.VerifyClustersState(s.T(), s.client, clusterIDs)
 			}
 		})


### PR DESCRIPTION
### Issue: N/A

### PR Description
Sanity upgrade is showing an issue where after upgrading, it cannot login to Rancher. It appears the issue is due to the admin token post upgrade not being respected. Proxy and airgap Rancher don't have this issue, but realistically, they should all have this issue. Diving deeper, it was noted that `rancherConfig` is not properly being passed to the configMap, causing this issue.

This PR addresses that and fixing a found bug in the ECR registry noted during release testing.