### PR TITLE
Add if always to reporting steps for GHA

### DIFF
--- a/.github/workflows/pr-sanity-test.yaml
+++ b/.github/workflows/pr-sanity-test.yaml
@@ -1,3 +1,4 @@
+---
 name: PR Sanity Test
 
 on:
@@ -137,6 +138,7 @@ jobs:
           timeout: ${{ env.TIMEOUT }}
 
       - name: Reporting Results to Qase
+        if: always()
         uses: ./.github/actions/report-to-qase
         with:
           qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}

--- a/.github/workflows/recurring-proxy-test.yaml
+++ b/.github/workflows/recurring-proxy-test.yaml
@@ -1,3 +1,4 @@
+---
 name: Recurring Proxy Test
 
 on:
@@ -172,6 +173,7 @@ jobs:
           timeout: ${{ env.TIMEOUT }}
 
       - name: Reporting Results to Qase
+        if: always()
         uses: ./.github/actions/report-to-qase
         with:
           qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
@@ -332,6 +334,7 @@ jobs:
           timeout: ${{ env.TIMEOUT }}
 
       - name: Reporting Results to Qase
+        if: always()
         uses: ./.github/actions/report-to-qase
         with:
           qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
@@ -493,6 +496,7 @@ jobs:
           timeout: ${{ env.TIMEOUT }}
 
       - name: Reporting Results to Qase
+        if: always()
         uses: ./.github/actions/report-to-qase
         with:
           qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
@@ -654,6 +658,7 @@ jobs:
           timeout: ${{ env.TIMEOUT }}
 
       - name: Reporting Results to Qase
+        if: always()
         uses: ./.github/actions/report-to-qase
         with:
           qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}

--- a/.github/workflows/recurring-proxy-upgrade-test.yaml
+++ b/.github/workflows/recurring-proxy-upgrade-test.yaml
@@ -1,3 +1,4 @@
+---
 name: Recurring Proxy Upgrade Test
 
 on:
@@ -183,6 +184,7 @@ jobs:
           timeout: ${{ env.TIMEOUT }}
 
       - name: Reporting Results to Qase
+        if: always()
         uses: ./.github/actions/report-to-qase
         with:
           qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
@@ -353,6 +355,7 @@ jobs:
           timeout: ${{ env.TIMEOUT }}
 
       - name: Reporting Results to Qase
+        if: always()
         uses: ./.github/actions/report-to-qase
         with:
           qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
@@ -525,6 +528,7 @@ jobs:
           timeout: ${{ env.TIMEOUT }}
 
       - name: Reporting Results to Qase
+        if: always()
         uses: ./.github/actions/report-to-qase
         with:
           qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
@@ -697,6 +701,7 @@ jobs:
           timeout: ${{ env.TIMEOUT }}
 
       - name: Reporting Results to Qase
+        if: always()
         uses: ./.github/actions/report-to-qase
         with:
           qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}

--- a/.github/workflows/recurring-sanity-test.yaml
+++ b/.github/workflows/recurring-sanity-test.yaml
@@ -1,3 +1,4 @@
+---
 name: Recurring Sanity Test
 
 on:
@@ -157,6 +158,7 @@ jobs:
           timeout: ${{ env.TIMEOUT }}
 
       - name: Reporting Results to Qase
+        if: always()
         uses: ./.github/actions/report-to-qase
         with:
           qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
@@ -298,6 +300,7 @@ jobs:
           timeout: ${{ env.TIMEOUT }}
 
       - name: Reporting Results to Qase
+        if: always()
         uses: ./.github/actions/report-to-qase
         with:
           qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
@@ -440,6 +443,7 @@ jobs:
           timeout: ${{ env.TIMEOUT }}
 
       - name: Reporting Results to Qase
+        if: always()
         uses: ./.github/actions/report-to-qase
         with:
           qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
@@ -582,6 +586,7 @@ jobs:
           timeout: ${{ env.TIMEOUT }}
 
       - name: Reporting Results to Qase
+        if: always()
         uses: ./.github/actions/report-to-qase
         with:
           qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}

--- a/.github/workflows/recurring-sanity-upgrade-test.yaml
+++ b/.github/workflows/recurring-sanity-upgrade-test.yaml
@@ -1,3 +1,4 @@
+---
 name: Recurring Sanity Upgrade Test
 
 on:
@@ -168,6 +169,7 @@ jobs:
           timeout: ${{ env.TIMEOUT }}
 
       - name: Reporting Results to Qase
+        if: always()
         uses: ./.github/actions/report-to-qase
         with:
           qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
@@ -319,6 +321,7 @@ jobs:
           timeout: ${{ env.TIMEOUT }}
 
       - name: Reporting Results to Qase
+        if: always()
         uses: ./.github/actions/report-to-qase
         with:
           qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
@@ -472,6 +475,7 @@ jobs:
           timeout: ${{ env.TIMEOUT }}
 
       - name: Reporting Results to Qase
+        if: always()
         uses: ./.github/actions/report-to-qase
         with:
           qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
@@ -625,6 +629,7 @@ jobs:
           timeout: ${{ env.TIMEOUT }}
 
       - name: Reporting Results to Qase
+        if: always()
         uses: ./.github/actions/report-to-qase
         with:
           qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}

--- a/.github/workflows/verify-changes.yaml
+++ b/.github/workflows/verify-changes.yaml
@@ -1,3 +1,4 @@
+---
 name: Verify Changes
 
 on:

--- a/tests/proxy/proxy_provisioning_test.go
+++ b/tests/proxy/proxy_provisioning_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/rancher/shepherd/clients/rancher"
@@ -107,7 +108,8 @@ func (p *TfpProxyProvisioningTestSuite) TestTfpNoProxyProvisioning() {
 
 		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
 
-		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion
+		currentDate := time.Now().Format("2006-01-02 03:04PM")
+		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion + " " + currentDate
 
 		p.Run((tt.name), func() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, p.terratestConfig.PathToRepo, "")
@@ -167,7 +169,8 @@ func (p *TfpProxyProvisioningTestSuite) TestTfpProxyProvisioning() {
 
 		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
 
-		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion
+		currentDate := time.Now().Format("2006-01-02 03:04PM")
+		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion + " " + currentDate
 
 		p.Run((tt.name), func() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, p.terratestConfig.PathToRepo, "")

--- a/tests/proxy/proxy_upgrade_rancher_test.go
+++ b/tests/proxy/proxy_upgrade_rancher_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/rancher/shepherd/clients/rancher"
@@ -143,7 +144,8 @@ func (p *TfpProxyUpgradeRancherTestSuite) provisionAndVerifyCluster(name string,
 
 		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
 
-		tt.name = name + tt.name + " Kubernetes version: " + terratest.KubernetesVersion
+		currentDate := time.Now().Format("2006-01-02 03:04PM")
+		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion + " " + currentDate
 
 		p.Run((tt.name), func() {
 			clusterIDs, customClusterNames = provisioning.Provision(p.T(), p.client, rancher, terraform, terratest, testUser, testPassword, p.terraformOptions, configMap, newFile, rootBody, file, false, true, true, customClusterNames)


### PR DESCRIPTION
### Issue: N/A

### Description
Upon any failures seen in any of the workflows, we need to be able to have failures reported to our Qase test runs. As of now, only successes get reported, but we need all statuses shown. Additionally, updated the proxy tests to get the date and time as there are now GHA workflows we run weekly.