### PR TITLE
Add recurring runs for Rancher2 tests

### DIFF
--- a/.github/workflows/rancher2-recurring-test.yaml
+++ b/.github/workflows/rancher2-recurring-test.yaml
@@ -1,0 +1,716 @@
+---
+name: Rancher2 Recurring Runs Testing
+
+on:
+  schedule:
+    - cron: "0 7 * * 2,4"
+  workflow_dispatch:
+    inputs:
+      rancher_version:
+        description: "Rancher tag version provided from check-rancher-tag workflow"
+      rancher-version-2-12:
+        description: "Rancher version for v2.12-head"
+        required: true
+        default: "head"
+      rancher-version-2-11:
+        description: "Rancher version for v2.11-head"
+        required: true
+        default: "v2.11-head"
+      rancher-version-2-10:
+        description: "Rancher version for v2.10-head"
+        required: true
+        default: "v2.10-head"
+      rancher-version-2-9:
+        description: "Rancher version for v2.9-head"
+        required: true
+        default: "v2.9-head"
+      qase-test-run-id-2-12:
+        description: "Qase Test Run ID for v2.12-head"
+        required: true
+        default: "4512"
+      qase-test-run-id-2-11:
+        description: "Qase Test Run ID for v2.11-head"
+        required: true
+        default: "4541"
+      qase-test-run-id-2-10:
+        description: "Qase Test Run ID for v2.10-head"
+        required: true
+        default: "4542"
+      qase-test-run-id-2-9:
+        description: "Qase Test Run ID for v2.9-head"
+        required: true
+        default: "4540"
+
+env:
+  AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
+  AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+  CLOUD_PROVIDER_VERSION: "5.95.0"
+  HOSTNAME_PREFIX: "tfp-recur"
+  LOCALS_PROVIDER_VERSION: "${{ vars.LOCALS_PROVIDER_VERSION }}"
+  PACKAGE: "rancher2/recurring"
+  RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION }}"
+  RKE_PROVIDER_VERSION: "${{ vars.RKE_PROVIDER_VERSION }}"
+  SUITE: "^TestTfpRancher2RecurringRunsTestSuite$"
+  TIMEOUT: "4h"
+
+jobs:
+  v2-12:
+    if: ${{ github.event_name == 'schedule' }} || (startsWith(inputs.rancher_version, 'v2.12.')) 
+    name: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-12 }}
+    runs-on: ubuntu-latest
+    environment: latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Whitelist Runner IP
+        uses: ./.github/actions/whitelist-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"
+
+      - name: Set up SSH Keys
+        uses: ./.github/actions/setup-ssh-keys
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ssh-private-key-name: ${{ secrets.SSH_PRIVATE_KEY_NAME }}
+          windows-ssh-private-key: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY }}
+          windows-ssh-private-key-name: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}
+
+      - name: Uniquify hostname prefix
+        uses: ./.github/actions/uniquify-hostname
+
+      - name: Set Rancher version
+        uses: ./.github/actions/set-env-var
+        with:
+          key: RANCHER_VERSION
+          value: ${{ github.event.inputs.rancher_version || (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher-version-2-12) || (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_12_HEAD) }}
+
+      - name: Get Release Qase ID
+        if: ${{ github.event.inputs.rancher_version }}
+        id: get-release-qase-id
+        uses: ./.github/actions/get-release-qase-id
+        with:
+          tag: ${{ github.event.inputs.rancher_version }}
+          qase_test_run_id_2_11: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_11 }}"
+          qase_test_run_id_2_10: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_10 }}"
+          qase_test_run_id_2_9: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_9 }}"
+
+      - name: Set Qase Test Run ID
+        uses: ./.github/actions/set-env-var
+        with:
+          key: QASE_TEST_RUN_ID
+          value: ${{ steps.get-release-qase-id.outputs.id || (github.event_name == 'workflow_dispatch' && github.event.inputs.qase-test-run-id-2-12) || (github.event_name == 'schedule' && vars.QASE_DEFAULT_TEST_RUN_ID_2_12) }}
+
+      - name: Create config.yaml
+        run: |
+          cat > config.yaml <<EOF
+          rancher:
+            host: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
+            adminPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
+            insecure: true
+          upgradeInput:
+            clusters:
+              -  versionToUpgrade: ${{ vars.RKE2_VERSION_2_12 }}
+          terraform:
+            cni: "${{ secrets.CNI }}"
+            defaultClusterRoleForProjectMembers: "true"
+            enableNetworkPolicy: false
+            provider: "${{ vars.PROVIDER_AMAZON }}"
+            privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
+            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
+            windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
+            awsCredentials:
+              awsAccessKey: "${{ secrets.AWS_ACCESS_KEY_ID }}"
+              awsSecretKey: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+            awsConfig:
+              ami: "${{ secrets.AWS_AMI }}"
+              awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
+              awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              region: "${{ secrets.AWS_REGION }}"
+              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
+              awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+              awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+              awsVpcID: "${{ secrets.AWS_VPC_ID }}"
+              awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
+              awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
+              awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
+              awsUser: "${{ secrets.AWS_USER }}"
+              sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
+              timeout: "${{ vars.TIMEOUT }}"
+              windowsAMI: "${{ secrets.WINDOWS_AMI }}"
+              windowsAWSUser: "${{ secrets.AWS_WINDOWS_USER }}" 
+              windowsAWSPassword: "${{ secrets.AWS_WINDOWS_PASSWORD }}"
+              windowsInstanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
+              windowsKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}"
+              ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
+              loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
+              targetType: "${{ vars.TARGET_TYPE }}"
+            standalone:
+              bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
+              certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_12 }}${{ vars.K3S_VERSION_SUFFIX }}"
+              osUser: "${{ secrets.OS_USER }}"
+              osGroup: "${{ secrets.OS_GROUP }}"
+              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
+              rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
+              rancherImage: "${{ secrets.RANCHER_IMAGE }}"
+              rancherTagVersion: "${{ vars.RANCHER_VERSION_2_12_HEAD }}"
+              repo: "${{ secrets.RANCHER_REPO }}"
+              rke2Version: "${{ vars.RKE2_VERSION_2_12 }}${{ vars.RKE2_VERSION_SUFFIX }}"
+          terratest:
+            pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            nodeCount: ${{ vars.NODE_COUNT }}
+            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            snapshotInput: {}
+          EOF
+
+      - name: Export CATTLE_TEST_CONFIG
+        run: echo "CATTLE_TEST_CONFIG=${{ github.workspace }}/config.yaml" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Set up Go environment
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "./go.mod"
+
+      - name: Build Packages
+        run: ./.github/scripts/build-packages.sh
+
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: "${{ vars.TERRAFORM_VERSION }}"
+          terraform_wrapper: false
+
+      - name: Run Rancher2 Test Suite
+        uses: ./.github/actions/run-test-suite
+        with:
+          package: ${{ env.PACKAGE }}
+          path-to-repo: ${{ secrets.PATH_TO_REPO }}
+          suite: ${{ env.SUITE }}
+          timeout: ${{ env.TIMEOUT }}
+
+      - name: Reporting Results to Qase
+        if: always()
+        uses: ./.github/actions/report-to-qase
+        with:
+          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || (github.event_name == 'workflow_dispatch' && github.event.inputs.qase-test-run-id-2-12) || (github.event_name == 'schedule' && vars.QASE_DEFAULT_TEST_RUN_ID_2_12) }}
+          qase-automation-token: ${{ secrets.QASE_TOKEN }}
+
+      - name: Reporting Results to Slack
+        uses: ./.github/actions/report-to-slack
+        with:
+          job-status: ${{ job.status }}
+          slack-channel: ${{ secrets.SLACK_CHANNEL }}
+          slack-token: ${{ secrets.SLACK_TOKEN }}
+
+      - name: Revoke Runner IP
+        if: always()
+        uses: ./.github/actions/revoke-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"
+
+  v2-11:
+    if: ${{ github.event_name == 'schedule' }} || (startsWith(inputs.rancher_version, 'v2.11.'))
+    name: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-11 }}
+    runs-on: ubuntu-latest
+    environment: latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Whitelist Runner IP
+        uses: ./.github/actions/whitelist-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"
+
+      - name: Set up SSH Keys
+        uses: ./.github/actions/setup-ssh-keys
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ssh-private-key-name: ${{ secrets.SSH_PRIVATE_KEY_NAME }}
+          windows-ssh-private-key: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY }}
+          windows-ssh-private-key-name: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}
+
+      - name: Uniquify hostname prefix
+        uses: ./.github/actions/uniquify-hostname
+
+      - name: Set Rancher version
+        uses: ./.github/actions/set-env-var
+        with:
+          key: RANCHER_VERSION
+          value: ${{ github.event.inputs.rancher_version || (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher-version-2-11) || (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_11_HEAD) }}
+
+      - name: Get Release Qase ID
+        if: ${{ github.event.inputs.rancher_version }}
+        id: get-release-qase-id
+        uses: ./.github/actions/get-release-qase-id
+        with:
+          tag: ${{ github.event.inputs.rancher_version }}
+          qase_test_run_id_2_11: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_11 }}"
+          qase_test_run_id_2_10: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_10 }}"
+          qase_test_run_id_2_9: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_9 }}"
+
+      - name: Set Qase Test Run ID
+        uses: ./.github/actions/set-env-var
+        with:
+          key: QASE_TEST_RUN_ID
+          value: ${{ steps.get-release-qase-id.outputs.id || (github.event_name == 'workflow_dispatch' && (github.event_name == 'schedule' && github.event.inputs.qase-test-run-id-2-11) || vars.QASE_DEFAULT_TEST_RUN_ID_2_11) }}
+
+      - name: Create config.yaml
+        run: |
+          cat > config.yaml <<EOF
+          rancher:
+            host: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
+            adminPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
+            insecure: true
+          upgradeInput:
+            clusters:
+              -  versionToUpgrade: ${{ vars.RKE2_VERSION_2_11 }}
+          terraform:
+            cni: "${{ secrets.CNI }}"
+            defaultClusterRoleForProjectMembers: "true"
+            enableNetworkPolicy: false
+            provider: "${{ vars.PROVIDER_AMAZON }}"
+            privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
+            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
+            windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
+            awsCredentials:
+              awsAccessKey: "${{ secrets.AWS_ACCESS_KEY_ID }}"
+              awsSecretKey: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+            awsConfig:
+              ami: "${{ secrets.AWS_AMI }}"
+              awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
+              awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              region: "${{ secrets.AWS_REGION }}"
+              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
+              awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+              awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+              awsVpcID: "${{ secrets.AWS_VPC_ID }}"
+              awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
+              awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
+              awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
+              awsUser: "${{ secrets.AWS_USER }}"
+              sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
+              timeout: "${{ vars.TIMEOUT }}"
+              windowsAMI: "${{ secrets.WINDOWS_AMI }}"
+              windowsAWSUser: "${{ secrets.AWS_WINDOWS_USER }}" 
+              windowsAWSPassword: "${{ secrets.AWS_WINDOWS_PASSWORD }}"
+              windowsInstanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
+              windowsKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}"
+              ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
+              loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
+              targetType: "${{ vars.TARGET_TYPE }}"
+            standalone:
+              bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
+              certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_11 }}${{ vars.K3S_VERSION_SUFFIX }}"
+              osUser: "${{ secrets.OS_USER }}"
+              osGroup: "${{ secrets.OS_GROUP }}"
+              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
+              rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
+              rancherImage: "${{ secrets.RANCHER_IMAGE }}"
+              rancherTagVersion: "${{ vars.RANCHER_VERSION_2_11_HEAD }}"
+              repo: "${{ secrets.RANCHER_REPO }}"
+              rke2Version: "${{ vars.RKE2_VERSION_2_11 }}${{ vars.RKE2_VERSION_SUFFIX }}"
+          terratest:
+            pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            nodeCount: ${{ vars.NODE_COUNT }}
+            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            snapshotInput: {}
+          EOF
+
+      - name: Export CATTLE_TEST_CONFIG
+        run: echo "CATTLE_TEST_CONFIG=${{ github.workspace }}/config.yaml" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Set up Go environment
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "./go.mod"
+
+      - name: Build Packages
+        run: ./.github/scripts/build-packages.sh
+
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: "${{ vars.TERRAFORM_VERSION }}"
+          terraform_wrapper: false
+
+      - name: Run Rancher2 Test Suite
+        uses: ./.github/actions/run-test-suite
+        with:
+          package: ${{ env.PACKAGE }}
+          path-to-repo: ${{ secrets.PATH_TO_REPO }}
+          suite: ${{ env.SUITE }}
+          timeout: ${{ env.TIMEOUT }}
+
+      - name: Reporting Results to Qase
+        if: always()
+        uses: ./.github/actions/report-to-qase
+        with:
+          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || (github.event_name == 'workflow_dispatch' && github.event.inputs.qase-test-run-id-2-11) || (github.event_name == 'schedule' && vars.QASE_DEFAULT_TEST_RUN_ID_2_11) }}
+          qase-automation-token: ${{ secrets.QASE_TOKEN }}
+
+      - name: Reporting Results to Slack
+        uses: ./.github/actions/report-to-slack
+        with:
+          job-status: ${{ job.status }}
+          slack-channel: ${{ secrets.SLACK_CHANNEL }}
+          slack-token: ${{ secrets.SLACK_TOKEN }}
+
+      - name: Revoke Runner IP
+        if: always()
+        uses: ./.github/actions/revoke-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"
+
+  v2-10:
+    if: ${{ github.event_name == 'schedule' }} || (startsWith(inputs.rancher_version, 'v2.10.'))
+    name: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-10 }}
+    runs-on: ubuntu-latest
+    environment: staging-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Whitelist Runner IP
+        uses: ./.github/actions/whitelist-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"
+
+      - name: Set up SSH Keys
+        uses: ./.github/actions/setup-ssh-keys
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ssh-private-key-name: ${{ secrets.SSH_PRIVATE_KEY_NAME }}
+          windows-ssh-private-key: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY }}
+          windows-ssh-private-key-name: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}
+
+      - name: Uniquify hostname prefix
+        uses: ./.github/actions/uniquify-hostname
+
+      - name: Set Rancher version
+        uses: ./.github/actions/set-env-var
+        with:
+          key: RANCHER_VERSION
+          value: ${{ github.event.inputs.rancher_version || (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher-version-2-10) || (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_10_HEAD) }}
+
+      - name: Get Release Qase ID
+        if: ${{ github.event.inputs.rancher_version }}
+        id: get-release-qase-id
+        uses: ./.github/actions/get-release-qase-id
+        with:
+          tag: ${{ github.event.inputs.rancher_version }}
+          qase_test_run_id_2_11: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_11 }}"
+          qase_test_run_id_2_10: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_10 }}"
+          qase_test_run_id_2_9: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_9 }}"
+
+      - name: Set Qase Test Run ID
+        uses: ./.github/actions/set-env-var
+        with:
+          key: QASE_TEST_RUN_ID
+          value: ${{ steps.get-release-qase-id.outputs.id || (github.event_name == 'workflow_dispatch' && github.event.inputs.qase-test-run-id-2-10) || (github.event_name == 'schedule' && vars.QASE_DEFAULT_TEST_RUN_ID_2_10) }}
+
+      - name: Create config.yaml
+        run: |
+          cat > config.yaml <<EOF
+          rancher:
+            host: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
+            adminPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
+            insecure: true
+          upgradeInput:
+            clusters:
+              -  versionToUpgrade: ${{ vars.RKE2_VERSION_2_10 }}
+          terraform:
+            cni: "${{ secrets.CNI }}"
+            defaultClusterRoleForProjectMembers: "true"
+            enableNetworkPolicy: false
+            provider: "${{ vars.PROVIDER_AMAZON }}"
+            privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
+            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
+            windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
+            awsCredentials:
+              awsAccessKey: "${{ secrets.AWS_ACCESS_KEY_ID }}"
+              awsSecretKey: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+            awsConfig:
+              ami: "${{ secrets.AWS_AMI }}"
+              awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
+              awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              region: "${{ secrets.AWS_REGION }}"
+              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
+              awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+              awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+              awsVpcID: "${{ secrets.AWS_VPC_ID }}"
+              awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
+              awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
+              awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
+              awsUser: "${{ secrets.AWS_USER }}"
+              sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
+              timeout: "${{ vars.TIMEOUT }}"
+              windowsAMI: "${{ secrets.WINDOWS_AMI }}"
+              windowsAWSUser: "${{ secrets.AWS_WINDOWS_USER }}" 
+              windowsAWSPassword: "${{ secrets.AWS_WINDOWS_PASSWORD }}"
+              windowsInstanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
+              windowsKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}"
+              ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
+              loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
+              targetType: "${{ vars.TARGET_TYPE }}"
+            standalone:
+              bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
+              certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_10 }}${{ vars.K3S_VERSION_SUFFIX }}"
+              osUser: "${{ secrets.OS_USER }}"
+              osGroup: "${{ secrets.OS_GROUP }}"
+              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
+              rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
+              rancherImage: "${{ secrets.RANCHER_IMAGE }}"
+              rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
+              rancherTagVersion: "${{ vars.RANCHER_VERSION_2_10_HEAD }}"
+              repo: "${{ secrets.RANCHER_REPO }}"
+              rke2Version: "${{ vars.RKE2_VERSION_2_10 }}${{ vars.RKE2_VERSION_SUFFIX }}"
+          terratest:
+            pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            nodeCount: ${{ vars.NODE_COUNT }}
+            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            snapshotInput: {}
+          EOF
+
+      - name: Export CATTLE_TEST_CONFIG
+        run: echo "CATTLE_TEST_CONFIG=${{ github.workspace }}/config.yaml" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Set up Go environment
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "./go.mod"
+
+      - name: Build Packages
+        run: ./.github/scripts/build-packages.sh
+
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: "${{ vars.TERRAFORM_VERSION }}"
+          terraform_wrapper: false
+
+      - name: Run Rancher2 Test Suite
+        uses: ./.github/actions/run-test-suite
+        with:
+          package: ${{ env.PACKAGE }}
+          path-to-repo: ${{ secrets.PATH_TO_REPO }}
+          suite: ${{ env.SUITE }}
+          timeout: ${{ env.TIMEOUT }}
+
+      - name: Reporting Results to Qase
+        if: always()
+        uses: ./.github/actions/report-to-qase
+        with:
+          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || (github.event_name == 'workflow_dispatch' && github.event.inputs.qase-test-run-id-2-10) || (github.event_name == 'schedule' && vars.QASE_DEFAULT_TEST_RUN_ID_2_10) }}
+          qase-automation-token: ${{ secrets.QASE_TOKEN }}
+
+      - name: Reporting Results to Slack
+        uses: ./.github/actions/report-to-slack
+        with:
+          job-status: ${{ job.status }}
+          slack-channel: ${{ secrets.SLACK_CHANNEL }}
+          slack-token: ${{ secrets.SLACK_TOKEN }}
+
+      - name: Revoke Runner IP
+        if: always()
+        uses: ./.github/actions/revoke-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"
+
+  v2-9:
+    if: ${{ github.event_name == 'schedule' }} || (startsWith(inputs.rancher_version, 'v2.9.'))
+    name: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-9 }}
+    runs-on: ubuntu-latest
+    environment: staging-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Whitelist Runner IP
+        uses: ./.github/actions/whitelist-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"
+
+      - name: Set up SSH Keys
+        uses: ./.github/actions/setup-ssh-keys
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ssh-private-key-name: ${{ secrets.SSH_PRIVATE_KEY_NAME }}
+          windows-ssh-private-key: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY }}
+          windows-ssh-private-key-name: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}
+
+      - name: Uniquify hostname prefix
+        uses: ./.github/actions/uniquify-hostname
+
+      - name: Set Rancher version
+        uses: ./.github/actions/set-env-var
+        with:
+          key: RANCHER_VERSION
+          value: ${{ github.event.inputs.rancher_version || (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher-version-2-9) || (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_9_HEAD) }}
+
+      - name: Get Release Qase ID
+        if: ${{ github.event.inputs.rancher_version }}
+        id: get-release-qase-id
+        uses: ./.github/actions/get-release-qase-id
+        with:
+          tag: ${{ github.event.inputs.rancher_version }}
+          qase_test_run_id_2_11: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_11 }}"
+          qase_test_run_id_2_10: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_10 }}"
+          qase_test_run_id_2_9: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_9 }}"
+
+      - name: Set Qase Test Run ID
+        uses: ./.github/actions/set-env-var
+        with:
+          key: QASE_TEST_RUN_ID
+          value: ${{ steps.get-release-qase-id.outputs.id || (github.event_name == 'workflow_dispatch' && github.event.inputs.qase-test-run-id-2-9) || (github.event_name == 'schedule' && vars.QASE_DEFAULT_TEST_RUN_ID_2_9) }}
+      - name: Create config.yaml
+        run: |
+          cat > config.yaml <<EOF
+          rancher:
+            host: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
+            adminPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
+            insecure: true
+          upgradeInput:
+            clusters:
+              -  versionToUpgrade: ${{ vars.RKE2_VERSION_2_9 }}
+          terraform:
+            cni: "${{ secrets.CNI }}"
+            defaultClusterRoleForProjectMembers: "true"
+            enableNetworkPolicy: false
+            provider: "${{ vars.PROVIDER_AMAZON }}"
+            privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
+            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
+            windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
+            awsCredentials:
+              awsAccessKey: "${{ secrets.AWS_ACCESS_KEY_ID }}"
+              awsSecretKey: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+            awsConfig:
+              ami: "${{ secrets.AWS_AMI }}"
+              awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
+              awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              region: "${{ secrets.AWS_REGION }}"
+              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
+              awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+              awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+              awsVpcID: "${{ secrets.AWS_VPC_ID }}"
+              awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
+              awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
+              awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
+              awsUser: "${{ secrets.AWS_USER }}"
+              sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
+              timeout: "${{ vars.TIMEOUT }}"
+              windowsAMI: "${{ secrets.WINDOWS_AMI }}"
+              windowsAWSUser: "${{ secrets.AWS_WINDOWS_USER }}" 
+              windowsAWSPassword: "${{ secrets.AWS_WINDOWS_PASSWORD }}"
+              windowsInstanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
+              windowsKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}"
+              ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
+              loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
+              targetType: "${{ vars.TARGET_TYPE }}"
+            standalone:
+              bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
+              certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_9 }}${{ vars.K3S_VERSION_SUFFIX }}"
+              osUser: "${{ secrets.OS_USER }}"
+              osGroup: "${{ secrets.OS_GROUP }}"
+              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
+              rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
+              rancherImage: "${{ secrets.RANCHER_IMAGE }}"
+              rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
+              rancherTagVersion: "${{ vars.RANCHER_VERSION_2_9_HEAD }}"
+              repo: "${{ secrets.RANCHER_REPO }}"
+              rke2Version: "${{ vars.RKE2_VERSION_2_9 }}${{ vars.RKE2_VERSION_SUFFIX }}"
+          terratest:
+            pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            nodeCount: ${{ vars.NODE_COUNT }}
+            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            snapshotInput: {}
+          EOF
+
+      - name: Export CATTLE_TEST_CONFIG
+        run: echo "CATTLE_TEST_CONFIG=${{ github.workspace }}/config.yaml" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Set up Go environment
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "./go.mod"
+
+      - name: Build Packages
+        run: ./.github/scripts/build-packages.sh
+
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: "${{ vars.TERRAFORM_VERSION }}"
+          terraform_wrapper: false
+
+      - name: Run Rancher2 Test Suite
+        uses: ./.github/actions/run-test-suite
+        with:
+          package: ${{ env.PACKAGE }}
+          path-to-repo: ${{ secrets.PATH_TO_REPO }}
+          suite: ${{ env.SUITE }}
+          timeout: ${{ env.TIMEOUT }}
+
+      - name: Reporting Results to Qase
+        if: always()
+        uses: ./.github/actions/report-to-qase
+        with:
+          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || (github.event_name == 'workflow_dispatch' && github.event.inputs.qase-test-run-id-2-9) || (github.event_name == 'schedule' && vars.QASE_DEFAULT_TEST_RUN_ID_2_9) }}
+          qase-automation-token: ${{ secrets.QASE_TOKEN }}
+
+      - name: Reporting Results to Slack
+        uses: ./.github/actions/report-to-slack
+        with:
+          job-status: ${{ job.status }}
+          slack-channel: ${{ secrets.SLACK_CHANNEL }}
+          slack-token: ${{ secrets.SLACK_TOKEN }}
+
+      - name: Revoke Runner IP
+        if: always()
+        uses: ./.github/actions/revoke-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"

--- a/framework/set/provisioning/imported/import-nodes.sh
+++ b/framework/set/provisioning/imported/import-nodes.sh
@@ -26,5 +26,4 @@ PEM=/home/${USER}/key.pem
 sudo chmod 600 ${PEM}
 sudo chown ${USER}:${GROUP} ${PEM}
 
-ssh -o ProxyCommand="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $PEM -W %h:%p $USER@$NODE_ONE_PUBLIC_DNS" \
-    -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $PEM $USER@$NODE_ONE_PUBLIC_DNS "$IMPORT_COMMAND"
+eval "$IMPORT_COMMAND"

--- a/tests/airgap/README.md
+++ b/tests/airgap/README.md
@@ -96,6 +96,8 @@ terraform:
   standaloneRegistry:
     assetsPath: ""                                # REQUIRED - ensure that you end with a trailing `/`
     registryName: ""                              # REQUIRED - fill with desired value
+terratest:
+  pathToRepo: "go/src/github.com/rancher/tfp-automation"
 ```
 
 Before running, be sure to run the following commands:

--- a/tests/proxy/README.md
+++ b/tests/proxy/README.md
@@ -104,8 +104,10 @@ terraform:
 #######################
 # TERRATEST CONFIG
 #######################
+terratest:  
   nodeCount: 3
   windowsNodeCount: 1
+  pathToRepo: "go/src/github.com/rancher/tfp-automation"
 ```
 
 Before running, be sure to run the following commands:

--- a/tests/rancher2/nodescaling/README.md
+++ b/tests/rancher2/nodescaling/README.md
@@ -36,6 +36,7 @@ Similar to the `provisioning` tests, the node scaling tests have static test cas
 
 ```yaml
 terratest:
+  pathToRepo: "go/src/github.com/rancher/tfp-automation"
   kubernetesVersion: ""
   nodeCount: 3
   psact: "" # Optional, can be left out or can have values `rancher-privileged` or `rancher-restricted`

--- a/tests/rancher2/provisioning/README.md
+++ b/tests/rancher2/provisioning/README.md
@@ -169,6 +169,7 @@ terratest:
   tfLogging: true
   nodeCount: 3
   windowsNodeCount: 1
+  pathToRepo: "go/src/github.com/rancher/tfp-automation"
 ```
 
 In addition, when running locally, you will need to ensure that you have `export RKE_PROVIDER_VERSION=x.x.x` defined for the RKE1 portion of the test. You also must ensure that you are not using the highest available K8s version as this test will perform an upgrade of the imported cluster.

--- a/tests/rancher2/psact/README.md
+++ b/tests/rancher2/psact/README.md
@@ -49,6 +49,7 @@ terraform:
     linodeRootPass: "<placeholder>"
 terratest:
   kubernetesVersion: ""
+  pathToRepo: "go/src/github.com/rancher/tfp-automation"
   ```
 
 See the below examples on how to run the tests:

--- a/tests/rancher2/rbac/README.md
+++ b/tests/rancher2/rbac/README.md
@@ -23,20 +23,19 @@ rancher:
     insecure: true
     cleanup: true
 terraform:
-    cloudCredentialName: ""
+    resourcePrefix: ""
     defaultClusterRoleForProjectMembers: "true"
     enableNetworkPolicy: false
-    hostnamePrefix: ""
-    machineConfigName: ""
     module: "linode_k3s"
     cni: "canal"
-    nodeTemplateName: ""                # Needed for RKE1 clusters
     linodeCredentials:
         linodeToken: ""
     linodeConfig:
         linodeImage: "linode/ubuntu22.04"
         region: "us-east"
         linodeRootPass: ""
+terratest:
+    pathToRepo: "go/src/github.com/rancher/tfp-automation"
 ```
 
 See the below examples on how to run the tests:

--- a/tests/rancher2/recurring/README.md
+++ b/tests/rancher2/recurring/README.md
@@ -1,0 +1,96 @@
+# Recurring Runs
+
+The `recurring` directory will spin up a Rancher environment, with the desired node provider, and will run various Rancher2 tests that are used for release testing. This is ran on a weekly basis alongside various infrastrucre-based testing via Github Actions.
+
+Please see below for more details for your config. Please note that the config can be in either JSON or YAML (all examples are illustrated in YAML).
+
+## Table of Contents
+1. [Getting Started](#Getting-Started)
+2. [Local Qase Reporting](#Local-Qase-Reporting)
+
+## Getting Started
+
+See below an example config on setting up a Rancher server powered by a RKE2 HA cluster using AWS as the node provider:
+
+```yaml
+rancher:
+  host: ""                                        # REQUIRED - fill out with the expected Rancher server URL
+  insecure: true                                  # REQUIRED - leave this as true
+
+upgradeInput:
+  clusters:
+    -  versionToUpgrade: ""                       # Leave off the suffix; the test will add it for K3s and RKE2
+
+terraform:
+  cni: ""
+  provider: ""                                    # REQUIRED - supported values are aws | linode | harvester | vsphere
+  privateKeyPath: ""                              # REQUIRED - specify private key that will be used to access created instances
+  resourcePrefix: ""
+
+  awsCredentials:
+    awsAccessKey: ""
+    awsSecretKey: ""
+  awsConfig:
+    ami: ""
+    awsKeyName: ""
+    awsInstanceType: ""
+    awsSecurityGroups: [""]
+    awsSubnetID: ""
+    awsVpcID: ""
+    awsZoneLetter: ""
+    awsRootSize: 100
+    awsRoute53Zone: ""
+    region: ""
+    prefix: ""
+    awsUser: ""
+    sshConnectionType: "ssh"
+    timeout: "5m"
+    ipAddressType: "ipv4"
+    loadBalancerType: "ipv4"
+    targetType: "instance"
+
+  standalone:
+    bootstrapPassword: ""                         # REQUIRED - this is the same as the adminPassword above, make sure they match
+    certManagerVersion: ""                        # REQUIRED - (e.g. v1.15.3)
+    k3sVersion: ""                                # REQUIRED - fill with desired K3s k8s value (make sure it's not the highest version)
+    rancherChartVersion: ""                       # REQUIRED - fill with desired value
+    rancherChartRepository: ""                    # REQUIRED - fill with desired value. Must end with a trailing /
+    rancherHostname: ""                           # REQUIRED - fill with desired value
+    rancherImage: ""                              # REQUIRED - fill with desired value
+    rancherTagVersion: ""                         # REQUIRED - fill with desired value
+    repo: ""                                      # REQUIRED - fill with desired value
+    rke2Group: ""                                 # REQUIRED - fill with group of the instance created
+    rke2User: ""                                  # REQUIRED - fill with username of the instance created
+    rancherAgentImage: ""                         # OPTIONAL - fill out only if you are using staging registry
+    rke2Version: ""                               # REQUIRED - fill with desired RKE2 k8s value (make sure it's not the highest version)
+
+terratest:
+  nodeCount: 3
+  windowsNodeCount: 1
+  pathToRepo: "go/src/github.com/rancher/tfp-automation"
+  snapshotInput: {}
+```
+
+Note: Depending on what `provider` is set to, only fill out the appropriate section. Before running locally, be sure to run the following commands:
+
+```yaml
+export RANCHER2_PROVIDER_VERSION=""
+export CATTLE_TEST_CONFIG=<path/to/yaml>
+export LOCALS_PROVIDER_VERSION=""
+export CLOUD_PROVIDER_VERSION=""
+```
+
+See the below examples on how to run the test:
+
+`gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/rancher2/recurring --junitfile results.xml --jsonfile results.json -- -timeout=3h -v -run "TfpRancher2RecurringRunsTestSuite$"`
+
+If the specified test passes immediately without warning, try adding the -count=1 flag to get around this issue. This will avoid previous results from interfering with the new test run.
+
+## Local Qase Reporting
+If you are planning to report to Qase locally, then you will need to have the following done:
+1. The `terratest` block in your config file must have `localQaseReporting: true`.
+2. The working shell session must have the following two environmental variables set:
+     - `QASE_AUTOMATION_TOKEN=""`
+     - `QASE_TEST_RUN_ID=""`
+3. Append `./reporter` to the end of the `gotestsum` command. See an example below::
+     - `gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/rancher2/recurring --junitfile results.xml --jsonfile results.json -- -timeout=60m -v -run "TfpRancher2RecurringRunsTestSuite$";/path/to/tfp-automation/reporter`

--- a/tests/rancher2/recurring/recurring_test.go
+++ b/tests/rancher2/recurring/recurring_test.go
@@ -1,0 +1,237 @@
+package sanity
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/rancher/shepherd/clients/rancher"
+	shepherdConfig "github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/shepherd/pkg/config/operations"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/configs"
+	"github.com/rancher/tfp-automation/defaults/keypath"
+	"github.com/rancher/tfp-automation/defaults/modules"
+	"github.com/rancher/tfp-automation/framework"
+	"github.com/rancher/tfp-automation/framework/cleanup"
+	"github.com/rancher/tfp-automation/framework/set/provisioning/imported"
+	"github.com/rancher/tfp-automation/framework/set/resources/rancher2"
+	resources "github.com/rancher/tfp-automation/framework/set/resources/sanity"
+	qase "github.com/rancher/tfp-automation/pipeline/qase/results"
+	"github.com/rancher/tfp-automation/tests/extensions/provisioning"
+	"github.com/rancher/tfp-automation/tests/infrastructure"
+	"github.com/rancher/tfp-automation/tests/rancher2/snapshot"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type TfpRancher2RecurringRunsTestSuite struct {
+	suite.Suite
+	client                     *rancher.Client
+	session                    *session.Session
+	cattleConfig               map[string]any
+	rancherConfig              *rancher.Config
+	terraformConfig            *config.TerraformConfig
+	terratestConfig            *config.TerratestConfig
+	standaloneTerraformOptions *terraform.Options
+	terraformOptions           *terraform.Options
+}
+
+func (r *TfpRancher2RecurringRunsTestSuite) TearDownSuite() {
+	_, keyPath := rancher2.SetKeyPath(keypath.SanityKeyPath, r.terratestConfig.PathToRepo, r.terraformConfig.Provider)
+	cleanup.Cleanup(r.T(), r.standaloneTerraformOptions, keyPath)
+}
+
+func (r *TfpRancher2RecurringRunsTestSuite) SetupSuite() {
+	r.cattleConfig = shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
+	r.rancherConfig, r.terraformConfig, r.terratestConfig = config.LoadTFPConfigs(r.cattleConfig)
+
+	_, keyPath := rancher2.SetKeyPath(keypath.SanityKeyPath, r.terratestConfig.PathToRepo, r.terraformConfig.Provider)
+	standaloneTerraformOptions := framework.Setup(r.T(), r.terraformConfig, r.terratestConfig, keyPath)
+	r.standaloneTerraformOptions = standaloneTerraformOptions
+
+	_, err := resources.CreateMainTF(r.T(), r.standaloneTerraformOptions, keyPath, r.terraformConfig, r.terratestConfig)
+	require.NoError(r.T(), err)
+
+	testSession := session.NewSession()
+	r.session = testSession
+
+	client, err := infrastructure.PostRancherSetup(r.T(), testSession, r.terraformConfig.Standalone.RancherHostname, false, false)
+	require.NoError(r.T(), err)
+
+	r.client = client
+
+	_, keyPath = rancher2.SetKeyPath(keypath.RancherKeyPath, r.terratestConfig.PathToRepo, "")
+	terraformOptions := framework.Setup(r.T(), r.terraformConfig, r.terratestConfig, keyPath)
+	r.terraformOptions = terraformOptions
+}
+
+func (r *TfpRancher2RecurringRunsTestSuite) TestTfpRecurringProvisionCustomCluster() {
+	tests := []struct {
+		name   string
+		module string
+	}{
+		{"Custom TFP RKE2", modules.CustomEC2RKE2},
+		{"Custom TFP RKE2 Windows", modules.CustomEC2RKE2Windows},
+		{"Custom TFP K3S", modules.CustomEC2K3s},
+	}
+
+	customClusterNames := []string{}
+	testUser, testPassword := configs.CreateTestCredentials()
+
+	for _, tt := range tests {
+		newFile, rootBody, file := rancher2.InitializeMainTF(r.terratestConfig)
+		defer file.Close()
+
+		configMap, err := provisioning.UniquifyTerraform([]map[string]any{r.cattleConfig})
+		require.NoError(r.T(), err)
+
+		_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, r.client.RancherConfig.AdminToken, configMap[0])
+		require.NoError(r.T(), err)
+
+		_, err = operations.ReplaceValue([]string{"terraform", "module"}, tt.module, configMap[0])
+		require.NoError(r.T(), err)
+
+		provisioning.GetK8sVersion(r.T(), r.client, r.terratestConfig, r.terraformConfig, configs.DefaultK8sVersion, configMap)
+
+		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+
+		currentDate := time.Now().Format("2006-01-02 03:04PM")
+		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion + " " + currentDate
+
+		r.Run((tt.name), func() {
+			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, r.terratestConfig.PathToRepo, "")
+			defer cleanup.Cleanup(r.T(), r.terraformOptions, keyPath)
+
+			clusterIDs, customClusterNames := provisioning.Provision(r.T(), r.client, rancher, terraform, terratest, testUser, testPassword, r.terraformOptions, configMap, newFile, rootBody, file, false, false, true, customClusterNames)
+			provisioning.VerifyClustersState(r.T(), r.client, clusterIDs)
+
+			if strings.Contains(terraform.Module, modules.CustomEC2RKE2Windows) {
+				clusterIDs, _ = provisioning.Provision(r.T(), r.client, rancher, terraform, terratest, testUser, testPassword, r.terraformOptions, configMap, newFile, rootBody, file, true, true, true, customClusterNames)
+				provisioning.VerifyClustersState(r.T(), r.client, clusterIDs)
+			}
+		})
+	}
+
+	if r.terratestConfig.LocalQaseReporting {
+		qase.ReportTest(r.terratestConfig)
+	}
+}
+
+func (r *TfpRancher2RecurringRunsTestSuite) TestTfpRecurringProvisionImportedCluster() {
+	tests := []struct {
+		name   string
+		module string
+	}{
+		{"Upgrade Imported TFP RKE2", modules.ImportEC2RKE2},
+		{"Upgrade Imported TFP RKE2 Windows", modules.ImportEC2RKE2Windows},
+		{"Upgrade Imported TFP K3S", modules.ImportEC2K3s},
+	}
+
+	testUser, testPassword := configs.CreateTestCredentials()
+
+	for _, tt := range tests {
+		newFile, rootBody, file := rancher2.InitializeMainTF(r.terratestConfig)
+		defer file.Close()
+
+		configMap, err := provisioning.UniquifyTerraform([]map[string]any{r.cattleConfig})
+		require.NoError(r.T(), err)
+
+		_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, r.client.RancherConfig.AdminToken, configMap[0])
+		require.NoError(r.T(), err)
+
+		_, err = operations.ReplaceValue([]string{"terraform", "module"}, tt.module, configMap[0])
+		require.NoError(r.T(), err)
+
+		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+
+		currentDate := time.Now().Format("2006-01-02 03:04PM")
+		tt.name = tt.name + " " + currentDate
+
+		r.Run((tt.name), func() {
+			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, r.terratestConfig.PathToRepo, "")
+			defer cleanup.Cleanup(r.T(), r.terraformOptions, keyPath)
+
+			clusterIDs, _ := provisioning.Provision(r.T(), r.client, rancher, terraform, terratest, testUser, testPassword, r.terraformOptions, configMap, newFile, rootBody, file, false, false, true, nil)
+			provisioning.VerifyClustersState(r.T(), r.client, clusterIDs)
+
+			err = imported.SetUpgradeImportedCluster(r.client, terraform)
+			require.NoError(r.T(), err)
+		})
+	}
+
+	if r.terratestConfig.LocalQaseReporting {
+		qase.ReportTest(r.terratestConfig)
+	}
+}
+
+func (r *TfpRancher2RecurringRunsTestSuite) TestTfpRecurringSnapshotRestore() {
+	nodeRolesDedicated := []config.Nodepool{config.EtcdNodePool, config.ControlPlaneNodePool, config.WorkerNodePool}
+
+	snapshotRestoreNone := config.TerratestConfig{
+		SnapshotInput: config.Snapshots{
+			SnapshotRestore: "none",
+		},
+	}
+
+	tests := []struct {
+		name         string
+		module       string
+		nodeRoles    []config.Nodepool
+		etcdSnapshot config.TerratestConfig
+	}{
+		{"RKE2 Snapshot Restore", modules.EC2RKE2, nodeRolesDedicated, snapshotRestoreNone},
+		{"K3S Snapshot Restore", modules.EC2K3s, nodeRolesDedicated, snapshotRestoreNone},
+	}
+
+	testUser, testPassword := configs.CreateTestCredentials()
+
+	for _, tt := range tests {
+		newFile, rootBody, file := rancher2.InitializeMainTF(r.terratestConfig)
+		defer file.Close()
+
+		configMap, err := provisioning.UniquifyTerraform([]map[string]any{r.cattleConfig})
+		require.NoError(r.T(), err)
+
+		_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, r.client.RancherConfig.AdminToken, configMap[0])
+		require.NoError(r.T(), err)
+
+		_, err = operations.ReplaceValue([]string{"terraform", "module"}, tt.module, configMap[0])
+		require.NoError(r.T(), err)
+
+		_, err = operations.ReplaceValue([]string{"terratest", "nodepools"}, tt.nodeRoles, configMap[0])
+		require.NoError(r.T(), err)
+
+		_, err = operations.ReplaceValue([]string{"terratest", "snapshotInput", "snapshotRestore"}, tt.etcdSnapshot.SnapshotInput.SnapshotRestore, configMap[0])
+		require.NoError(r.T(), err)
+
+		provisioning.GetK8sVersion(r.T(), r.client, r.terratestConfig, r.terraformConfig, configs.DefaultK8sVersion, configMap)
+
+		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+
+		currentDate := time.Now().Format("2006-01-02 03:04PM")
+		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion + " " + currentDate
+
+		r.Run(tt.name, func() {
+			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, r.terratestConfig.PathToRepo, "")
+			defer cleanup.Cleanup(r.T(), r.terraformOptions, keyPath)
+
+			clusterIDs, _ := provisioning.Provision(r.T(), r.client, rancher, terraform, terratest, testUser, testPassword, r.terraformOptions, configMap, newFile, rootBody, file, false, false, false, nil)
+			provisioning.VerifyClustersState(r.T(), r.client, clusterIDs)
+
+			snapshot.RestoreSnapshot(r.T(), r.client, rancher, terraform, terratest, testUser, testPassword, r.terraformOptions, configMap, newFile, rootBody, file)
+			provisioning.VerifyClustersState(r.T(), r.client, clusterIDs)
+		})
+	}
+
+	if r.terratestConfig.LocalQaseReporting {
+		qase.ReportTest(r.terratestConfig)
+	}
+}
+
+func TestTfpRancher2RecurringRunsTestSuite(t *testing.T) {
+	suite.Run(t, new(TfpRancher2RecurringRunsTestSuite))
+}

--- a/tests/rancher2/snapshot/README.md
+++ b/tests/rancher2/snapshot/README.md
@@ -16,8 +16,7 @@ Please see below for more details for your config. Please note that the config c
 
 ## Table of Contents
 1. [Getting Started](#Getting-Started)
-2. [ETCD Snapshots](#ETCD-Snapshots)
-3. [Local Qase Reporting](#Local-Qase-Reporting)
+2. [Local Qase Reporting](#Local-Qase-Reporting)
 
 ## Getting Started
 In your config file, set the following:
@@ -32,7 +31,7 @@ terraform:
     disableSnapshot: false
     snapshotCron: "0 */5 * * *"
     snapshotRetention: 3
-    s3:
+    s3:                               # Optional block, use if you want an S3 snapshot
       bucket: ""
       cloudCredentialName: ""
       endpoint: "s3.us-east-2.amazonaws.com"
@@ -41,23 +40,11 @@ terraform:
       region: "us-east-2"
       skipSSLVerify: true
 terratest:
+  pathToRepo: "go/src/github.com/rancher/tfp-automation"
   snapshotInput: {}
 ```
 
 To see what goes into the `terraform` block in addition to the `rancher`, please refer to the tfp-automation [README](../../README.md).
-
-## ETCD Snapshots
-Similar to the `provisioning` tests, the snapshot tests have static test cases as well as dynamicInput tests you can specify. In order to run the dynamicInput tests, you will need to define the `terratest` block in your config file. See an example below:
-
-```yaml
-terratest:
-  kubernetesVersion: ""
-  snapshotInput:
-    upgradeKubernetesVersion: "" # If left blank, the default version in Rancher will be used.
-    snapshotRestore: "all" # Options include none, kubernetesVersion, all. Option 'none' means that only the etcd will be restored.
-    controlPlaneConcurrencyValue: "15%"
-    workerConcurrencyValue: "20%"
-  ```
 
 See the below examples on how to run the tests:
 

--- a/tests/rancher2/snapshot/snapshot.go
+++ b/tests/rancher2/snapshot/snapshot.go
@@ -53,9 +53,9 @@ const (
 	serviceType         = "service"
 )
 
-// snapshotRestore creates workloads, takes a snapshot of the cluster, restores the cluster and verifies the workloads created after
+// RestoreSnapshot creates workloads, takes a snapshot of the cluster, restores the cluster and verifies the workloads created after
 // a snapshot no longer are present in the cluster
-func snapshotRestore(t *testing.T, client *rancher.Client, rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig,
+func RestoreSnapshot(t *testing.T, client *rancher.Client, rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig,
 	terratestConfig *config.TerratestConfig, testUser, testPassword string, terraformOptions *terraform.Options, configMap []map[string]any,
 	newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File) {
 	initialWorkloadName := namegen.AppendRandomString(initialWorkload)

--- a/tests/rancher2/snapshot/snapshot_restore_test.go
+++ b/tests/rancher2/snapshot/snapshot_restore_test.go
@@ -103,7 +103,7 @@ func (s *SnapshotRestoreTestSuite) TestTfpSnapshotRestore() {
 			clusterIDs, _ := provisioning.Provision(s.T(), s.client, rancher, terraform, terratest, testUser, testPassword, s.terraformOptions, configMap, newFile, rootBody, file, false, false, false, nil)
 			provisioning.VerifyClustersState(s.T(), adminClient, clusterIDs)
 
-			snapshotRestore(s.T(), s.client, rancher, terraform, terratest, testUser, testPassword, s.terraformOptions, configMap, newFile, rootBody, file)
+			RestoreSnapshot(s.T(), s.client, rancher, terraform, terratest, testUser, testPassword, s.terraformOptions, configMap, newFile, rootBody, file)
 			provisioning.VerifyClustersState(s.T(), adminClient, clusterIDs)
 		})
 	}

--- a/tests/rancher2/upgrading/README.md
+++ b/tests/rancher2/upgrading/README.md
@@ -35,6 +35,7 @@ terratest:
   kubernetesVersion: ""
   upgradedKubernetesVersion: "" # If left blank or is omitted completely, the latest version in Rancher will be used. This is only for RKE1/RKE2/K3s. Hosted clusters MUST have this filled out.
   psact: "" # Optional, can be left out or can have values `rancher-privileged` or `rancher-restricted`
+  pathToRepo: "go/src/github.com/rancher/tfp-automation"
   ```
 
 Additionally, you will need to ensure that the initial cluster version is NOT the latest version found in Rancher. This is because if you leave `upgradedKubernetesVersion` blank, then the test will automatically upgrade to the latest version found in Rancher.

--- a/tests/registries/README.md
+++ b/tests/registries/README.md
@@ -97,6 +97,8 @@ terraform:
     ecrUsername: ""                               # REQUIRED (ecr registry only)
     ecrURI: ""                                    # REQUIRED (ecr registry only)
     ecrAMI: ""                                    # REQUIRED (ecr registry only) - with Amazon ECR Credential Helper
+terratest:
+  pathToRepo: "go/src/github.com/rancher/tfp-automation"
 ```
 
 Before running, be sure to run the following commands:

--- a/tests/rke/README.md
+++ b/tests/rke/README.md
@@ -56,6 +56,8 @@ terraform:
     timeout: "5m"
   standalone:
     osUser: ""
+terratest:
+  pathToRepo: "go/src/github.com/rancher/tfp-automation"
 ```
 
 Before running, be sure to run the following commands:

--- a/tests/sanity/README.md
+++ b/tests/sanity/README.md
@@ -88,8 +88,10 @@ terraform:
 #######################
 # TERRATEST CONFIG
 #######################
+terratest:  
   nodeCount: 3
   windowsNodeCount: 1
+  pathToRepo: "go/src/github.com/rancher/tfp-automation"
 ```
 
 Before running, be sure to run the following commands:


### PR DESCRIPTION
### Issue: N/A

### Description
To build upon the GHA workflows that we have the infrastructure-based tests, this PR extends that functionality to the Rancher2 tests. The idea is that eventually, we can have this as a template for the `rancher/tests` for release testing as well.