### PR TITLE
implement recurring runs for proxy + proxy upgrade suites

### DIFF
--- a/.github/actions/revoke-runner-ip/action.yaml
+++ b/.github/actions/revoke-runner-ip/action.yaml
@@ -1,0 +1,89 @@
+name: "Revoke Runner IP"
+description: "Remove runner IP from AWS prefix list"
+inputs:
+  prefix-list-id:
+    description: "AWS prefix list ID"
+    required: true
+  region:
+    description: "AWS region"
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      run: |
+        set -euo pipefail
+
+        RUNNER_IPV4=$(curl -4 -s https://checkip.amazonaws.com)
+        REGION="${{ inputs.region }}"
+        PREFIX_LIST_ID="${{ inputs.prefix-list-id }}"
+
+        echo "::add-mask::$RUNNER_IPV4"
+        echo "::add-mask::$PREFIX_LIST_ID"
+
+        remove_ip_from_prefix_list() {
+          local prefix_list_id=$1
+          local cidr=$2
+
+          local max_retries=10
+          local attempt=1
+
+          while true; do
+            current_version=$(aws ec2 describe-managed-prefix-lists \
+              --prefix-list-ids "$prefix_list_id" \
+              --region "$REGION" \
+              --query "PrefixLists[0].Version" --output text)
+
+            ip_exists=$(aws ec2 get-managed-prefix-list-entries \
+              --prefix-list-id "$prefix_list_id" \
+              --region "$REGION" \
+              --query "Entries[?Cidr=='$cidr'] | length(@)" \
+              --output text)
+
+            if [[ "$ip_exists" == "0" ]]; then
+              echo "Runner IP not present in prefix list, Skipping..."
+              break
+            else
+              echo "Removing runner from prefix list (attempt $attempt)..."
+              set +e
+              output=$(aws ec2 modify-managed-prefix-list \
+                --prefix-list-id "$prefix_list_id" \
+                --region "$REGION" \
+                --current-version "$current_version" \
+                --remove-entries "Cidr=$cidr" 2>&1)
+              exit_code=$?
+
+              if [[ $exit_code -eq 0 ]]; then
+                prefix_list_id_out=$(echo "$output" | jq -r '.PrefixList.PrefixListId')
+                prefix_list_arn_out=$(echo "$output" | jq -r '.PrefixList.PrefixListArn')
+
+                echo "::add-mask::$prefix_list_id_out"
+                echo "::add-mask::$prefix_list_arn_out"
+
+                echo "Runner successfully removed from prefix list."
+                break
+              else
+                if echo "$output" | grep -q "PrefixListVersionMismatch"; then
+                  echo "Version mismatch detected, retrying..."
+                  ((attempt++))
+                elif echo "$output" | grep -q "IncorrectState"; then
+                  echo "Prefix list modify in progress, retrying..."
+                  ((attempt++))
+                else
+                  echo "Error removing runner: $output"
+                  exit $exit_code
+                fi
+
+                if (( attempt > max_retries )); then
+                  echo "Max retries reached, failed."
+                  exit $exit_code
+                fi
+
+                sleep 2
+                continue
+              fi
+            fi
+          done
+        }
+
+        remove_ip_from_prefix_list "$PREFIX_LIST_ID" "$RUNNER_IPV4/32"

--- a/.github/actions/whitelist-runner-ip/action.yaml
+++ b/.github/actions/whitelist-runner-ip/action.yaml
@@ -1,0 +1,89 @@
+name: "Whitelist Runner IP"
+description: "Add runner IP to AWS prefix list"
+inputs:
+  prefix-list-id:
+    description: "AWS prefix list ID"
+    required: true
+  region:
+    description: "AWS region"
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      run: |
+        set -euo pipefail
+
+        RUNNER_IPV4=$(curl -4 -s https://checkip.amazonaws.com)
+        REGION="${{ inputs.region }}"
+        PREFIX_LIST_ID="${{ inputs.prefix-list-id }}"
+
+        echo "::add-mask::$RUNNER_IPV4"
+        echo "::add-mask::$PREFIX_LIST_ID"
+
+        add_ip_to_prefix_list() {
+          local prefix_list_id=$1
+          local cidr=$2
+
+          local max_retries=10
+          local attempt=1
+
+          while true; do
+            current_version=$(aws ec2 describe-managed-prefix-lists \
+              --prefix-list-ids "$prefix_list_id" \
+              --region "$REGION" \
+              --query "PrefixLists[0].Version" --output text)
+
+            ip_exists=$(aws ec2 get-managed-prefix-list-entries \
+              --prefix-list-id "$prefix_list_id" \
+              --region "$REGION" \
+              --query "Entries[?Cidr=='$cidr'] | length(@)" \
+              --output text)
+
+            if [[ "$ip_exists" == "0" ]]; then
+              echo "Adding runner to prefix list (attempt $attempt)..."
+              set +e
+              output=$(aws ec2 modify-managed-prefix-list \
+                --prefix-list-id "$prefix_list_id" \
+                --region "$REGION" \
+                --current-version "$current_version" \
+                --add-entries "Cidr=$cidr,Description=TFP_GitHubRunner" 2>&1)
+              exit_code=$?
+
+              if [[ $exit_code -eq 0 ]]; then
+                prefix_list_id_out=$(echo "$output" | jq -r '.PrefixList.PrefixListId')
+                prefix_list_arn_out=$(echo "$output" | jq -r '.PrefixList.PrefixListArn')
+
+                echo "::add-mask::$prefix_list_id_out"
+                echo "::add-mask::$prefix_list_arn_out"
+
+                echo "Runner successfully added to prefix list."
+                break
+              else
+                if echo "$output" | grep -q "PrefixListVersionMismatch"; then
+                  echo "Version mismatch detected, retrying..."
+                  ((attempt++))
+                elif echo "$output" | grep -q "IncorrectState"; then
+                  echo "Prefix list modify in progress, retrying..."
+                  ((attempt++))
+                else
+                  echo "Error adding runner: $output"
+                  exit $exit_code
+                fi
+
+                if (( attempt > max_retries )); then
+                  echo "Max retries reached, failed."
+                  exit $exit_code
+                fi
+
+                sleep 5
+                continue
+              fi
+            else
+              echo "Runner already present in prefix list. Skipping..."
+              break
+            fi
+          done
+        }
+
+        add_ip_to_prefix_list "$PREFIX_LIST_ID" "$RUNNER_IPV4/32"

--- a/.github/workflows/pr-sanity-test.yaml
+++ b/.github/workflows/pr-sanity-test.yaml
@@ -14,7 +14,7 @@ env:
   RANCHER2_PROVIDER_VERSION: "7.0.0"
   RKE_PROVIDER_VERSION: "1.7.0"
   RKE2_VERSION: "v1.32.4+rke2r1"
-  SUITE: TestTfpSanityProvisioningTestSuite$
+  SUITE: ^TestTfpSanityProvisioningTestSuite$
   TERRAFORM_VERSION: "1.12.1"
   TIMEOUT: 2h
   QASE_TEST_RUN_ID: "4512"

--- a/.github/workflows/recurring-proxy-test.yaml
+++ b/.github/workflows/recurring-proxy-test.yaml
@@ -1,27 +1,29 @@
-name: Recurring Sanity Upgrade Test
+name: Recurring Proxy Test
 
 on:
   schedule:
-    - cron: "0 8 * * 1"
+    - cron: "0 9 * * 1"
   workflow_dispatch:
 
 env:
+  AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
+  AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+  AWS_DEFAULT_REGION: "${{ secrets.AWS_REGION }}"
   CLOUD_PROVIDER_VERSION: "5.95.0"
-  HOSTNAME_PREFIX: tfp-sanity
+  HOSTNAME_PREFIX: tfp-proxy
   LOCALS_PROVIDER_VERSION: "2.5.2"
-  PACKAGE: sanity
+  PACKAGE: proxy
   RANCHER_VERSION: ""
   RANCHER2_PROVIDER_VERSION: "7.0.0"
   RKE_PROVIDER_VERSION: "1.7.0"
   RKE2_VERSION: ""
-  RKE2_VERSION_2_9: v1.30.12+rke2r1
-  RKE2_VERSION_2_10: v1.31.8+rke2r1
-  RKE2_VERSION_2_11: v1.32.4+rke2r1
-  RKE2_VERSION_2_12: v1.32.4+rke2r1
-  SUITE: ^TestTfpSanityUpgradeRancherTestSuite$
+  RKE2_VERSION_2_9: v1.30.12
+  RKE2_VERSION_2_10: v1.31.8
+  RKE2_VERSION_2_11: v1.32.4
+  RKE2_VERSION_2_12: v1.32.4
+  SUITE: ^TestTfpProxyProvisioningTestSuite$
   TERRAFORM_VERSION: "1.12.1"
   TIMEOUT: 2h
-  UPGRADED_RANCHER_VERSION: ""
   QASE_TEST_RUN_ID: ""
   QASE_TEST_RUN_ID_2_9: "4540"
   QASE_TEST_RUN_ID_2_10: "4542"
@@ -30,7 +32,7 @@ env:
 
 jobs:
   v2-12-head:
-    name: v2.11.2 -> v2.12-head
+    name: v2.12-head
     runs-on: ubuntu-latest
     environment: latest
 
@@ -39,6 +41,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - name: Whitelist Runner IP
+        uses: ./.github/actions/whitelist-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -55,12 +63,6 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: v2.11.2
-
-      - name: Set upgraded Rancher version
-        uses: ./.github/actions/set-env-var
-        with:
-          key: UPGRADED_RANCHER_VERSION
           value: head
 
       - name: Set RKE2 version
@@ -90,6 +92,8 @@ jobs:
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
             windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
+            proxy:
+              proxyBastion: ""
             awsCredentials:
               awsAccessKey: "${{ secrets.AWS_ACCESS_KEY_ID }}"
               awsSecretKey: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
@@ -99,7 +103,7 @@ jobs:
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               region: "${{ secrets.AWS_REGION }}"
-              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
+              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PROXY }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
               awsVpcID: "${{ secrets.AWS_VPC_ID }}"
@@ -128,10 +132,10 @@ jobs:
               rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ env.RKE2_VERSION }}"
-              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL}}"
-              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherRepo: "${{ secrets.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION}}"
+            standaloneRegistry:
+              registryName: "${{ secrets.REGISTRY_NAME }}"
+              registryPassword: "${{ secrets.REGISTRY_PASSWORD }}"
+              registryUsername: "${{ secrets.REGISTRY_USERNAME }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             nodeCount: ${{ vars.NODE_COUNT }}
@@ -159,7 +163,7 @@ jobs:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false
 
-      - name: Run Sanity Upgrade Test Suite
+      - name: Run Proxy Test Suite
         uses: ./.github/actions/run-test-suite
         with:
           package: ${{ env.PACKAGE }}
@@ -180,8 +184,15 @@ jobs:
           slack-channel: ${{ secrets.SLACK_CHANNEL }}
           slack-token: ${{ secrets.SLACK_TOKEN }}
 
+      - name: Revoke Runner IP
+        if: always()
+        uses: ./.github/actions/revoke-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"
+
   v2-11-head:
-    name: v2.11.2 -> v2.11-head
+    name: v2.11-head
     runs-on: ubuntu-latest
     environment: latest
 
@@ -190,6 +201,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - name: Whitelist Runner IP
+        uses: ./.github/actions/whitelist-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -202,19 +219,13 @@ jobs:
       - name: Uniquify hostname prefix
         uses: ./.github/actions/uniquify-hostname
 
-      - name: Set Rancher version
+      - name: Set RANCHER_VERSION
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: v2.11.2
-
-      - name: Set upgraded Rancher version
-        uses: ./.github/actions/set-env-var
-        with:
-          key: UPGRADED_RANCHER_VERSION
           value: v2.11-head
 
-      - name: Set RKE2 version
+      - name: Set RKE2_VERSION
         uses: ./.github/actions/set-env-var
         with:
           key: RKE2_VERSION
@@ -241,6 +252,8 @@ jobs:
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
             windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
+            proxy:
+              proxyBastion: ""
             awsCredentials:
               awsAccessKey: "${{ secrets.AWS_ACCESS_KEY_ID }}"
               awsSecretKey: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
@@ -250,7 +263,7 @@ jobs:
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               region: "${{ secrets.AWS_REGION }}"
-              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
+              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PROXY }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
               awsVpcID: "${{ secrets.AWS_VPC_ID }}"
@@ -279,10 +292,10 @@ jobs:
               rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ env.RKE2_VERSION }}"
-              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL}}"
-              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherRepo: "${{ secrets.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION}}"
+            standaloneRegistry:
+              registryName: "${{ secrets.REGISTRY_NAME }}"
+              registryPassword: "${{ secrets.REGISTRY_PASSWORD }}"
+              registryUsername: "${{ secrets.REGISTRY_USERNAME }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             nodeCount: ${{ vars.NODE_COUNT }}
@@ -310,7 +323,7 @@ jobs:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false
 
-      - name: Run Sanity Upgrade Test Suite
+      - name: Run Proxy Test Suite
         uses: ./.github/actions/run-test-suite
         with:
           package: ${{ env.PACKAGE }}
@@ -331,16 +344,29 @@ jobs:
           slack-channel: ${{ secrets.SLACK_CHANNEL }}
           slack-token: ${{ secrets.SLACK_TOKEN }}
 
+      - name: Revoke Runner IP
+        if: always()
+        uses: ./.github/actions/revoke-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"
+
   v2-10-head:
-    name: v2.10.6 -> v2.10-head
+    name: v2.10-head
     runs-on: ubuntu-latest
-    environment: upgrade-prime-staging
+    environment: staging-latest
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - name: Whitelist Runner IP
+        uses: ./.github/actions/whitelist-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -353,19 +379,13 @@ jobs:
       - name: Uniquify hostname prefix
         uses: ./.github/actions/uniquify-hostname
 
-      - name: Set Rancher version
+      - name: Set RANCHER_VERSION
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: v2.10.6
-
-      - name: Set upgraded Rancher version
-        uses: ./.github/actions/set-env-var
-        with:
-          key: UPGRADED_RANCHER_VERSION
           value: v2.10-head
 
-      - name: Set RKE2 version
+      - name: Set RKE2_VERSION
         uses: ./.github/actions/set-env-var
         with:
           key: RKE2_VERSION
@@ -392,6 +412,8 @@ jobs:
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
             windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
+            proxy:
+              proxyBastion: ""
             awsCredentials:
               awsAccessKey: "${{ secrets.AWS_ACCESS_KEY_ID }}"
               awsSecretKey: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
@@ -401,7 +423,7 @@ jobs:
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               region: "${{ secrets.AWS_REGION }}"
-              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
+              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PROXY }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
               awsVpcID: "${{ secrets.AWS_VPC_ID }}"
@@ -424,18 +446,17 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
-              rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
+              rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
               rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ env.RKE2_VERSION }}"
-              upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
-              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL}}"
-              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherRepo: "${{ secrets.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION}}"
+            standaloneRegistry:
+              registryName: "${{ secrets.REGISTRY_NAME }}"
+              registryPassword: "${{ secrets.REGISTRY_PASSWORD }}"
+              registryUsername: "${{ secrets.REGISTRY_USERNAME }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             nodeCount: ${{ vars.NODE_COUNT }}
@@ -463,7 +484,7 @@ jobs:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false
 
-      - name: Run Sanity Upgrade Test Suite
+      - name: Run Proxy Test Suite
         uses: ./.github/actions/run-test-suite
         with:
           package: ${{ env.PACKAGE }}
@@ -484,16 +505,29 @@ jobs:
           slack-channel: ${{ secrets.SLACK_CHANNEL }}
           slack-token: ${{ secrets.SLACK_TOKEN }}
 
+      - name: Revoke Runner IP
+        if: always()
+        uses: ./.github/actions/revoke-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"
+
   v2-9-head:
-    name: v2.9.10 -> v2.9-head
+    name: v2.9-head
     runs-on: ubuntu-latest
-    environment: upgrade-prime-staging
+    environment: staging-latest
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - name: Whitelist Runner IP
+        uses: ./.github/actions/whitelist-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -506,19 +540,13 @@ jobs:
       - name: Uniquify hostname prefix
         uses: ./.github/actions/uniquify-hostname
 
-      - name: Set Rancher version
+      - name: Set RANCHER_VERSION
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: v2.9.10
-
-      - name: Set upgraded Rancher version
-        uses: ./.github/actions/set-env-var
-        with:
-          key: UPGRADED_RANCHER_VERSION
           value: v2.9-head
 
-      - name: Set RKE2 version
+      - name: Set RKE2_VERSION
         uses: ./.github/actions/set-env-var
         with:
           key: RKE2_VERSION
@@ -545,6 +573,8 @@ jobs:
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
             windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
+            proxy:
+              proxyBastion: ""
             awsCredentials:
               awsAccessKey: "${{ secrets.AWS_ACCESS_KEY_ID }}"
               awsSecretKey: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
@@ -554,7 +584,7 @@ jobs:
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               region: "${{ secrets.AWS_REGION }}"
-              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
+              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PROXY }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
               awsVpcID: "${{ secrets.AWS_VPC_ID }}"
@@ -577,18 +607,17 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
-              rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
+              rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
               rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ env.RKE2_VERSION }}"
-              upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
-              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL}}"
-              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherRepo: "${{ secrets.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION}}"
+            standaloneRegistry:
+              registryName: "${{ secrets.REGISTRY_NAME }}"
+              registryPassword: "${{ secrets.REGISTRY_PASSWORD }}"
+              registryUsername: "${{ secrets.REGISTRY_USERNAME }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             nodeCount: ${{ vars.NODE_COUNT }}
@@ -616,7 +645,7 @@ jobs:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false
 
-      - name: Run Sanity Upgrade Test Suite
+      - name: Run Proxy Test Suite
         uses: ./.github/actions/run-test-suite
         with:
           package: ${{ env.PACKAGE }}
@@ -636,3 +665,10 @@ jobs:
           job-status: ${{ job.status }}
           slack-channel: ${{ secrets.SLACK_CHANNEL }}
           slack-token: ${{ secrets.SLACK_TOKEN }}
+
+      - name: Revoke Runner IP
+        if: always()
+        uses: ./.github/actions/revoke-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"

--- a/.github/workflows/recurring-proxy-upgrade-test.yaml
+++ b/.github/workflows/recurring-proxy-upgrade-test.yaml
@@ -1,24 +1,27 @@
-name: Recurring Sanity Upgrade Test
+name: Recurring Proxy Upgrade Test
 
 on:
   schedule:
-    - cron: "0 8 * * 1"
+    - cron: "0 9 * * 1"
   workflow_dispatch:
 
 env:
+  AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
+  AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+  AWS_DEFAULT_REGION: "${{ secrets.AWS_REGION }}"
   CLOUD_PROVIDER_VERSION: "5.95.0"
-  HOSTNAME_PREFIX: tfp-sanity
+  HOSTNAME_PREFIX: tfp-proxy-up
   LOCALS_PROVIDER_VERSION: "2.5.2"
-  PACKAGE: sanity
+  PACKAGE: proxy
   RANCHER_VERSION: ""
   RANCHER2_PROVIDER_VERSION: "7.0.0"
   RKE_PROVIDER_VERSION: "1.7.0"
   RKE2_VERSION: ""
-  RKE2_VERSION_2_9: v1.30.12+rke2r1
-  RKE2_VERSION_2_10: v1.31.8+rke2r1
-  RKE2_VERSION_2_11: v1.32.4+rke2r1
-  RKE2_VERSION_2_12: v1.32.4+rke2r1
-  SUITE: ^TestTfpSanityUpgradeRancherTestSuite$
+  RKE2_VERSION_2_9: v1.30.12
+  RKE2_VERSION_2_10: v1.31.8
+  RKE2_VERSION_2_11: v1.32.4
+  RKE2_VERSION_2_12: v1.32.4
+  SUITE: ^TestTfpProxyUpgradeRancherTestSuite$
   TERRAFORM_VERSION: "1.12.1"
   TIMEOUT: 2h
   UPGRADED_RANCHER_VERSION: ""
@@ -39,6 +42,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - name: Whitelist Runner IP
+        uses: ./.github/actions/whitelist-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -90,6 +99,8 @@ jobs:
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
             windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
+            proxy:
+              proxyBastion: ""
             awsCredentials:
               awsAccessKey: "${{ secrets.AWS_ACCESS_KEY_ID }}"
               awsSecretKey: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
@@ -99,7 +110,7 @@ jobs:
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               region: "${{ secrets.AWS_REGION }}"
-              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
+              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PROXY }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
               awsVpcID: "${{ secrets.AWS_VPC_ID }}"
@@ -128,10 +139,14 @@ jobs:
               rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ env.RKE2_VERSION }}"
-              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL}}"
-              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
+              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
               upgradedRancherRepo: "${{ secrets.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION}}"
+              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
+              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
+            standaloneRegistry:
+              registryName: "${{ secrets.REGISTRY_NAME }}"
+              registryPassword: "${{ secrets.REGISTRY_PASSWORD }}"
+              registryUsername: "${{ secrets.REGISTRY_USERNAME }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             nodeCount: ${{ vars.NODE_COUNT }}
@@ -159,7 +174,7 @@ jobs:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false
 
-      - name: Run Sanity Upgrade Test Suite
+      - name: Run Proxy Upgrade Test Suite
         uses: ./.github/actions/run-test-suite
         with:
           package: ${{ env.PACKAGE }}
@@ -180,6 +195,13 @@ jobs:
           slack-channel: ${{ secrets.SLACK_CHANNEL }}
           slack-token: ${{ secrets.SLACK_TOKEN }}
 
+      - name: Revoke Runner IP
+        if: always()
+        uses: ./.github/actions/revoke-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"
+
   v2-11-head:
     name: v2.11.2 -> v2.11-head
     runs-on: ubuntu-latest
@@ -190,6 +212,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - name: Whitelist Runner IP
+        uses: ./.github/actions/whitelist-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -214,7 +242,7 @@ jobs:
           key: UPGRADED_RANCHER_VERSION
           value: v2.11-head
 
-      - name: Set RKE2 version
+      - name: Set RKE2_VERSION
         uses: ./.github/actions/set-env-var
         with:
           key: RKE2_VERSION
@@ -241,6 +269,8 @@ jobs:
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
             windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
+            proxy:
+              proxyBastion: ""
             awsCredentials:
               awsAccessKey: "${{ secrets.AWS_ACCESS_KEY_ID }}"
               awsSecretKey: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
@@ -250,7 +280,7 @@ jobs:
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               region: "${{ secrets.AWS_REGION }}"
-              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
+              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PROXY }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
               awsVpcID: "${{ secrets.AWS_VPC_ID }}"
@@ -279,10 +309,14 @@ jobs:
               rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ env.RKE2_VERSION }}"
-              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL}}"
-              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
+              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
               upgradedRancherRepo: "${{ secrets.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION}}"
+              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
+              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
+            standaloneRegistry:
+              registryName: "${{ secrets.REGISTRY_NAME }}"
+              registryPassword: "${{ secrets.REGISTRY_PASSWORD }}"
+              registryUsername: "${{ secrets.REGISTRY_USERNAME }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             nodeCount: ${{ vars.NODE_COUNT }}
@@ -310,7 +344,7 @@ jobs:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false
 
-      - name: Run Sanity Upgrade Test Suite
+      - name: Run Proxy Upgrade Test Suite
         uses: ./.github/actions/run-test-suite
         with:
           package: ${{ env.PACKAGE }}
@@ -331,6 +365,13 @@ jobs:
           slack-channel: ${{ secrets.SLACK_CHANNEL }}
           slack-token: ${{ secrets.SLACK_TOKEN }}
 
+      - name: Revoke Runner IP
+        if: always()
+        uses: ./.github/actions/revoke-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"
+
   v2-10-head:
     name: v2.10.6 -> v2.10-head
     runs-on: ubuntu-latest
@@ -341,6 +382,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - name: Whitelist Runner IP
+        uses: ./.github/actions/whitelist-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -365,7 +412,7 @@ jobs:
           key: UPGRADED_RANCHER_VERSION
           value: v2.10-head
 
-      - name: Set RKE2 version
+      - name: Set RKE2_VERSION
         uses: ./.github/actions/set-env-var
         with:
           key: RKE2_VERSION
@@ -392,6 +439,8 @@ jobs:
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
             windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
+            proxy:
+              proxyBastion: ""
             awsCredentials:
               awsAccessKey: "${{ secrets.AWS_ACCESS_KEY_ID }}"
               awsSecretKey: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
@@ -401,7 +450,7 @@ jobs:
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               region: "${{ secrets.AWS_REGION }}"
-              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
+              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PROXY }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
               awsVpcID: "${{ secrets.AWS_VPC_ID }}"
@@ -424,18 +473,22 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
-              rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
+              rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
               rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ env.RKE2_VERSION }}"
-              upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
-              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL}}"
-              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
+              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
               upgradedRancherRepo: "${{ secrets.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION}}"
+              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
+              upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
+              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
+            standaloneRegistry:
+              registryName: "${{ secrets.REGISTRY_NAME }}"
+              registryPassword: "${{ secrets.REGISTRY_PASSWORD }}"
+              registryUsername: "${{ secrets.REGISTRY_USERNAME }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             nodeCount: ${{ vars.NODE_COUNT }}
@@ -463,7 +516,7 @@ jobs:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false
 
-      - name: Run Sanity Upgrade Test Suite
+      - name: Run Proxy Upgrade Test Suite
         uses: ./.github/actions/run-test-suite
         with:
           package: ${{ env.PACKAGE }}
@@ -484,6 +537,13 @@ jobs:
           slack-channel: ${{ secrets.SLACK_CHANNEL }}
           slack-token: ${{ secrets.SLACK_TOKEN }}
 
+      - name: Revoke Runner IP
+        if: always()
+        uses: ./.github/actions/revoke-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"
+
   v2-9-head:
     name: v2.9.10 -> v2.9-head
     runs-on: ubuntu-latest
@@ -494,6 +554,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - name: Whitelist Runner IP
+        uses: ./.github/actions/whitelist-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -518,7 +584,7 @@ jobs:
           key: UPGRADED_RANCHER_VERSION
           value: v2.9-head
 
-      - name: Set RKE2 version
+      - name: Set RKE2_VERSION
         uses: ./.github/actions/set-env-var
         with:
           key: RKE2_VERSION
@@ -545,6 +611,8 @@ jobs:
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
             windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
+            proxy:
+              proxyBastion: ""
             awsCredentials:
               awsAccessKey: "${{ secrets.AWS_ACCESS_KEY_ID }}"
               awsSecretKey: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
@@ -554,7 +622,7 @@ jobs:
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               region: "${{ secrets.AWS_REGION }}"
-              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
+              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PROXY }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
               awsVpcID: "${{ secrets.AWS_VPC_ID }}"
@@ -577,18 +645,22 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
-              rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
+              rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
               rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ env.RKE2_VERSION }}"
-              upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
-              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL}}"
-              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
+              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
               upgradedRancherRepo: "${{ secrets.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION}}"
+              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
+              upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
+              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
+            standaloneRegistry:
+              registryName: "${{ secrets.REGISTRY_NAME }}"
+              registryPassword: "${{ secrets.REGISTRY_PASSWORD }}"
+              registryUsername: "${{ secrets.REGISTRY_USERNAME }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             nodeCount: ${{ vars.NODE_COUNT }}
@@ -616,7 +688,7 @@ jobs:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false
 
-      - name: Run Sanity Upgrade Test Suite
+      - name: Run Proxy Upgrade Test Suite
         uses: ./.github/actions/run-test-suite
         with:
           package: ${{ env.PACKAGE }}
@@ -636,3 +708,10 @@ jobs:
           job-status: ${{ job.status }}
           slack-channel: ${{ secrets.SLACK_CHANNEL }}
           slack-token: ${{ secrets.SLACK_TOKEN }}
+
+      - name: Revoke Runner IP
+        if: always()
+        uses: ./.github/actions/revoke-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"

--- a/.github/workflows/recurring-sanity-test.yaml
+++ b/.github/workflows/recurring-sanity-test.yaml
@@ -18,7 +18,7 @@ env:
   RKE2_VERSION_2_10: v1.31.8+rke2r1
   RKE2_VERSION_2_11: v1.32.4+rke2r1
   RKE2_VERSION_2_12: v1.32.4+rke2r1
-  SUITE: TestTfpSanityProvisioningTestSuite$
+  SUITE: ^TestTfpSanityProvisioningTestSuite$
   TERRAFORM_VERSION: "1.12.1"
   TIMEOUT: 2h
   QASE_TEST_RUN_ID: ""
@@ -313,7 +313,7 @@ jobs:
   v2-10-head:
     name: v2.10-head
     runs-on: ubuntu-latest
-    environment: staging-alpha
+    environment: staging-latest
 
     steps:
       - name: Checkout repository
@@ -455,7 +455,7 @@ jobs:
   v2-9-head:
     name: v2.9-head
     runs-on: ubuntu-latest
-    environment: staging-alpha
+    environment: staging-latest
 
     steps:
       - name: Checkout repository

--- a/framework/set/resources/upgrade/createMainTF.go
+++ b/framework/set/resources/upgrade/createMainTF.go
@@ -61,7 +61,7 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 		terraform.InitAndApply(t, terraformOptions)
 	case terraformConfig.Standalone.UpgradeProxyRancher:
 		logrus.Infof("Upgrading Proxy Rancher...")
-		_, err := proxy.UpgradeProxiedRancher(file, newFile, rootBody, terraformConfig, terratestConfig, proxyNode, serverNode)
+		_, err := proxy.UpgradeProxiedRancher(file, newFile, rootBody, terraformConfig, terratestConfig, serverNode, proxyNode)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
GHA workflows to support weekly recurring runs for proxy + proxy upgrade `tfp-automation` tests.

Also, made a small semantic update to sanity workflow environments.