### PR TITLE
Consolidate recurring and release testing workflows

### DIFF
--- a/.github/workflows/proxy-test.yaml
+++ b/.github/workflows/proxy-test.yaml
@@ -1,40 +1,69 @@
 ---
-name: Recurring Proxy Upgrade Test
+name: Proxy Testing
 
 on:
   schedule:
     - cron: "0 9 * * 1"
   workflow_dispatch:
+    inputs:
+      rancher-version-2-12:
+        description: "Rancher version for v2.12.x"
+        required: true
+        default: "head"
+      rancher-version-2-11:
+        description: "Rancher version for v2.11.x"
+        required: true
+        default: "v2.11.2"
+      rancher-version-2-10:
+        description: "Rancher version for v2.10.x"
+        required: true
+        default: "v2.10.6"
+      rancher-version-2-9:
+        description: "Rancher version for v2.9.x"
+        required: true
+        default: "v2.9.10"
+      qase-test-run-id-2-12:
+        description: "Qase Test Run ID for v2.12.x"
+        required: true
+        default: "4512"
+      qase-test-run-id-2-11:
+        description: "Qase Test Run ID for v2.11.x"
+        required: true
+        default: "4541"
+      qase-test-run-id-2-10:
+        description: "Qase Test Run ID for v2.10.x"
+        required: true
+        default: "4542"
+      qase-test-run-id-2-9:
+        description: "Qase Test Run ID for v2.9.x"
+        required: true
+        default: "4540"
 
 env:
   AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
   AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
   AWS_DEFAULT_REGION: "${{ secrets.AWS_REGION }}"
   CLOUD_PROVIDER_VERSION: "5.95.0"
-  HOSTNAME_PREFIX: tfp-proxy-up
+  HOSTNAME_PREFIX: "tfp-proxy"
   LOCALS_PROVIDER_VERSION: "2.5.2"
-  PACKAGE: proxy
+  PACKAGE: "proxy"
   RANCHER_VERSION: ""
   RANCHER2_PROVIDER_VERSION: "7.0.0"
   RKE_PROVIDER_VERSION: "1.7.0"
   RKE2_VERSION: ""
-  RKE2_VERSION_2_9: v1.30.12
-  RKE2_VERSION_2_10: v1.31.8
-  RKE2_VERSION_2_11: v1.32.4
-  RKE2_VERSION_2_12: v1.32.4
-  SUITE: ^TestTfpProxyUpgradeRancherTestSuite$
+  RKE2_VERSION_2_9: "v1.30.12"
+  RKE2_VERSION_2_10: "v1.31.8"
+  RKE2_VERSION_2_11: "v1.32.4"
+  RKE2_VERSION_2_12: "v1.32.4"
+  SUITE: "^TestTfpProxyProvisioningTestSuite$"
   TERRAFORM_VERSION: "1.12.1"
-  TIMEOUT: 2h
-  UPGRADED_RANCHER_VERSION: ""
+  TIMEOUT: "2h"
   QASE_TEST_RUN_ID: ""
-  QASE_TEST_RUN_ID_2_9: "4540"
-  QASE_TEST_RUN_ID_2_10: "4542"
-  QASE_TEST_RUN_ID_2_11: "4541"
-  QASE_TEST_RUN_ID_2_12: "4512"
 
 jobs:
-  v2-12-head:
-    name: v2.11.2 -> v2.12-head
+  v2-12:
+    if: ${{ github.event_name == 'schedule' }}
+    name: ${{ github.event.inputs.rancher-version-2-12 }}
     runs-on: ubuntu-latest
     environment: latest
 
@@ -61,19 +90,13 @@ jobs:
       - name: Uniquify hostname prefix
         uses: ./.github/actions/uniquify-hostname
 
-      - name: Set Rancher version
+      - name: Set RANCHER_VERSION
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: v2.11.2
+          value: ${{ github.event.inputs.rancher-version-2-12 }}
 
-      - name: Set upgraded Rancher version
-        uses: ./.github/actions/set-env-var
-        with:
-          key: UPGRADED_RANCHER_VERSION
-          value: head
-
-      - name: Set RKE2 version
+      - name: Set RKE2_VERSION
         uses: ./.github/actions/set-env-var
         with:
           key: RKE2_VERSION
@@ -83,7 +106,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: QASE_TEST_RUN_ID
-          value: ${{ env.QASE_TEST_RUN_ID_2_12 }}
+          value: ${{ github.event.inputs.qase-test-run-id-2-12 }}
 
       - name: Create config.yaml
         run: |
@@ -140,10 +163,6 @@ jobs:
               rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ env.RKE2_VERSION }}"
-              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
-              upgradedRancherRepo: "${{ secrets.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
             standaloneRegistry:
               registryName: "${{ secrets.REGISTRY_NAME }}"
               registryPassword: "${{ secrets.REGISTRY_PASSWORD }}"
@@ -175,7 +194,7 @@ jobs:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false
 
-      - name: Run Proxy Upgrade Test Suite
+      - name: Run Proxy Test Suite
         uses: ./.github/actions/run-test-suite
         with:
           package: ${{ env.PACKAGE }}
@@ -187,7 +206,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
+          qase-test-run-id: ${{env.QASE_TEST_RUN_ID }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -203,9 +222,9 @@ jobs:
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
           region: "${{ secrets.AWS_REGION }}"
-
-  v2-11-head:
-    name: v2.11.2 -> v2.11-head
+  
+  v2-11:
+    name: ${{ github.event.inputs.rancher-version-2-11 }}
     runs-on: ubuntu-latest
     environment: latest
 
@@ -232,17 +251,11 @@ jobs:
       - name: Uniquify hostname prefix
         uses: ./.github/actions/uniquify-hostname
 
-      - name: Set Rancher version
+      - name: Set RANCHER_VERSION
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: v2.11.2
-
-      - name: Set upgraded Rancher version
-        uses: ./.github/actions/set-env-var
-        with:
-          key: UPGRADED_RANCHER_VERSION
-          value: v2.11-head
+          value: ${{ github.event.inputs.rancher-version-2-11 }}
 
       - name: Set RKE2_VERSION
         uses: ./.github/actions/set-env-var
@@ -254,7 +267,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: QASE_TEST_RUN_ID
-          value: ${{ env.QASE_TEST_RUN_ID_2_11 }}
+          value: ${{ github.event.inputs.qase-test-run-id-2-11 }}
 
       - name: Create config.yaml
         run: |
@@ -311,10 +324,6 @@ jobs:
               rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ env.RKE2_VERSION }}"
-              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
-              upgradedRancherRepo: "${{ secrets.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
             standaloneRegistry:
               registryName: "${{ secrets.REGISTRY_NAME }}"
               registryPassword: "${{ secrets.REGISTRY_PASSWORD }}"
@@ -346,7 +355,7 @@ jobs:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false
 
-      - name: Run Proxy Upgrade Test Suite
+      - name: Run Proxy Test Suite
         uses: ./.github/actions/run-test-suite
         with:
           package: ${{ env.PACKAGE }}
@@ -358,7 +367,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
+          qase-test-run-id: ${{env.QASE_TEST_RUN_ID }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -375,10 +384,10 @@ jobs:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
           region: "${{ secrets.AWS_REGION }}"
 
-  v2-10-head:
-    name: v2.10.6 -> v2.10-head
+  v2-10:
+    name: ${{ github.event.inputs.rancher-version-2-10 }}
     runs-on: ubuntu-latest
-    environment: upgrade-prime-staging
+    environment: staging-latest
 
     steps:
       - name: Checkout repository
@@ -403,17 +412,11 @@ jobs:
       - name: Uniquify hostname prefix
         uses: ./.github/actions/uniquify-hostname
 
-      - name: Set Rancher version
+      - name: Set RANCHER_VERSION
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: v2.10.6
-
-      - name: Set upgraded Rancher version
-        uses: ./.github/actions/set-env-var
-        with:
-          key: UPGRADED_RANCHER_VERSION
-          value: v2.10-head
+          value: ${{ github.event.inputs.rancher-version-2-10 }}
 
       - name: Set RKE2_VERSION
         uses: ./.github/actions/set-env-var
@@ -425,7 +428,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: QASE_TEST_RUN_ID
-          value: ${{ env.QASE_TEST_RUN_ID_2_10 }}
+          value: ${{ github.event.inputs.qase-test-run-id-2-10 }}
 
       - name: Create config.yaml
         run: |
@@ -483,11 +486,6 @@ jobs:
               rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ env.RKE2_VERSION }}"
-              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
-              upgradedRancherRepo: "${{ secrets.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
             standaloneRegistry:
               registryName: "${{ secrets.REGISTRY_NAME }}"
               registryPassword: "${{ secrets.REGISTRY_PASSWORD }}"
@@ -519,7 +517,7 @@ jobs:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false
 
-      - name: Run Proxy Upgrade Test Suite
+      - name: Run Proxy Test Suite
         uses: ./.github/actions/run-test-suite
         with:
           package: ${{ env.PACKAGE }}
@@ -548,10 +546,10 @@ jobs:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
           region: "${{ secrets.AWS_REGION }}"
 
-  v2-9-head:
-    name: v2.9.10 -> v2.9-head
+  v2-9:
+    name: ${{ github.event.inputs.rancher-version-2-9 }}
     runs-on: ubuntu-latest
-    environment: upgrade-prime-staging
+    environment: staging-latest
 
     steps:
       - name: Checkout repository
@@ -576,17 +574,11 @@ jobs:
       - name: Uniquify hostname prefix
         uses: ./.github/actions/uniquify-hostname
 
-      - name: Set Rancher version
+      - name: Set RANCHER_VERSION
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: v2.9.10
-
-      - name: Set upgraded Rancher version
-        uses: ./.github/actions/set-env-var
-        with:
-          key: UPGRADED_RANCHER_VERSION
-          value: v2.9-head
+          value: ${{ github.event.inputs.rancher-version-2-9 }}
 
       - name: Set RKE2_VERSION
         uses: ./.github/actions/set-env-var
@@ -598,7 +590,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: QASE_TEST_RUN_ID
-          value: ${{ env.QASE_TEST_RUN_ID_2_9 }}
+          value: ${{ github.event.inputs.qase-test-run-id-2-9 }}
 
       - name: Create config.yaml
         run: |
@@ -656,11 +648,6 @@ jobs:
               rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ env.RKE2_VERSION }}"
-              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
-              upgradedRancherRepo: "${{ secrets.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
             standaloneRegistry:
               registryName: "${{ secrets.REGISTRY_NAME }}"
               registryPassword: "${{ secrets.REGISTRY_PASSWORD }}"
@@ -692,7 +679,7 @@ jobs:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false
 
-      - name: Run Proxy Upgrade Test Suite
+      - name: Run Proxy Test Suite
         uses: ./.github/actions/run-test-suite
         with:
           package: ${{ env.PACKAGE }}

--- a/.github/workflows/proxy-upgrade-test.yaml
+++ b/.github/workflows/proxy-upgrade-test.yaml
@@ -1,36 +1,73 @@
 ---
-name: Recurring Sanity Test
+name: Proxy Upgrade Testing
 
 on:
   schedule:
-    - cron: "0 7 * * 1-5"
+    - cron: "0 9 * * 1"
   workflow_dispatch:
+    inputs:
+      upgraded-rancher-version-2-12:
+        description: "Upgraded Rancher version for v2.12.x"
+        required: true
+        default: "head"
+      upgraded-rancher-version-2-11:
+        description: "Upgraded Rancher version for v2.11.x"
+        required: true
+        default: "v2.11-head"
+      upgraded-rancher-version-2-10:
+        description: "Upgraded Rancher version for v2.10.x"
+        required: true
+        default: "v2.10-head"
+      upgraded-rancher-version-2-9:
+        description: "Upgraded Rancher version for v2.9.x"
+        required: true
+        default: "v2.9-head"
+      qase-test-run-id-2-12:
+        description: "Qase Test Run ID for v2.12.x"
+        required: true
+        default: "4512"
+      qase-test-run-id-2-11:
+        description: "Qase Test Run ID for v2.11.x"
+        required: true
+        default: "4541"
+      qase-test-run-id-2-10:
+        description: "Qase Test Run ID for v2.10.x"
+        required: true
+        default: "4542"
+      qase-test-run-id-2-9:
+        description: "Qase Test Run ID for v2.9.x"
+        required: true
+        default: "4540"
 
 env:
+  AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
+  AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+  AWS_DEFAULT_REGION: "${{ secrets.AWS_REGION }}"
   CLOUD_PROVIDER_VERSION: "5.95.0"
-  HOSTNAME_PREFIX: tfp-sanity
+  HOSTNAME_PREFIX: "tfp-proxy-up"
   LOCALS_PROVIDER_VERSION: "2.5.2"
-  PACKAGE: sanity
+  PACKAGE: "proxy"
   RANCHER_VERSION: ""
+  RANCHER_VERSION_2_9: "v2.9.10"
+  RANCHER_VERSION_2_10: "v2.10.6"
+  RANCHER_VERSION_2_11: "v2.11.2"
   RANCHER2_PROVIDER_VERSION: "7.0.0"
   RKE_PROVIDER_VERSION: "1.7.0"
   RKE2_VERSION: ""
-  RKE2_VERSION_2_9: v1.30.12+rke2r1
-  RKE2_VERSION_2_10: v1.31.8+rke2r1
-  RKE2_VERSION_2_11: v1.32.4+rke2r1
-  RKE2_VERSION_2_12: v1.32.4+rke2r1
-  SUITE: ^TestTfpSanityProvisioningTestSuite$
+  RKE2_VERSION_2_9: "v1.30.12"
+  RKE2_VERSION_2_10: "v1.31.8"
+  RKE2_VERSION_2_11: "v1.32.4"
+  RKE2_VERSION_2_12: "v1.32.4"
+  SUITE: "^TestTfpProxyUpgradeRancherTestSuite$"
   TERRAFORM_VERSION: "1.12.1"
-  TIMEOUT: 2h
+  TIMEOUT: "2h"
+  UPGRADED_RANCHER_VERSION: ""
   QASE_TEST_RUN_ID: ""
-  QASE_TEST_RUN_ID_2_9: "4540"
-  QASE_TEST_RUN_ID_2_10: "4542"
-  QASE_TEST_RUN_ID_2_11: "4541"
-  QASE_TEST_RUN_ID_2_12: "4512"
 
 jobs:
-  v2-12-head:
-    name: v2.12-head
+  v2-12:
+    if: ${{ github.event_name == 'schedule' }}
+    name: v2.11.2 -> ${{ github.event.inputs.upgraded-rancher-version-2-12 }}
     runs-on: ubuntu-latest
     environment: latest
 
@@ -39,6 +76,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - name: Whitelist Runner IP
+        uses: ./.github/actions/whitelist-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -55,9 +98,15 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: head
+          value: ${{ env.RANCHER_VERSION_2_11 }}
 
-      - name: Set RKE2 version
+      - name: Set upgraded Rancher version
+        uses: ./.github/actions/set-env-var
+        with:
+          key: UPGRADED_RANCHER_VERSION
+          value: ${{ github.event.inputs.upgraded-rancher-version-2-12 }}
+
+      - name: Set RKE2_VERSION
         uses: ./.github/actions/set-env-var
         with:
           key: RKE2_VERSION
@@ -67,7 +116,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: QASE_TEST_RUN_ID
-          value: ${{ env.QASE_TEST_RUN_ID_2_12 }}
+          value: ${{ github.event.inputs.qase-test-run-id-2-12 }}
 
       - name: Create config.yaml
         run: |
@@ -84,6 +133,8 @@ jobs:
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
             windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
+            proxy:
+              proxyBastion: ""
             awsCredentials:
               awsAccessKey: "${{ secrets.AWS_ACCESS_KEY_ID }}"
               awsSecretKey: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
@@ -93,7 +144,7 @@ jobs:
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               region: "${{ secrets.AWS_REGION }}"
-              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
+              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PROXY }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
               awsVpcID: "${{ secrets.AWS_VPC_ID }}"
@@ -122,6 +173,14 @@ jobs:
               rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ env.RKE2_VERSION }}"
+              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
+              upgradedRancherRepo: "${{ secrets.UPGRADED_RANCHER_REPO }}"
+              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
+              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
+            standaloneRegistry:
+              registryName: "${{ secrets.REGISTRY_NAME }}"
+              registryPassword: "${{ secrets.REGISTRY_PASSWORD }}"
+              registryUsername: "${{ secrets.REGISTRY_USERNAME }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             nodeCount: ${{ vars.NODE_COUNT }}
@@ -149,7 +208,7 @@ jobs:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false
 
-      - name: Run Sanity Test Suite
+      - name: Run Proxy Upgrade Test Suite
         uses: ./.github/actions/run-test-suite
         with:
           package: ${{ env.PACKAGE }}
@@ -161,7 +220,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
+          qase-test-run-id: ${{env.QASE_TEST_RUN_ID }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -171,8 +230,15 @@ jobs:
           slack-channel: ${{ secrets.SLACK_CHANNEL }}
           slack-token: ${{ secrets.SLACK_TOKEN }}
 
-  v2-11-head:
-    name: v2.11-head
+      - name: Revoke Runner IP
+        if: always()
+        uses: ./.github/actions/revoke-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"
+
+  v2-11:
+    name: v2.11.2 -> ${{ github.event.inputs.upgraded-rancher-version-2-11 }}
     runs-on: ubuntu-latest
     environment: latest
 
@@ -182,6 +248,12 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Whitelist Runner IP
+        uses: ./.github/actions/whitelist-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"
+
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
         with:
@@ -197,9 +269,15 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: v2.11-head
+          value: ${{ env.RANCHER_VERSION_2_11 }}
 
-      - name: Set RKE2 version
+      - name: Set upgraded Rancher version
+        uses: ./.github/actions/set-env-var
+        with:
+          key: UPGRADED_RANCHER_VERSION
+          value: ${{ github.event.inputs.upgraded-rancher-version-2-11 }}
+
+      - name: Set RKE2_VERSION
         uses: ./.github/actions/set-env-var
         with:
           key: RKE2_VERSION
@@ -209,7 +287,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: QASE_TEST_RUN_ID
-          value: ${{ env.QASE_TEST_RUN_ID_2_11 }}
+          value: ${{ github.event.inputs.qase-test-run-id-2-11 }}
 
       - name: Create config.yaml
         run: |
@@ -226,6 +304,8 @@ jobs:
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
             windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
+            proxy:
+              proxyBastion: ""
             awsCredentials:
               awsAccessKey: "${{ secrets.AWS_ACCESS_KEY_ID }}"
               awsSecretKey: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
@@ -235,7 +315,7 @@ jobs:
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               region: "${{ secrets.AWS_REGION }}"
-              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
+              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PROXY }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
               awsVpcID: "${{ secrets.AWS_VPC_ID }}"
@@ -264,6 +344,14 @@ jobs:
               rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ env.RKE2_VERSION }}"
+              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
+              upgradedRancherRepo: "${{ secrets.UPGRADED_RANCHER_REPO }}"
+              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
+              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
+            standaloneRegistry:
+              registryName: "${{ secrets.REGISTRY_NAME }}"
+              registryPassword: "${{ secrets.REGISTRY_PASSWORD }}"
+              registryUsername: "${{ secrets.REGISTRY_USERNAME }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             nodeCount: ${{ vars.NODE_COUNT }}
@@ -291,7 +379,7 @@ jobs:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false
 
-      - name: Run Sanity Test Suite
+      - name: Run Proxy Upgrade Test Suite
         uses: ./.github/actions/run-test-suite
         with:
           package: ${{ env.PACKAGE }}
@@ -303,7 +391,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
+          qase-test-run-id: ${{env.QASE_TEST_RUN_ID }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -313,16 +401,29 @@ jobs:
           slack-channel: ${{ secrets.SLACK_CHANNEL }}
           slack-token: ${{ secrets.SLACK_TOKEN }}
 
-  v2-10-head:
-    name: v2.10-head
+      - name: Revoke Runner IP
+        if: always()
+        uses: ./.github/actions/revoke-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"
+
+  v2-10:
+    name: v2.10.6 -> ${{ github.event.inputs.upgraded-rancher-version-2-10 }}
     runs-on: ubuntu-latest
-    environment: staging-latest
+    environment: upgrade-prime-staging
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - name: Whitelist Runner IP
+        uses: ./.github/actions/whitelist-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -339,9 +440,15 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: v2.10-head
+          value: ${{ env.RANCHER_VERSION_2_10 }}
 
-      - name: Set RKE2 version
+      - name: Set upgraded Rancher version
+        uses: ./.github/actions/set-env-var
+        with:
+          key: UPGRADED_RANCHER_VERSION
+          value: ${{ github.event.inputs.upgraded-rancher-version-2-10 }}
+
+      - name: Set RKE2_VERSION
         uses: ./.github/actions/set-env-var
         with:
           key: RKE2_VERSION
@@ -351,7 +458,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: QASE_TEST_RUN_ID
-          value: ${{ env.QASE_TEST_RUN_ID_2_10 }}
+          value: ${{ github.event.inputs.qase-test-run-id-2-10 }}
 
       - name: Create config.yaml
         run: |
@@ -368,6 +475,8 @@ jobs:
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
             windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
+            proxy:
+              proxyBastion: ""
             awsCredentials:
               awsAccessKey: "${{ secrets.AWS_ACCESS_KEY_ID }}"
               awsSecretKey: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
@@ -377,7 +486,7 @@ jobs:
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               region: "${{ secrets.AWS_REGION }}"
-              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
+              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PROXY }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
               awsVpcID: "${{ secrets.AWS_VPC_ID }}"
@@ -407,6 +516,15 @@ jobs:
               rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ env.RKE2_VERSION }}"
+              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
+              upgradedRancherRepo: "${{ secrets.UPGRADED_RANCHER_REPO }}"
+              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
+              upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
+              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
+            standaloneRegistry:
+              registryName: "${{ secrets.REGISTRY_NAME }}"
+              registryPassword: "${{ secrets.REGISTRY_PASSWORD }}"
+              registryUsername: "${{ secrets.REGISTRY_USERNAME }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             nodeCount: ${{ vars.NODE_COUNT }}
@@ -434,7 +552,7 @@ jobs:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false
 
-      - name: Run Sanity Test Suite
+      - name: Run Proxy Upgrade Test Suite
         uses: ./.github/actions/run-test-suite
         with:
           package: ${{ env.PACKAGE }}
@@ -446,7 +564,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
+          qase-test-run-id: ${{env.QASE_TEST_RUN_ID }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -456,16 +574,29 @@ jobs:
           slack-channel: ${{ secrets.SLACK_CHANNEL }}
           slack-token: ${{ secrets.SLACK_TOKEN }}
 
-  v2-9-head:
-    name: v2.9-head
+      - name: Revoke Runner IP
+        if: always()
+        uses: ./.github/actions/revoke-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"
+
+  v2-9:
+    name: v2.9.10 -> ${{ github.event.inputs.upgraded-rancher-version-2-9 }}
     runs-on: ubuntu-latest
-    environment: staging-latest
+    environment: upgrade-prime-staging
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - name: Whitelist Runner IP
+        uses: ./.github/actions/whitelist-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -482,9 +613,15 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: v2.9-head
+          value: ${{ env.RANCHER_VERSION_2_9 }}
 
-      - name: Set RKE2 version
+      - name: Set upgraded Rancher version
+        uses: ./.github/actions/set-env-var
+        with:
+          key: UPGRADED_RANCHER_VERSION
+          value: ${{ github.event.inputs.upgraded-rancher-version-2-9 }}
+
+      - name: Set RKE2_VERSION
         uses: ./.github/actions/set-env-var
         with:
           key: RKE2_VERSION
@@ -494,7 +631,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: QASE_TEST_RUN_ID
-          value: ${{ env.QASE_TEST_RUN_ID_2_9 }}
+          value: ${{ github.event.inputs.qase-test-run-id-2-9 }}
 
       - name: Create config.yaml
         run: |
@@ -511,6 +648,8 @@ jobs:
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
             windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
+            proxy:
+              proxyBastion: ""
             awsCredentials:
               awsAccessKey: "${{ secrets.AWS_ACCESS_KEY_ID }}"
               awsSecretKey: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
@@ -520,7 +659,7 @@ jobs:
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               region: "${{ secrets.AWS_REGION }}"
-              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
+              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PROXY }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
               awsVpcID: "${{ secrets.AWS_VPC_ID }}"
@@ -550,6 +689,15 @@ jobs:
               rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ env.RKE2_VERSION }}"
+              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
+              upgradedRancherRepo: "${{ secrets.UPGRADED_RANCHER_REPO }}"
+              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
+              upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
+              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
+            standaloneRegistry:
+              registryName: "${{ secrets.REGISTRY_NAME }}"
+              registryPassword: "${{ secrets.REGISTRY_PASSWORD }}"
+              registryUsername: "${{ secrets.REGISTRY_USERNAME }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             nodeCount: ${{ vars.NODE_COUNT }}
@@ -577,7 +725,7 @@ jobs:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false
 
-      - name: Run Sanity Test Suite
+      - name: Run Proxy Upgrade Test Suite
         uses: ./.github/actions/run-test-suite
         with:
           package: ${{ env.PACKAGE }}
@@ -589,7 +737,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
+          qase-test-run-id: ${{env.QASE_TEST_RUN_ID }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -598,3 +746,10 @@ jobs:
           job-status: ${{ job.status }}
           slack-channel: ${{ secrets.SLACK_CHANNEL }}
           slack-token: ${{ secrets.SLACK_TOKEN }}
+
+      - name: Revoke Runner IP
+        if: always()
+        uses: ./.github/actions/revoke-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"

--- a/.github/workflows/sanity-test.yaml
+++ b/.github/workflows/sanity-test.yaml
@@ -1,39 +1,66 @@
 ---
-name: Recurring Proxy Test
+name: Sanity Testing
 
 on:
   schedule:
-    - cron: "0 9 * * 1"
+    - cron: "0 7 * * 1-5"
   workflow_dispatch:
+    inputs:
+      rancher-version-2-12:
+        description: "Rancher version for v2.12.x"
+        required: true
+        default: "head"
+      rancher-version-2-11:
+        description: "Rancher version for v2.11.x"
+        required: true
+        default: "v2.11.2"
+      rancher-version-2-10:
+        description: "Rancher version for v2.10.x"
+        required: true
+        default: "v2.10.6"
+      rancher-version-2-9:
+        description: "Rancher version for v2.9.x"
+        required: true
+        default: "v2.9.10"
+      qase-test-run-id-2-12:
+        description: "Qase Test Run ID for v2.12.x"
+        required: true
+        default: "4512"
+      qase-test-run-id-2-11:
+        description: "Qase Test Run ID for v2.11.x"
+        required: true
+        default: "4541"
+      qase-test-run-id-2-10:
+        description: "Qase Test Run ID for v2.10.x"
+        required: true
+        default: "4542"
+      qase-test-run-id-2-9:
+        description: "Qase Test Run ID for v2.9.x"
+        required: true
+        default: "4540"
 
 env:
-  AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
-  AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
-  AWS_DEFAULT_REGION: "${{ secrets.AWS_REGION }}"
   CLOUD_PROVIDER_VERSION: "5.95.0"
-  HOSTNAME_PREFIX: tfp-proxy
+  HOSTNAME_PREFIX: "tfp-sanity"
   LOCALS_PROVIDER_VERSION: "2.5.2"
-  PACKAGE: proxy
+  PACKAGE: "sanity"
   RANCHER_VERSION: ""
   RANCHER2_PROVIDER_VERSION: "7.0.0"
   RKE_PROVIDER_VERSION: "1.7.0"
   RKE2_VERSION: ""
-  RKE2_VERSION_2_9: v1.30.12
-  RKE2_VERSION_2_10: v1.31.8
-  RKE2_VERSION_2_11: v1.32.4
-  RKE2_VERSION_2_12: v1.32.4
-  SUITE: ^TestTfpProxyProvisioningTestSuite$
+  RKE2_VERSION_2_9: "v1.30.12+rke2r1"
+  RKE2_VERSION_2_10: "v1.31.8+rke2r1"
+  RKE2_VERSION_2_11: "v1.32.4+rke2r1"
+  RKE2_VERSION_2_12: "v1.32.4+rke2r1"
+  SUITE: "^TestTfpSanityProvisioningTestSuite$"
   TERRAFORM_VERSION: "1.12.1"
-  TIMEOUT: 2h
+  TIMEOUT: "2h"
   QASE_TEST_RUN_ID: ""
-  QASE_TEST_RUN_ID_2_9: "4540"
-  QASE_TEST_RUN_ID_2_10: "4542"
-  QASE_TEST_RUN_ID_2_11: "4541"
-  QASE_TEST_RUN_ID_2_12: "4512"
 
 jobs:
-  v2-12-head:
-    name: v2.12-head
+  v2-12:
+    if: ${{ github.event_name == 'schedule' }}
+    name: ${{ github.event.inputs.rancher-version-2-12 }}
     runs-on: ubuntu-latest
     environment: latest
 
@@ -42,12 +69,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-
-      - name: Whitelist Runner IP
-        uses: ./.github/actions/whitelist-runner-ip
-        with:
-          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -64,7 +85,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: head
+          value: ${{ github.event.inputs.rancher-version-2-12 }}
 
       - name: Set RKE2 version
         uses: ./.github/actions/set-env-var
@@ -76,7 +97,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: QASE_TEST_RUN_ID
-          value: ${{ env.QASE_TEST_RUN_ID_2_12 }}
+          value: ${{ github.event.inputs.qase-test-run-id-2-12 }}
 
       - name: Create config.yaml
         run: |
@@ -93,8 +114,6 @@ jobs:
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
             windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
-            proxy:
-              proxyBastion: ""
             awsCredentials:
               awsAccessKey: "${{ secrets.AWS_ACCESS_KEY_ID }}"
               awsSecretKey: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
@@ -104,7 +123,7 @@ jobs:
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               region: "${{ secrets.AWS_REGION }}"
-              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PROXY }}]
+              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
               awsVpcID: "${{ secrets.AWS_VPC_ID }}"
@@ -133,10 +152,6 @@ jobs:
               rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ env.RKE2_VERSION }}"
-            standaloneRegistry:
-              registryName: "${{ secrets.REGISTRY_NAME }}"
-              registryPassword: "${{ secrets.REGISTRY_PASSWORD }}"
-              registryUsername: "${{ secrets.REGISTRY_USERNAME }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             nodeCount: ${{ vars.NODE_COUNT }}
@@ -164,7 +179,7 @@ jobs:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false
 
-      - name: Run Proxy Test Suite
+      - name: Run Sanity Test Suite
         uses: ./.github/actions/run-test-suite
         with:
           package: ${{ env.PACKAGE }}
@@ -176,7 +191,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
+          qase-test-run-id: ${{env.QASE_TEST_RUN_ID }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -186,15 +201,9 @@ jobs:
           slack-channel: ${{ secrets.SLACK_CHANNEL }}
           slack-token: ${{ secrets.SLACK_TOKEN }}
 
-      - name: Revoke Runner IP
-        if: always()
-        uses: ./.github/actions/revoke-runner-ip
-        with:
-          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
-
-  v2-11-head:
-    name: v2.11-head
+  v2-11:
+    if: ${{ github.event_name == 'schedule' }}
+    name: ${{ github.event.inputs.rancher-version-2-11 }}
     runs-on: ubuntu-latest
     environment: latest
 
@@ -204,12 +213,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Whitelist Runner IP
-        uses: ./.github/actions/whitelist-runner-ip
-        with:
-          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
-
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
         with:
@@ -221,13 +224,13 @@ jobs:
       - name: Uniquify hostname prefix
         uses: ./.github/actions/uniquify-hostname
 
-      - name: Set RANCHER_VERSION
+      - name: Set Rancher version
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: v2.11-head
+          value: ${{ github.event.inputs.rancher-version-2-11 }}
 
-      - name: Set RKE2_VERSION
+      - name: Set RKE2 version
         uses: ./.github/actions/set-env-var
         with:
           key: RKE2_VERSION
@@ -237,7 +240,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: QASE_TEST_RUN_ID
-          value: ${{ env.QASE_TEST_RUN_ID_2_11 }}
+          value: ${{ github.event.inputs.qase-test-run-id-2-11 }}
 
       - name: Create config.yaml
         run: |
@@ -254,8 +257,6 @@ jobs:
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
             windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
-            proxy:
-              proxyBastion: ""
             awsCredentials:
               awsAccessKey: "${{ secrets.AWS_ACCESS_KEY_ID }}"
               awsSecretKey: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
@@ -265,7 +266,7 @@ jobs:
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               region: "${{ secrets.AWS_REGION }}"
-              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PROXY }}]
+              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
               awsVpcID: "${{ secrets.AWS_VPC_ID }}"
@@ -294,10 +295,6 @@ jobs:
               rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ env.RKE2_VERSION }}"
-            standaloneRegistry:
-              registryName: "${{ secrets.REGISTRY_NAME }}"
-              registryPassword: "${{ secrets.REGISTRY_PASSWORD }}"
-              registryUsername: "${{ secrets.REGISTRY_USERNAME }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             nodeCount: ${{ vars.NODE_COUNT }}
@@ -325,7 +322,7 @@ jobs:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false
 
-      - name: Run Proxy Test Suite
+      - name: Run Sanity Test Suite
         uses: ./.github/actions/run-test-suite
         with:
           package: ${{ env.PACKAGE }}
@@ -337,7 +334,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
+          qase-test-run-id: ${{env.QASE_TEST_RUN_ID }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -347,15 +344,9 @@ jobs:
           slack-channel: ${{ secrets.SLACK_CHANNEL }}
           slack-token: ${{ secrets.SLACK_TOKEN }}
 
-      - name: Revoke Runner IP
-        if: always()
-        uses: ./.github/actions/revoke-runner-ip
-        with:
-          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
-
-  v2-10-head:
-    name: v2.10-head
+  v2-10:
+    if: ${{ github.event_name == 'schedule' }}
+    name: ${{ github.event.inputs.rancher-version-2-10 }}
     runs-on: ubuntu-latest
     environment: staging-latest
 
@@ -364,12 +355,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-
-      - name: Whitelist Runner IP
-        uses: ./.github/actions/whitelist-runner-ip
-        with:
-          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -382,13 +367,13 @@ jobs:
       - name: Uniquify hostname prefix
         uses: ./.github/actions/uniquify-hostname
 
-      - name: Set RANCHER_VERSION
+      - name: Set Rancher version
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: v2.10-head
+          value: ${{ github.event.inputs.rancher-version-2-10 }}
 
-      - name: Set RKE2_VERSION
+      - name: Set RKE2 version
         uses: ./.github/actions/set-env-var
         with:
           key: RKE2_VERSION
@@ -398,7 +383,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: QASE_TEST_RUN_ID
-          value: ${{ env.QASE_TEST_RUN_ID_2_10 }}
+          value: ${{ github.event.inputs.qase-test-run-id-2-10 }}
 
       - name: Create config.yaml
         run: |
@@ -415,8 +400,6 @@ jobs:
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
             windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
-            proxy:
-              proxyBastion: ""
             awsCredentials:
               awsAccessKey: "${{ secrets.AWS_ACCESS_KEY_ID }}"
               awsSecretKey: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
@@ -426,7 +409,7 @@ jobs:
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               region: "${{ secrets.AWS_REGION }}"
-              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PROXY }}]
+              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
               awsVpcID: "${{ secrets.AWS_VPC_ID }}"
@@ -456,10 +439,6 @@ jobs:
               rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ env.RKE2_VERSION }}"
-            standaloneRegistry:
-              registryName: "${{ secrets.REGISTRY_NAME }}"
-              registryPassword: "${{ secrets.REGISTRY_PASSWORD }}"
-              registryUsername: "${{ secrets.REGISTRY_USERNAME }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             nodeCount: ${{ vars.NODE_COUNT }}
@@ -487,7 +466,7 @@ jobs:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false
 
-      - name: Run Proxy Test Suite
+      - name: Run Sanity Test Suite
         uses: ./.github/actions/run-test-suite
         with:
           package: ${{ env.PACKAGE }}
@@ -499,7 +478,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
+          qase-test-run-id: ${{env.QASE_TEST_RUN_ID }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -509,15 +488,9 @@ jobs:
           slack-channel: ${{ secrets.SLACK_CHANNEL }}
           slack-token: ${{ secrets.SLACK_TOKEN }}
 
-      - name: Revoke Runner IP
-        if: always()
-        uses: ./.github/actions/revoke-runner-ip
-        with:
-          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
-
-  v2-9-head:
-    name: v2.9-head
+  v2-9:
+    if: ${{ github.event_name == 'schedule' }}
+    name: ${{ github.event.inputs.rancher-version-2-9 }}
     runs-on: ubuntu-latest
     environment: staging-latest
 
@@ -526,12 +499,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-
-      - name: Whitelist Runner IP
-        uses: ./.github/actions/whitelist-runner-ip
-        with:
-          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -544,13 +511,13 @@ jobs:
       - name: Uniquify hostname prefix
         uses: ./.github/actions/uniquify-hostname
 
-      - name: Set RANCHER_VERSION
+      - name: Set Rancher version
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: v2.9-head
+          value: ${{ github.event.inputs.rancher-version-2-9 }}
 
-      - name: Set RKE2_VERSION
+      - name: Set RKE2 version
         uses: ./.github/actions/set-env-var
         with:
           key: RKE2_VERSION
@@ -560,7 +527,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: QASE_TEST_RUN_ID
-          value: ${{ env.QASE_TEST_RUN_ID_2_9 }}
+          value: ${{ github.event.inputs.qase-test-run-id-2-9 }}
 
       - name: Create config.yaml
         run: |
@@ -577,8 +544,6 @@ jobs:
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
             windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
-            proxy:
-              proxyBastion: ""
             awsCredentials:
               awsAccessKey: "${{ secrets.AWS_ACCESS_KEY_ID }}"
               awsSecretKey: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
@@ -588,7 +553,7 @@ jobs:
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               region: "${{ secrets.AWS_REGION }}"
-              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PROXY }}]
+              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
               awsVpcID: "${{ secrets.AWS_VPC_ID }}"
@@ -618,10 +583,6 @@ jobs:
               rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ env.RKE2_VERSION }}"
-            standaloneRegistry:
-              registryName: "${{ secrets.REGISTRY_NAME }}"
-              registryPassword: "${{ secrets.REGISTRY_PASSWORD }}"
-              registryUsername: "${{ secrets.REGISTRY_USERNAME }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             nodeCount: ${{ vars.NODE_COUNT }}
@@ -649,7 +610,7 @@ jobs:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false
 
-      - name: Run Proxy Test Suite
+      - name: Run Sanity Test Suite
         uses: ./.github/actions/run-test-suite
         with:
           package: ${{ env.PACKAGE }}
@@ -661,7 +622,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
+          qase-test-run-id: ${{env.QASE_TEST_RUN_ID }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -670,10 +631,3 @@ jobs:
           job-status: ${{ job.status }}
           slack-channel: ${{ secrets.SLACK_CHANNEL }}
           slack-token: ${{ secrets.SLACK_TOKEN }}
-
-      - name: Revoke Runner IP
-        if: always()
-        uses: ./.github/actions/revoke-runner-ip
-        with:
-          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"

--- a/.github/workflows/sanity-upgrade-test.yaml
+++ b/.github/workflows/sanity-upgrade-test.yaml
@@ -1,37 +1,70 @@
 ---
-name: Recurring Sanity Upgrade Test
+name: Sanity Upgrade Testing
 
 on:
   schedule:
     - cron: "0 8 * * 1"
   workflow_dispatch:
+    inputs:
+      upgraded-rancher-version-2-12:
+        description: "Upgraded Rancher version for v2.12.x"
+        required: true
+        default: "head"
+      upgraded-rancher-version-2-11:
+        description: "Upgraded Rancher version for v2.11.x"
+        required: true
+        default: "v2.11-head"
+      upgraded-rancher-version-2-10:
+        description: "Upgraded Rancher version for v2.10.x"
+        required: true
+        default: "v2.10-head"
+      upgraded-rancher-version-2-9:
+        description: "Upgraded Rancher version for v2.9.x"
+        required: true
+        default: "v2.9-head"
+      qase-test-run-id-2-12:
+        description: "Qase Test Run ID for v2.12.x"
+        required: true
+        default: "4512"
+      qase-test-run-id-2-11:
+        description: "Qase Test Run ID for v2.11.x"
+        required: true
+        default: "4541"
+      qase-test-run-id-2-10:
+        description: "Qase Test Run ID for v2.10.x"
+        required: true
+        default: "4542"
+      qase-test-run-id-2-9:
+        description: "Qase Test Run ID for v2.9.x"
+        required: true
+        default: "4540"
 
 env:
   CLOUD_PROVIDER_VERSION: "5.95.0"
-  HOSTNAME_PREFIX: tfp-sanity
+  HOSTNAME_PREFIX: "tfp-sanity-up"
   LOCALS_PROVIDER_VERSION: "2.5.2"
-  PACKAGE: sanity
+  PACKAGE: "sanity"
   RANCHER_VERSION: ""
+  RANCHER_VERSION_2_9: "v2.9.10"
+  RANCHER_VERSION_2_10: "v2.10.6"
+  RANCHER_VERSION_2_11: "v2.11.2"
   RANCHER2_PROVIDER_VERSION: "7.0.0"
   RKE_PROVIDER_VERSION: "1.7.0"
   RKE2_VERSION: ""
-  RKE2_VERSION_2_9: v1.30.12+rke2r1
-  RKE2_VERSION_2_10: v1.31.8+rke2r1
-  RKE2_VERSION_2_11: v1.32.4+rke2r1
-  RKE2_VERSION_2_12: v1.32.4+rke2r1
-  SUITE: ^TestTfpSanityUpgradeRancherTestSuite$
+  RKE2_VERSION_2_9: "v1.30.12+rke2r1"
+  RKE2_VERSION_2_10: "v1.31.8+rke2r1"
+  RKE2_VERSION_2_11: "v1.32.4+rke2r1"
+  RKE2_VERSION_2_12: "v1.32.4+rke2r1"
+  SUITE: "^TestTfpSanityUpgradeRancherTestSuite$"
   TERRAFORM_VERSION: "1.12.1"
-  TIMEOUT: 2h
+  TIMEOUT: "2h"
   UPGRADED_RANCHER_VERSION: ""
   QASE_TEST_RUN_ID: ""
-  QASE_TEST_RUN_ID_2_9: "4540"
-  QASE_TEST_RUN_ID_2_10: "4542"
-  QASE_TEST_RUN_ID_2_11: "4541"
-  QASE_TEST_RUN_ID_2_12: "4512"
 
 jobs:
-  v2-12-head:
-    name: v2.11.2 -> v2.12-head
+  v2-12:
+    if: ${{ github.event_name == 'schedule' }}
+    name: v2.11.2 -> ${{ github.event.inputs.upgraded-rancher-version-2-12 }}
     runs-on: ubuntu-latest
     environment: latest
 
@@ -56,13 +89,13 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: v2.11.2
+          value: ${{ env.RANCHER_VERSION_2_11 }}
 
       - name: Set upgraded Rancher version
         uses: ./.github/actions/set-env-var
         with:
           key: UPGRADED_RANCHER_VERSION
-          value: head
+          value: ${{ github.event.inputs.upgraded-rancher-version-2-12 }}
 
       - name: Set RKE2 version
         uses: ./.github/actions/set-env-var
@@ -74,7 +107,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: QASE_TEST_RUN_ID
-          value: ${{ env.QASE_TEST_RUN_ID_2_12 }}
+          qase-test-run-id: ${{env.QASE_TEST_RUN_ID }}
 
       - name: Create config.yaml
         run: |
@@ -172,7 +205,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
+          qase-test-run-id: ${{env.QASE_TEST_RUN_ID }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -182,8 +215,8 @@ jobs:
           slack-channel: ${{ secrets.SLACK_CHANNEL }}
           slack-token: ${{ secrets.SLACK_TOKEN }}
 
-  v2-11-head:
-    name: v2.11.2 -> v2.11-head
+  v2-11:
+    name: v2.11.2 -> ${{ github.event.inputs.upgraded-rancher-version-2-11 }}
     runs-on: ubuntu-latest
     environment: latest
 
@@ -208,13 +241,13 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: v2.11.2
+          value: ${{ env.RANCHER_VERSION_2_11 }}
 
       - name: Set upgraded Rancher version
         uses: ./.github/actions/set-env-var
         with:
           key: UPGRADED_RANCHER_VERSION
-          value: v2.11-head
+          value: ${{ github.event.inputs.upgraded-rancher-version-2-11 }}
 
       - name: Set RKE2 version
         uses: ./.github/actions/set-env-var
@@ -226,7 +259,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: QASE_TEST_RUN_ID
-          value: ${{ env.QASE_TEST_RUN_ID_2_11 }}
+          value: ${{ github.event.inputs.qase-test-run-id-2-11 }}
 
       - name: Create config.yaml
         run: |
@@ -334,8 +367,8 @@ jobs:
           slack-channel: ${{ secrets.SLACK_CHANNEL }}
           slack-token: ${{ secrets.SLACK_TOKEN }}
 
-  v2-10-head:
-    name: v2.10.6 -> v2.10-head
+  v2-10:
+    name: v2.10.6 -> ${{ github.event.inputs.upgraded-rancher-version-2-10 }}
     runs-on: ubuntu-latest
     environment: upgrade-prime-staging
 
@@ -360,13 +393,13 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: v2.10.6
+          value: ${{ env.RANCHER_VERSION_2_10 }}
 
       - name: Set upgraded Rancher version
         uses: ./.github/actions/set-env-var
         with:
           key: UPGRADED_RANCHER_VERSION
-          value: v2.10-head
+          value: ${{ github.event.inputs.upgraded-rancher-version-2-10 }}
 
       - name: Set RKE2 version
         uses: ./.github/actions/set-env-var
@@ -378,7 +411,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: QASE_TEST_RUN_ID
-          value: ${{ env.QASE_TEST_RUN_ID_2_10 }}
+          value: ${{ github.event.inputs.qase-test-run-id-2-10 }}
 
       - name: Create config.yaml
         run: |
@@ -488,8 +521,8 @@ jobs:
           slack-channel: ${{ secrets.SLACK_CHANNEL }}
           slack-token: ${{ secrets.SLACK_TOKEN }}
 
-  v2-9-head:
-    name: v2.9.10 -> v2.9-head
+  v2-9:
+    name: v2.9.10 -> ${{ github.event.inputs.upgraded-rancher-version-2-9 }}
     runs-on: ubuntu-latest
     environment: upgrade-prime-staging
 
@@ -514,13 +547,13 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: v2.9.10
+          value: ${{ env.RANCHER_VERSION_2_9 }}
 
       - name: Set upgraded Rancher version
         uses: ./.github/actions/set-env-var
         with:
           key: UPGRADED_RANCHER_VERSION
-          value: v2.9-head
+          value: ${{ github.event.inputs.upgraded-rancher-version-2-9 }}
 
       - name: Set RKE2 version
         uses: ./.github/actions/set-env-var
@@ -532,7 +565,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: QASE_TEST_RUN_ID
-          value: ${{ env.QASE_TEST_RUN_ID_2_9 }}
+          value: ${{ github.event.inputs.qase-test-run-id-2-9 }}
 
       - name: Create config.yaml
         run: |


### PR DESCRIPTION
### Issue: N/A

### Description
As per offline discussions, we want to ensure that we have a means to have our recurring runs and release testing work together. An easy way to do this is to leverage just one YAML for each test. We do this by setting a default value when on a schedule and for release testing, we manually trigger the workflow with inputted values.

Long term, the goal is to ensure that we have a trigger in `rancher/rancher` so when a new alpha/RC is cut, the release testing portion automatically will occur. But this will be a workaround in the meantime.