### PR TITLE
Update missed areas for rancher and qase versions

### DIFF
--- a/.github/workflows/proxy-test.yaml
+++ b/.github/workflows/proxy-test.yaml
@@ -89,7 +89,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-12 || vars.RANCHER_VERSION_2_12_HEAD }}
+          value: ${{ github.event.inputs.rancher_version || (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher-version-2-12) || vars.RANCHER_VERSION_2_12_HEAD }}
 
       - name: Get Release Qase ID
         if: ${{ github.event.inputs.rancher_version }}
@@ -205,7 +205,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-12 || vars.QASE_DEFAULT_TEST_RUN_ID_2_12 }}
+          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || (github.event_name == 'workflow_dispatch' && github.event.inputs.qase-test-run-id-2-12) || vars.QASE_DEFAULT_TEST_RUN_ID_2_12 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -255,7 +255,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-11 || vars.RANCHER_VERSION_2_11_HEAD }}
+          value: ${{ github.event.inputs.rancher_version || (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher-version-2-11) || vars.RANCHER_VERSION_2_11_HEAD }}
 
       - name: Get Release Qase ID
         if: ${{ github.event.inputs.rancher_version }}
@@ -371,7 +371,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-11 || vars.QASE_DEFAULT_TEST_RUN_ID_2_11 }}
+          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || (github.event_name == 'workflow_dispatch' && github.event.inputs.qase-test-run-id-2-11) || vars.QASE_DEFAULT_TEST_RUN_ID_2_11 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -421,7 +421,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: ${{ github.event.inputs.rancher-version-2-10 || github.event.inputs.qase-test-run-id-2-10 || vars.RANCHER_VERSION_2_10_HEAD }}
+          value: ${{ github.event.inputs.rancher-version-2-10 || (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher-version-2-10) || vars.RANCHER_VERSION_2_10_HEAD }}
 
       - name: Get Release Qase ID
         if: ${{ github.event.inputs.rancher_version }}
@@ -538,7 +538,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-10 || vars.QASE_DEFAULT_TEST_RUN_ID_2_10 }}
+          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || (github.event_name == 'workflow_dispatch' && github.event.inputs.qase-test-run-id-2-10) || vars.QASE_DEFAULT_TEST_RUN_ID_2_10 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -588,7 +588,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-9 || vars.RANCHER_VERSION_2_9_HEAD }}
+          value: ${{ github.event.inputs.rancher_version || (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher-version-2-9) || vars.RANCHER_VERSION_2_9_HEAD }}
 
       - name: Get Release Qase ID
         if: ${{ github.event.inputs.rancher_version }}
@@ -705,7 +705,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-9 || vars.QASE_DEFAULT_TEST_RUN_ID_2_9 }}
+          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || (github.event_name == 'workflow_dispatch' && github.event.inputs.qase-test-run-id-2-9) || vars.QASE_DEFAULT_TEST_RUN_ID_2_9 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack

--- a/.github/workflows/proxy-upgrade-test.yaml
+++ b/.github/workflows/proxy-upgrade-test.yaml
@@ -89,7 +89,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: UPGRADED_RANCHER_VERSION
-          value: ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-12 || vars.QASE_DEFAULT_TEST_RUN_ID_2_12 }}
+          value: ${{ github.event.inputs.rancher_version || (github.event_name == 'workflow_dispatch' && github.event.inputs.upgraded-rancher-version-2-12) || vars.QASE_DEFAULT_TEST_RUN_ID_2_12 }}
 
       - name: Get Release Qase ID
         if: ${{ github.event.inputs.rancher_version }}
@@ -209,7 +209,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-12 || vars.QASE_DEFAULT_TEST_RUN_ID_2_12 }}
+          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || (github.event_name == 'workflow_dispatch' && github.event.inputs.qase-test-run-id-2-12) || vars.QASE_DEFAULT_TEST_RUN_ID_2_12 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -259,7 +259,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: UPGRADED_RANCHER_VERSION
-          value: ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-11 || vars.RANCHER_VERSION_2_11_HEAD }}
+          value: ${{ github.event.inputs.rancher_version || (github.event_name == 'workflow_dispatch' && github.event.inputs.upgraded-rancher-version-2-11) || vars.RANCHER_VERSION_2_11_HEAD }}
 
       - name: Get Release Qase ID
         if: ${{ github.event.inputs.rancher_version }}
@@ -379,7 +379,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-11 || vars.QASE_DEFAULT_TEST_RUN_ID_2_11 }}
+          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || (github.event_name == 'workflow_dispatch' && github.event.inputs.qase-test-run-id-2-11) || vars.QASE_DEFAULT_TEST_RUN_ID_2_11 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -429,7 +429,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: UPGRADED_RANCHER_VERSION
-          value: ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-10 || vars.RANCHER_VERSION_2_10_HEAD }}
+          value: ${{ github.event.inputs.rancher_version || (github.event_name == 'workflow_dispatch' && github.event.inputs.upgraded-rancher-version-2-10) || vars.RANCHER_VERSION_2_10_HEAD }}
 
       - name: Get Release Qase ID
         if: ${{ github.event.inputs.rancher_version }}
@@ -551,7 +551,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-10 || vars.QASE_DEFAULT_TEST_RUN_ID_2_10 }}
+          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || (github.event_name == 'workflow_dispatch' && github.event.inputs.qase-test-run-id-2-10) || vars.QASE_DEFAULT_TEST_RUN_ID_2_10 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -601,7 +601,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: UPGRADED_RANCHER_VERSION
-          value: ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-9 || vars.RANCHER_VERSION_2_9_HEAD }}
+          value: ${{ github.event.inputs.rancher_version || (github.event_name == 'workflow_dispatch' && github.event.inputs.upgraded-rancher-version-2-9) || vars.RANCHER_VERSION_2_9_HEAD }}
 
       - name: Get Release Qase ID
         if: ${{ github.event.inputs.rancher_version }}
@@ -723,7 +723,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-9 || vars.QASE_DEFAULT_TEST_RUN_ID_2_9 }}
+          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || (github.event_name == 'workflow_dispatch' && github.event.inputs.qase-test-run-id-2-9) || vars.QASE_DEFAULT_TEST_RUN_ID_2_9 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack

--- a/.github/workflows/sanity-test.yaml
+++ b/.github/workflows/sanity-test.yaml
@@ -80,7 +80,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-12 || vars.RANCHER_VERSION_2_12_HEAD }}
+          value: ${{ github.event.inputs.rancher_version || (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher-version-2-12) || vars.RANCHER_VERSION_2_12_HEAD }}
 
       - name: Get Release Qase ID
         if: ${{ github.event.inputs.rancher_version }}
@@ -190,7 +190,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-12 || vars.QASE_DEFAULT_TEST_RUN_ID_2_12 }}
+          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || (github.event_name == 'workflow_dispatch' && github.event.inputs.qase-test-run-id-2-12) || vars.QASE_DEFAULT_TEST_RUN_ID_2_12 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -202,7 +202,7 @@ jobs:
 
   v2-11:
     if: ${{ github.event_name == 'schedule' }} || (startsWith(inputs.rancher_version, 'v2.11.'))
-    name: ${{ github.event.inputs.rancher-version-2-11 }}
+    name: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-11 }}
     runs-on: ubuntu-latest
     environment: latest
 
@@ -227,7 +227,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-11 || vars.RANCHER_VERSION_2_11_HEAD }}
+          value: ${{ github.event.inputs.rancher_version || (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher-version-2-11) || vars.RANCHER_VERSION_2_11_HEAD }}
 
       - name: Get Release Qase ID
         if: ${{ github.event.inputs.rancher_version }}
@@ -337,7 +337,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-11 || vars.QASE_DEFAULT_TEST_RUN_ID_2_11 }}
+          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || (github.event_name == 'workflow_dispatch' && github.event.inputs.qase-test-run-id-2-11) || vars.QASE_DEFAULT_TEST_RUN_ID_2_11 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -349,7 +349,7 @@ jobs:
 
   v2-10:
     if: ${{ github.event_name == 'schedule' }} || (startsWith(inputs.rancher_version, 'v2.10.'))
-    name: ${{ github.event.inputs.rancher-version-2-10 }}
+    name: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-10 }}
     runs-on: ubuntu-latest
     environment: staging-latest
 
@@ -374,7 +374,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-10 || vars.RANCHER_VERSION_2_10_HEAD }}
+          value: ${{ github.event.inputs.rancher_version || (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher-version-2-10) || vars.RANCHER_VERSION_2_10_HEAD }}
 
       - name: Get Release Qase ID
         if: ${{ github.event.inputs.rancher_version }}
@@ -485,7 +485,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-10 || vars.QASE_DEFAULT_TEST_RUN_ID_2_10 }}
+          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || (github.event_name == 'workflow_dispatch' && github.event.inputs.qase-test-run-id-2-10) || vars.QASE_DEFAULT_TEST_RUN_ID_2_10 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -497,7 +497,7 @@ jobs:
 
   v2-9:
     if: ${{ github.event_name == 'schedule' }} || (startsWith(inputs.rancher_version, 'v2.9.'))
-    name: ${{ github.event.inputs.rancher-version-2-9 }}
+    name: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-9 }}
     runs-on: ubuntu-latest
     environment: staging-latest
 
@@ -522,7 +522,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-9 || vars.RANCHER_VERSION_2_9_HEAD }}
+          value: ${{ github.event.inputs.rancher_version || (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher-version-2-9) || vars.RANCHER_VERSION_2_9_HEAD }}
 
       - name: Get Release Qase ID
         if: ${{ github.event.inputs.rancher_version }}
@@ -632,7 +632,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-9 || vars.QASE_DEFAULT_TEST_RUN_ID_2_9 }}
+          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || (github.event_name == 'workflow_dispatch' && github.event.inputs.qase-test-run-id-2-9) || vars.QASE_DEFAULT_TEST_RUN_ID_2_9 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack

--- a/.github/workflows/sanity-upgrade-test.yaml
+++ b/.github/workflows/sanity-upgrade-test.yaml
@@ -80,7 +80,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: UPGRADED_RANCHER_VERSION
-          value: ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-12 || vars.RANCHER_VERSION_2_12_HEAD }}
+          value: ${{ github.event.inputs.rancher_version || (github.event_name == 'workflow_dispatch' && github.event.inputs.upgraded-rancher-version-2-12) || vars.RANCHER_VERSION_2_12_HEAD }}
 
       - name: Get Release Qase ID
         if: ${{ github.event.inputs.rancher_version }}
@@ -194,7 +194,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-12 || vars.QASE_DEFAULT_TEST_RUN_ID_2_12 }}
+          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || (github.event_name == 'workflow_dispatch' && github.event.inputs.qase-test-run-id-2-12) || vars.QASE_DEFAULT_TEST_RUN_ID_2_12 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -206,7 +206,7 @@ jobs:
 
   v2-11:
     if: ${{ github.event_name == 'schedule' }} || (startsWith(inputs.rancher_version, 'v2.11.'))
-    name: v2.11.2 -> ${{ github.event.inputs.upgraded-rancher-version-2-11 }}
+    name: ${{ vars.RELEASED_RANCHER_VERSION_2_11 }} -> ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-11 }}
     runs-on: ubuntu-latest
     environment: latest
 
@@ -231,7 +231,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: UPGRADED_RANCHER_VERSION
-          value: ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-11 || vars.RANCHER_VERSION_2_11_HEAD }}
+          value: ${{ github.event.inputs.rancher_version || (github.event_name == 'workflow_dispatch' && github.event.inputs.upgraded-rancher-version-2-11) || vars.RANCHER_VERSION_2_11_HEAD }}
 
       - name: Get Release Qase ID
         if: ${{ github.event.inputs.rancher_version }}
@@ -345,7 +345,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-11 || vars.QASE_DEFAULT_TEST_RUN_ID_2_11 }}
+          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || (github.event_name == 'workflow_dispatch' && github.event.inputs.qase-test-run-id-2-11) || vars.QASE_DEFAULT_TEST_RUN_ID_2_11 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -357,7 +357,7 @@ jobs:
 
   v2-10:
     if: ${{ github.event_name == 'schedule' }} || (startsWith(inputs.rancher_version, 'v2.10.'))
-    name: v2.10.6 -> ${{ github.event.inputs.upgraded-rancher-version-2-10 }}
+    name: ${{ vars.RELEASED_RANCHER_VERSION_2_10 }} -> ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-10 }}
     runs-on: ubuntu-latest
     environment: upgrade-prime-staging
 
@@ -382,7 +382,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: UPGRADED_RANCHER_VERSION
-          value: ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-10 || vars.RANCHER_VERSION_2_10_HEAD }}
+          value: ${{ github.event.inputs.rancher_version || (github.event_name == 'workflow_dispatch' && github.event.inputs.upgraded-rancher-version-2-10) || vars.RANCHER_VERSION_2_10_HEAD }}
 
       - name: Get Release Qase ID
         if: ${{ github.event.inputs.rancher_version }}
@@ -498,7 +498,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-10 || vars.QASE_DEFAULT_TEST_RUN_ID_2_10 }}
+          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || (github.event_name == 'workflow_dispatch' && github.event.inputs.qase-test-run-id-2-10) || vars.QASE_DEFAULT_TEST_RUN_ID_2_10 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -510,7 +510,7 @@ jobs:
 
   v2-9:
     if: ${{ github.event_name == 'schedule' }} || (startsWith(inputs.rancher_version, 'v2.9.'))
-    name: v2.9.10 -> ${{ github.event.inputs.upgraded-rancher-version-2-9 }}
+    name: ${{ vars.RELEASED_RANCHER_VERSION_2_9 }} -> ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-9 }}
     runs-on: ubuntu-latest
     environment: upgrade-prime-staging
 
@@ -535,7 +535,7 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: UPGRADED_RANCHER_VERSION
-          value: ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-9 || vars.RANCHER_VERSION_2_9_HEAD }}
+          value: ${{ github.event.inputs.rancher_version || (github.event_name == 'workflow_dispatch' && github.event.inputs.upgraded-rancher-version-2-9) || vars.RANCHER_VERSION_2_9_HEAD }}
 
       - name: Get Release Qase ID
         if: ${{ github.event.inputs.rancher_version }}
@@ -651,7 +651,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || github.event.inputs.qase-test-run-id-2-9 || vars.QASE_DEFAULT_TEST_RUN_ID_2_9 }}
+          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || (github.event_name == 'workflow_dispatch' && github.event.inputs.qase-test-run-id-2-9) || vars.QASE_DEFAULT_TEST_RUN_ID_2_9 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack


### PR DESCRIPTION
### Issue: N/A

### Description
Like description says, updating missed areas for updated Rancher and Qase versions from the last PR. Testing in the PR worked, but did not once merged as these updates weren't existing.