### PR TITLE
Update rancher and qase versions for scheduled runs

### DIFF
--- a/.github/workflows/airgap-test.yaml
+++ b/.github/workflows/airgap-test.yaml
@@ -155,7 +155,7 @@ jobs:
       - name: Reporting Results to Qase
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
+          qase-test-run-id: ${{ vars.QASE_RELEASE_TEST_RUN_ID_2_11 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -301,7 +301,7 @@ jobs:
       - name: Reporting Results to Qase
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
+          qase-test-run-id: ${{ vars.QASE_RELEASE_TEST_RUN_ID_2_10 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -447,7 +447,7 @@ jobs:
       - name: Reporting Results to Qase
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
+          qase-test-run-id: ${{ vars.QASE_RELEASE_TEST_RUN_ID_2_9 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack

--- a/.github/workflows/airgap-upgrade-test.yaml
+++ b/.github/workflows/airgap-upgrade-test.yaml
@@ -160,7 +160,7 @@ jobs:
       - name: Reporting Results to Qase
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
+          qase-test-run-id: ${{ vars.QASE_RELEASE_TEST_RUN_ID_2_11 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -311,7 +311,7 @@ jobs:
       - name: Reporting Results to Qase
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
+          qase-test-run-id: ${{ vars.QASE_RELEASE_TEST_RUN_ID_2_10 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -462,7 +462,7 @@ jobs:
       - name: Reporting Results to Qase
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
+          qase-test-run-id: ${{ vars.QASE_RELEASE_TEST_RUN_ID_2_9 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack

--- a/.github/workflows/pr-sanity-test.yaml
+++ b/.github/workflows/pr-sanity-test.yaml
@@ -96,7 +96,7 @@ jobs:
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
+              rancherTagVersion: "${{ vars.RANCHER_VERSION_2_12_HEAD }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_12 }}${{ vars.RKE2_VERSION_SUFFIX }}"
           terratest:
@@ -138,7 +138,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
+          qase-test-run-id: ${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_12 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack

--- a/.github/workflows/proxy-test.yaml
+++ b/.github/workflows/proxy-test.yaml
@@ -90,7 +90,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-12 }}
+          value: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-12 || vars.RANCHER_VERSION_2_12_HEAD }}
 
       - name: Get Release Qase ID
         if: ${{ github.event.inputs.rancher_version }}
@@ -106,7 +106,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: QASE_TEST_RUN_ID
-          value: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-12 }}
+          value: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-12 || vars.QASE_DEFAULT_TEST_RUN_ID_2_12 }}
 
       - name: Create config.yaml
         run: |
@@ -160,7 +160,7 @@ jobs:
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
+              rancherTagVersion: "${{ vars.RANCHER_VERSION_2_12_HEAD }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_12 }}"
             standaloneRegistry:
@@ -206,7 +206,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
+          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-12 || vars.QASE_DEFAULT_TEST_RUN_ID_2_12 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -256,7 +256,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-11 }}
+          value: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-11 || vars.RANCHER_VERSION_2_11_HEAD }}
 
       - name: Get Release Qase ID
         if: ${{ github.event.inputs.rancher_version }}
@@ -272,7 +272,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: QASE_TEST_RUN_ID
-          value: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-11 }}
+          value: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-11 || vars.QASE_DEFAULT_TEST_RUN_ID_2_11 }}
 
       - name: Create config.yaml
         run: |
@@ -326,7 +326,7 @@ jobs:
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
+              rancherTagVersion: "${{ vars.RANCHER_VERSION_2_11_HEAD }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_11 }}"
             standaloneRegistry:
@@ -372,7 +372,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
+          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-11 || vars.QASE_DEFAULT_TEST_RUN_ID_2_11 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -422,7 +422,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: ${{ github.event.inputs.rancher-version-2-10 || env.RANCHER_VERSION_2_10 }}
+          value: ${{ github.event.inputs.rancher-version-2-10 || github.event.inputs.qase-test-run-id-2-10 || vars.RANCHER_VERSION_2_10_HEAD }}
 
       - name: Get Release Qase ID
         if: ${{ github.event.inputs.rancher_version }}
@@ -493,7 +493,7 @@ jobs:
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
-              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
+              rancherTagVersion: "${{ vars.RANCHER_VERSION_2_10_HEAD }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_10 }}"
             standaloneRegistry:
@@ -539,7 +539,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
+          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-10 || vars.QASE_DEFAULT_TEST_RUN_ID_2_10 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -589,7 +589,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-9 }}
+          value: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-9 || vars.RANCHER_VERSION_2_9_HEAD }}
 
       - name: Get Release Qase ID
         if: ${{ github.event.inputs.rancher_version }}
@@ -605,7 +605,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: QASE_TEST_RUN_ID
-          value: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-9 }}
+          value: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-9 || vars.QASE_DEFAULT_TEST_RUN_ID_2_9 }}
 
       - name: Create config.yaml
         run: |
@@ -660,7 +660,7 @@ jobs:
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
-              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
+              rancherTagVersion: "${{ vars.RANCHER_VERSION_2_9_HEAD }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_9 }}"
             standaloneRegistry:
@@ -706,7 +706,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
+          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-9 || vars.QASE_DEFAULT_TEST_RUN_ID_2_9 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack

--- a/.github/workflows/proxy-upgrade-test.yaml
+++ b/.github/workflows/proxy-upgrade-test.yaml
@@ -89,7 +89,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: UPGRADED_RANCHER_VERSION
-          value: ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-12 }}
+          value: ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-12 || vars.QASE_DEFAULT_TEST_RUN_ID_2_12 }}
 
       - name: Get Release Qase ID
         if: ${{ github.event.inputs.rancher_version }}
@@ -165,7 +165,7 @@ jobs:
               upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
               upgradedRancherRepo: "${{ secrets.UPGRADED_RANCHER_REPO }}"
               upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
+              upgradedRancherTagVersion: "${{ vars.RANCHER_VERSION_2_12_HEAD }}"
             standaloneRegistry:
               registryName: "${{ secrets.REGISTRY_NAME }}"
               registryPassword: "${{ secrets.REGISTRY_PASSWORD }}"
@@ -209,7 +209,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
+          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-12 || vars.QASE_DEFAULT_TEST_RUN_ID_2_12 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -259,7 +259,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: UPGRADED_RANCHER_VERSION
-          value: ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-11 }}
+          value: ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-11 || vars.RANCHER_VERSION_2_11_HEAD }}
 
       - name: Get Release Qase ID
         if: ${{ github.event.inputs.rancher_version }}
@@ -275,7 +275,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: QASE_TEST_RUN_ID
-          value: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-11 }}
+          value: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-11 || vars.QASE_DEFAULT_TEST_RUN_ID_2_11 }}
 
       - name: Create config.yaml
         run: |
@@ -335,7 +335,7 @@ jobs:
               upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
               upgradedRancherRepo: "${{ secrets.UPGRADED_RANCHER_REPO }}"
               upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
+              upgradedRancherTagVersion: "${{ vars.RANCHER_VERSION_2_11_HEAD }}"
             standaloneRegistry:
               registryName: "${{ secrets.REGISTRY_NAME }}"
               registryPassword: "${{ secrets.REGISTRY_PASSWORD }}"
@@ -379,7 +379,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ github.event.inputs.qase-test-run-id-2-11 || env.QASE_TEST_RUN_ID_2_11 }}
+          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-11 || vars.QASE_DEFAULT_TEST_RUN_ID_2_11 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -429,7 +429,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: UPGRADED_RANCHER_VERSION
-          value: ${{ github.event.inputs.upgraded-rancher-version-2-10 || env.UPGRADED_RANCHER_VERSION_2_10 }}
+          value: ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-10 || vars.RANCHER_VERSION_2_10_HEAD }}
 
       - name: Get Release Qase ID
         if: ${{ github.event.inputs.rancher_version }}
@@ -445,7 +445,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: QASE_TEST_RUN_ID
-          value: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-10 }}
+          value: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-10 || vars.QASE_DEFAULT_TEST_RUN_ID_2_10 }}
 
       - name: Create config.yaml
         run: |
@@ -507,7 +507,7 @@ jobs:
               upgradedRancherRepo: "${{ secrets.UPGRADED_RANCHER_REPO }}"
               upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
               upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
+              upgradedRancherTagVersion: "${{ vars.RANCHER_VERSION_2_10_HEAD }}"
             standaloneRegistry:
               registryName: "${{ secrets.REGISTRY_NAME }}"
               registryPassword: "${{ secrets.REGISTRY_PASSWORD }}"
@@ -551,7 +551,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ github.event.inputs.qase-test-run-id-2-10 || env.QASE_TEST_RUN_ID_2_10 }}
+          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-10 || vars.QASE_DEFAULT_TEST_RUN_ID_2_10 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -601,7 +601,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: UPGRADED_RANCHER_VERSION
-          value: ${{ github.event.inputs.upgraded-rancher-version-2-9 || env.UPGRADED_RANCHER_VERSION_2_9 }}
+          value: ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-9 || vars.RANCHER_VERSION_2_9_HEAD }}
 
       - name: Get Release Qase ID
         if: ${{ github.event.inputs.rancher_version }}
@@ -617,7 +617,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: QASE_TEST_RUN_ID
-          value: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-9 }}
+          value: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-9 || vars.QASE_DEFAULT_TEST_RUN_ID_2_9 }}
 
       - name: Create config.yaml
         run: |
@@ -679,7 +679,7 @@ jobs:
               upgradedRancherRepo: "${{ secrets.UPGRADED_RANCHER_REPO }}"
               upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
               upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
+              upgradedRancherTagVersion: "${{ vars.RANCHER_VERSION_2_9_HEAD }}"
             standaloneRegistry:
               registryName: "${{ secrets.REGISTRY_NAME }}"
               registryPassword: "${{ secrets.REGISTRY_PASSWORD }}"
@@ -723,7 +723,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ github.event.inputs.qase-test-run-id-2-9 || env.QASE_TEST_RUN_ID_2_9 }}
+          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-9 || vars.QASE_DEFAULT_TEST_RUN_ID_2_9 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack

--- a/.github/workflows/registry-test.yaml
+++ b/.github/workflows/registry-test.yaml
@@ -168,7 +168,7 @@ jobs:
       - name: Reporting Results to Qase
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
+          qase-test-run-id: ${{ vars.QASE_RELEASE_TEST_RUN_ID_2_11 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -328,7 +328,7 @@ jobs:
       - name: Reporting Results to Qase
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
+          qase-test-run-id: ${{ vars.QASE_RELEASE_TEST_RUN_ID_2_10 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -488,7 +488,7 @@ jobs:
       - name: Reporting Results to Qase
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
+          qase-test-run-id: ${{ vars.QASE_RELEASE_TEST_RUN_ID_2_9 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack

--- a/.github/workflows/sanity-test.yaml
+++ b/.github/workflows/sanity-test.yaml
@@ -81,7 +81,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-12 }}
+          value: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-12 || vars.RANCHER_VERSION_2_12_HEAD}}
 
       - name: Get Release Qase ID
         if: ${{ github.event.inputs.rancher_version }}
@@ -97,7 +97,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: QASE_TEST_RUN_ID
-          value: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-12 }}
+          value: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-12 || vars.QASE_DEFAULT_TEST_RUN_ID_2_12}}
 
       - name: Create config.yaml
         run: |
@@ -149,7 +149,7 @@ jobs:
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
+              rancherTagVersion: "${{ vars.RANCHER_VERSION_2_12_HEAD }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_12 }}${{ vars.RKE2_VERSION_SUFFIX }}"
           terratest:
@@ -191,7 +191,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
+          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-12 || vars.QASE_DEFAULT_TEST_RUN_ID_2_12 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -228,7 +228,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-11 }}
+          value: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-11 || vars.RANCHER_VERSION_2_11_HEAD }}
 
       - name: Get Release Qase ID
         if: ${{ github.event.inputs.rancher_version }}
@@ -244,7 +244,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: QASE_TEST_RUN_ID
-          value: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-11 }}
+          value: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-11 || vars.QASE_DEFAULT_TEST_RUN_ID_2_11 }}
 
       - name: Create config.yaml
         run: |
@@ -296,7 +296,7 @@ jobs:
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
+              rancherTagVersion: "${{ vars.RANCHER_VERSION_2_11_HEAD }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_11 }}${{ vars.RKE2_VERSION_SUFFIX }}"
           terratest:
@@ -338,7 +338,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
+          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-11 || vars.QASE_DEFAULT_TEST_RUN_ID_2_11 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -375,7 +375,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-10 }}
+          value: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-10 || vars.RANCHER_VERSION_2_10_HEAD }}
 
       - name: Get Release Qase ID
         if: ${{ github.event.inputs.rancher_version }}
@@ -391,7 +391,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: QASE_TEST_RUN_ID
-          value: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-10 }}
+          value: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-10 || vars.QASE_DEFAULT_TEST_RUN_ID_2_10 }}
 
       - name: Create config.yaml
         run: |
@@ -444,7 +444,7 @@ jobs:
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
-              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
+              rancherTagVersion: "${{ vars.RANCHER_VERSION_2_10_HEAD }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_10 }}${{ vars.RKE2_VERSION_SUFFIX }}"
           terratest:
@@ -486,7 +486,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
+          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-10 || vars.QASE_DEFAULT_TEST_RUN_ID_2_10 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -523,7 +523,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-9 }}
+          value: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-9 || vars.RANCHER_VERSION_2_9_HEAD }}
 
       - name: Get Release Qase ID
         if: ${{ github.event.inputs.rancher_version }}
@@ -539,8 +539,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: QASE_TEST_RUN_ID
-          value: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-9 }}
-
+          value: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-9 || vars.QASE_DEFAULT_TEST_RUN_ID_2_9 }}
       - name: Create config.yaml
         run: |
           cat > config.yaml <<EOF
@@ -592,7 +591,7 @@ jobs:
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
-              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
+              rancherTagVersion: "${{ vars.RANCHER_VERSION_2_9_HEAD }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_9 }}${{ vars.RKE2_VERSION_SUFFIX }}"
           terratest:
@@ -634,7 +633,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
+          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-9 || vars.QASE_DEFAULT_TEST_RUN_ID_2_9 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack

--- a/.github/workflows/sanity-upgrade-test.yaml
+++ b/.github/workflows/sanity-upgrade-test.yaml
@@ -80,7 +80,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: UPGRADED_RANCHER_VERSION
-          value: ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-12 }}
+          value: ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-12 || vars.RANCHER_VERSION_2_12_HEAD }}
 
       - name: Get Release Qase ID
         if: ${{ github.event.inputs.rancher_version }}
@@ -96,7 +96,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: QASE_TEST_RUN_ID
-          value: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-12 }}
+          value: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-12 || vars.QASE_DEFAULT_TEST_RUN_ID_2_12 }}
 
       - name: Create config.yaml
         run: |
@@ -154,7 +154,7 @@ jobs:
               upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL}}"
               upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
               upgradedRancherRepo: "${{ secrets.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION}}"
+              upgradedRancherTagVersion: "${{ vars.RANCHER_VERSION_2_12_HEAD}}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             nodeCount: ${{ vars.NODE_COUNT }}
@@ -194,7 +194,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
+          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-12 || vars.QASE_DEFAULT_TEST_RUN_ID_2_12 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -231,7 +231,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: UPGRADED_RANCHER_VERSION
-          value: ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-11 }}
+          value: ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-11 || vars.RANCHER_VERSION_2_11_HEAD }}
 
       - name: Get Release Qase ID
         if: ${{ github.event.inputs.rancher_version }}
@@ -247,7 +247,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: QASE_TEST_RUN_ID
-          value: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-11 }}
+          value: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-11 || vars.QASE_DEFAULT_TEST_RUN_ID_2_11 }}
 
       - name: Create config.yaml
         run: |
@@ -305,7 +305,7 @@ jobs:
               upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL}}"
               upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
               upgradedRancherRepo: "${{ secrets.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION}}"
+              upgradedRancherTagVersion: "${{ vars.RANCHER_VERSION_2_11_HEAD }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             nodeCount: ${{ vars.NODE_COUNT }}
@@ -345,7 +345,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
+          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-11 || vars.QASE_DEFAULT_TEST_RUN_ID_2_11 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -382,7 +382,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: UPGRADED_RANCHER_VERSION
-          value: ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-10 }}
+          value: ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-10 || vars.RANCHER_VERSION_2_10_HEAD }}
 
       - name: Get Release Qase ID
         if: ${{ github.event.inputs.rancher_version }}
@@ -398,7 +398,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: QASE_TEST_RUN_ID
-          value: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-10 }}
+          value: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-10 || vars.QASE_DEFAULT_TEST_RUN_ID_2_10 }}
 
       - name: Create config.yaml
         run: |
@@ -458,7 +458,7 @@ jobs:
               upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL}}"
               upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
               upgradedRancherRepo: "${{ secrets.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION}}"
+              upgradedRancherTagVersion: "${{ vars.RANCHER_VERSION_2_10_HEAD }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             nodeCount: ${{ vars.NODE_COUNT }}
@@ -498,7 +498,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
+          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-10 || vars.QASE_DEFAULT_TEST_RUN_ID_2_10 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -535,7 +535,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: UPGRADED_RANCHER_VERSION
-          value: ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-9 }}
+          value: ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-9 || vars.RANCHER_VERSION_2_9_HEAD }}
 
       - name: Get Release Qase ID
         if: ${{ github.event.inputs.rancher_version }}
@@ -551,7 +551,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: QASE_TEST_RUN_ID
-          value: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-9 }}
+          value: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-9 || vars.QASE_DEFAULT_TEST_RUN_ID_2_9 }}
 
       - name: Create config.yaml
         run: |
@@ -611,7 +611,7 @@ jobs:
               upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL}}"
               upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
               upgradedRancherRepo: "${{ secrets.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION}}"
+              upgradedRancherTagVersion: "${{ vars.RANCHER_VERSION_2_9_HEAD }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             nodeCount: ${{ vars.NODE_COUNT }}
@@ -651,7 +651,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ env.QASE_TEST_RUN_ID }}
+          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-9 || vars.QASE_DEFAULT_TEST_RUN_ID_2_9 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack


### PR DESCRIPTION
### Issue: N/A

### Description
The scheduled sanity job failed. Looking into it, it's because the rancher and qase versions were empty. Upon further investigation, we simply need to just ensure that in a scenario where we have a scheduled run, we update our conditionals for that.