### PR TITLE
Add v2.12 to the list of release lines

### DIFF
--- a/.github/workflows/check-rancher-tag.yaml
+++ b/.github/workflows/check-rancher-tag.yaml
@@ -28,7 +28,7 @@ jobs:
         id: get-latest-tag
         uses: ./.github/actions/get-latest-rancher-tag
         with:
-          release_lines: "v2.11 v2.10 v2.9"
+          release_lines: "v2.12 v2.11 v2.10 v2.9"
           prime_artifacts_path: ${{ secrets.PRIME_ARTIFACTS_PATH }}
 
       - name: Check for new Rancher tag


### PR DESCRIPTION
### Issue: N/A

### Description
Small PR to add `v2.12` to the release lines so that `check rancher tag` workflow can run the sanity and sanity upgrade tests against alphas.