### PR TITLE
Update Qase reporting per release line

### DIFF
--- a/.github/workflows/sanity-test.yaml
+++ b/.github/workflows/sanity-test.yaml
@@ -24,7 +24,11 @@ env:
   SUITE: TestTfpSanityProvisioningTestSuite$
   TERRAFORM_VERSION: "1.9.5"
   TIMEOUT: 2h
-  QASE_TEST_RUN_ID: "4512"
+  QASE_TEST_RUN_ID: ""
+  QASE_TEST_RUN_ID_2_9: "4540"
+  QASE_TEST_RUN_ID_2_10: "4542"
+  QASE_TEST_RUN_ID_2_11: "4541"
+  QASE_TEST_RUN_ID_2_12: "4512"
 
 jobs:
   v2-12-head:
@@ -49,17 +53,23 @@ jobs:
       - name: Uniquify hostname prefix
         uses: ./.github/actions/uniquify-hostname
 
-      - name: Set RANCHER_VERSION
+      - name: Set Rancher version
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
           value: head
 
-      - name: Set RKE2_VERSION
+      - name: Set RKE2 version
         uses: ./.github/actions/set-env-var
         with:
           key: RKE2_VERSION
           value: ${{ env.RKE2_VERSION_2_12 }}
+
+      - name: Set Qase Test Run ID
+        uses: ./.github/actions/set-env-var
+        with:
+          key: QASE_TEST_RUN_ID
+          value: ${{ env.QASE_TEST_RUN_ID_2_12 }}
 
       - name: Create config.yaml
         run: |
@@ -184,17 +194,23 @@ jobs:
       - name: Uniquify hostname prefix
         uses: ./.github/actions/uniquify-hostname
 
-      - name: Set RANCHER_VERSION
+      - name: Set Rancher version
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
           value: v2.11-head
 
-      - name: Set RKE2_VERSION
+      - name: Set RKE2 version
         uses: ./.github/actions/set-env-var
         with:
           key: RKE2_VERSION
           value: ${{ env.RKE2_VERSION_2_11 }}
+
+      - name: Set Qase Test Run ID
+        uses: ./.github/actions/set-env-var
+        with:
+          key: QASE_TEST_RUN_ID
+          value: ${{ env.QASE_TEST_RUN_ID_2_11 }}
 
       - name: Create config.yaml
         run: |
@@ -319,17 +335,23 @@ jobs:
       - name: Uniquify hostname prefix
         uses: ./.github/actions/uniquify-hostname
 
-      - name: Set RANCHER_VERSION
+      - name: Set Rancher version
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
           value: v2.10-head
 
-      - name: Set RKE2_VERSION
+      - name: Set RKE2 version
         uses: ./.github/actions/set-env-var
         with:
           key: RKE2_VERSION
           value: ${{ env.RKE2_VERSION_2_10 }}
+
+      - name: Set Qase Test Run ID
+        uses: ./.github/actions/set-env-var
+        with:
+          key: QASE_TEST_RUN_ID
+          value: ${{ env.QASE_TEST_RUN_ID_2_10 }}
 
       - name: Create config.yaml
         run: |
@@ -455,17 +477,23 @@ jobs:
       - name: Uniquify hostname prefix
         uses: ./.github/actions/uniquify-hostname
 
-      - name: Set RANCHER_VERSION
+      - name: Set Rancher version
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
           value: v2.9-head
 
-      - name: Set RKE2_VERSION
+      - name: Set RKE2 version
         uses: ./.github/actions/set-env-var
         with:
           key: RKE2_VERSION
           value: ${{ env.RKE2_VERSION_2_9 }}
+
+      - name: Set Qase Test Run ID
+        uses: ./.github/actions/set-env-var
+        with:
+          key: QASE_TEST_RUN_ID
+          value: ${{ env.QASE_TEST_RUN_ID_2_9 }}
 
       - name: Create config.yaml
         run: |

--- a/tests/sanity/sanity_provisioning_test.go
+++ b/tests/sanity/sanity_provisioning_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/rancher/shepherd/clients/rancher"
@@ -102,7 +103,8 @@ func (s *TfpSanityProvisioningTestSuite) TestTfpProvisioningSanity() {
 
 		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
 
-		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion
+		currentDate := time.Now().Format("2006-01-02 03:04PM")
+		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion + " " + currentDate
 
 		s.Run((tt.name), func() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, s.terratestConfig.PathToRepo, "")


### PR DESCRIPTION
### Issue: N/A

### Description
As discussed offline, per recurring runs ongoing work, we will need to ensure that we have respective Qase IDs per each release in the cycle. This PR does that.