### PR TITLE
Pass in rancherConfig to the EULA function

### DIFF
--- a/tests/airgap/airgap_provisioning_test.go
+++ b/tests/airgap/airgap_provisioning_test.go
@@ -60,7 +60,7 @@ func (a *TfpAirgapProvisioningTestSuite) SetupSuite() {
 	testSession := session.NewSession()
 	a.session = testSession
 
-	client, err := infrastructure.PostRancherSetup(a.T(), testSession, a.terraformConfig.Standalone.AirgapInternalFQDN, false, true)
+	client, err := infrastructure.PostRancherSetup(a.T(), a.rancherConfig, testSession, a.terraformConfig.Standalone.AirgapInternalFQDN, false, true)
 	require.NoError(a.T(), err)
 
 	a.client = client

--- a/tests/airgap/airgap_upgrade_rancher_test.go
+++ b/tests/airgap/airgap_upgrade_rancher_test.go
@@ -72,7 +72,7 @@ func (a *TfpAirgapUpgradeRancherTestSuite) SetupSuite() {
 	testSession := session.NewSession()
 	a.session = testSession
 
-	client, err := infrastructure.PostRancherSetup(a.T(), testSession, a.terraformConfig.Standalone.AirgapInternalFQDN, false, true)
+	client, err := infrastructure.PostRancherSetup(a.T(), a.rancherConfig, testSession, a.terraformConfig.Standalone.AirgapInternalFQDN, false, true)
 	require.NoError(a.T(), err)
 
 	a.client = client
@@ -93,7 +93,7 @@ func (a *TfpAirgapUpgradeRancherTestSuite) TestTfpUpgradeAirgapRancher() {
 	err := upgrade.CreateMainTF(a.T(), a.upgradeTerraformOptions, keyPath, a.terraformConfig, a.terratestConfig, "", "", a.bastion, a.registry)
 	require.NoError(a.T(), err)
 
-	a.client, err = infrastructure.PostRancherSetup(a.T(), a.session, a.terraformConfig.Standalone.AirgapInternalFQDN, false, true)
+	a.client, err = infrastructure.PostRancherSetup(a.T(), a.rancherConfig, a.session, a.terraformConfig.Standalone.AirgapInternalFQDN, false, true)
 	require.NoError(a.T(), err)
 
 	provisioning.VerifyClustersState(a.T(), a.client, clusterIDs)

--- a/tests/infrastructure/acceptEULA.go
+++ b/tests/infrastructure/acceptEULA.go
@@ -1,25 +1,19 @@
 package infrastructure
 
 import (
-	"os"
 	"testing"
 
 	"github.com/rancher/rancher/tests/v2/actions/pipeline"
 	"github.com/rancher/shepherd/clients/rancher"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	"github.com/rancher/shepherd/extensions/token"
-	shepherdConfig "github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/session"
-	"github.com/rancher/tfp-automation/config"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
 // PostRancherSetup is a helper function that creates a Rancher client and accepts the EULA, if needed
-func PostRancherSetup(t *testing.T, session *session.Session, host string, showToken, isAirgap bool) (*rancher.Client, error) {
-	cattleConfig := shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
-	rancherConfig, _, _ := config.LoadTFPConfigs(cattleConfig)
-
+func PostRancherSetup(t *testing.T, rancherConfig *rancher.Config, session *session.Session, host string, showToken, isAirgap bool) (*rancher.Client, error) {
 	adminUser := &management.User{
 		Username: "admin",
 		Password: rancherConfig.AdminPassword,

--- a/tests/infrastructure/setup_proxy_rancher_test.go
+++ b/tests/infrastructure/setup_proxy_rancher_test.go
@@ -1,10 +1,13 @@
 package infrastructure
 
 import (
+	"os"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/rancher/shepherd/clients/rancher"
 	ranchFrame "github.com/rancher/shepherd/pkg/config"
+	shepherdConfig "github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/defaults/keypath"
@@ -21,12 +24,14 @@ type ProxyRancherTestSuite struct {
 	session          *session.Session
 	terraformConfig  *config.TerraformConfig
 	terratestConfig  *config.TerratestConfig
+	cattleConfig     map[string]any
+	rancherConfig    *rancher.Config
 	terraformOptions *terraform.Options
 }
 
 func (i *ProxyRancherTestSuite) TestCreateProxyRancher() {
-	i.terraformConfig = new(config.TerraformConfig)
-	ranchFrame.LoadConfig(config.TerraformConfigurationFileKey, i.terraformConfig)
+	i.cattleConfig = shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
+	i.rancherConfig, i.terraformConfig, i.terratestConfig = config.LoadTFPConfigs(i.cattleConfig)
 
 	i.terratestConfig = new(config.TerratestConfig)
 	ranchFrame.LoadConfig(config.TerratestConfigurationFileKey, i.terratestConfig)
@@ -45,7 +50,7 @@ func (i *ProxyRancherTestSuite) TestCreateProxyRancher() {
 	testSession := session.NewSession()
 	i.session = testSession
 
-	_, err = PostRancherSetup(i.T(), i.session, i.terraformConfig.Standalone.RancherHostname, false, false)
+	_, err = PostRancherSetup(i.T(), i.rancherConfig, i.session, i.terraformConfig.Standalone.RancherHostname, false, false)
 	require.NoError(i.T(), err)
 }
 

--- a/tests/proxy/proxy_provisioning_test.go
+++ b/tests/proxy/proxy_provisioning_test.go
@@ -60,7 +60,7 @@ func (p *TfpProxyProvisioningTestSuite) SetupSuite() {
 	testSession := session.NewSession()
 	p.session = testSession
 
-	client, err := infrastructure.PostRancherSetup(p.T(), testSession, p.terraformConfig.Standalone.RancherHostname, false, false)
+	client, err := infrastructure.PostRancherSetup(p.T(), p.rancherConfig, testSession, p.terraformConfig.Standalone.RancherHostname, false, false)
 	require.NoError(p.T(), err)
 
 	p.client = client

--- a/tests/proxy/proxy_upgrade_rancher_test.go
+++ b/tests/proxy/proxy_upgrade_rancher_test.go
@@ -72,7 +72,7 @@ func (p *TfpProxyUpgradeRancherTestSuite) SetupSuite() {
 	testSession := session.NewSession()
 	p.session = testSession
 
-	client, err := infrastructure.PostRancherSetup(p.T(), testSession, p.terraformConfig.Standalone.RancherHostname, false, false)
+	client, err := infrastructure.PostRancherSetup(p.T(), p.rancherConfig, testSession, p.terraformConfig.Standalone.RancherHostname, false, false)
 	require.NoError(p.T(), err)
 
 	p.client = client
@@ -93,7 +93,7 @@ func (p *TfpProxyUpgradeRancherTestSuite) TestTfpUpgradeProxyRancher() {
 	err := upgrade.CreateMainTF(p.T(), p.upgradeTerraformOptions, keyPath, p.terraformConfig, p.terratestConfig, p.proxyPrivateIP, p.proxyNode, "", "")
 	require.NoError(p.T(), err)
 
-	p.client, err = infrastructure.PostRancherSetup(p.T(), p.session, p.terraformConfig.Standalone.RancherHostname, false, false)
+	p.client, err = infrastructure.PostRancherSetup(p.T(), p.rancherConfig, p.session, p.terraformConfig.Standalone.RancherHostname, false, false)
 	require.NoError(p.T(), err)
 
 	provisioning.VerifyClustersState(p.T(), p.client, clusterIDs)

--- a/tests/rancher2/recurring/recurring_test.go
+++ b/tests/rancher2/recurring/recurring_test.go
@@ -59,7 +59,7 @@ func (r *TfpRancher2RecurringRunsTestSuite) SetupSuite() {
 	testSession := session.NewSession()
 	r.session = testSession
 
-	client, err := infrastructure.PostRancherSetup(r.T(), testSession, r.terraformConfig.Standalone.RancherHostname, false, false)
+	client, err := infrastructure.PostRancherSetup(r.T(), r.rancherConfig, testSession, r.terraformConfig.Standalone.RancherHostname, false, false)
 	require.NoError(r.T(), err)
 
 	r.client = client

--- a/tests/registries/registries_test.go
+++ b/tests/registries/registries_test.go
@@ -63,7 +63,7 @@ func (r *TfpRegistriesTestSuite) SetupSuite() {
 	testSession := session.NewSession()
 	r.session = testSession
 
-	client, err := infrastructure.PostRancherSetup(r.T(), testSession, r.terraformConfig.Standalone.RancherHostname, false, false)
+	client, err := infrastructure.PostRancherSetup(r.T(), r.rancherConfig, testSession, r.terraformConfig.Standalone.RancherHostname, false, false)
 	require.NoError(r.T(), err)
 
 	r.client = client

--- a/tests/sanity/sanity_provisioning_rke1_test.go
+++ b/tests/sanity/sanity_provisioning_rke1_test.go
@@ -56,7 +56,7 @@ func (s *TfpSanityRKE1ProvisioningTestSuite) SetupSuite() {
 	testSession := session.NewSession()
 	s.session = testSession
 
-	client, err := infrastructure.PostRancherSetup(s.T(), testSession, s.terraformConfig.Standalone.RancherHostname, false, false)
+	client, err := infrastructure.PostRancherSetup(s.T(), s.rancherConfig, testSession, s.terraformConfig.Standalone.RancherHostname, false, false)
 	require.NoError(s.T(), err)
 
 	s.client = client

--- a/tests/sanity/sanity_provisioning_test.go
+++ b/tests/sanity/sanity_provisioning_test.go
@@ -57,7 +57,7 @@ func (s *TfpSanityProvisioningTestSuite) SetupSuite() {
 	testSession := session.NewSession()
 	s.session = testSession
 
-	client, err := infrastructure.PostRancherSetup(s.T(), testSession, s.terraformConfig.Standalone.RancherHostname, false, false)
+	client, err := infrastructure.PostRancherSetup(s.T(), s.rancherConfig, testSession, s.terraformConfig.Standalone.RancherHostname, false, false)
 	require.NoError(s.T(), err)
 
 	s.client = client

--- a/tests/sanity/sanity_upgrade_rancher_test.go
+++ b/tests/sanity/sanity_upgrade_rancher_test.go
@@ -70,7 +70,7 @@ func (s *TfpSanityUpgradeRancherTestSuite) SetupSuite() {
 	testSession := session.NewSession()
 	s.session = testSession
 
-	client, err := infrastructure.PostRancherSetup(s.T(), testSession, s.terraformConfig.Standalone.RancherHostname, false, false)
+	client, err := infrastructure.PostRancherSetup(s.T(), s.rancherConfig, testSession, s.terraformConfig.Standalone.RancherHostname, false, false)
 	require.NoError(s.T(), err)
 
 	s.client = client
@@ -91,7 +91,7 @@ func (s *TfpSanityUpgradeRancherTestSuite) TestTfpUpgradeRancher() {
 	err := upgrade.CreateMainTF(s.T(), s.upgradeTerraformOptions, keyPath, s.terraformConfig, s.terratestConfig, s.serverNodeOne, "", "", "")
 	require.NoError(s.T(), err)
 
-	s.client, err = infrastructure.PostRancherSetup(s.T(), s.session, s.terraformConfig.Standalone.RancherHostname, false, false)
+	s.client, err = infrastructure.PostRancherSetup(s.T(), s.rancherConfig, s.session, s.terraformConfig.Standalone.RancherHostname, false, false)
 	require.NoError(s.T(), err)
 
 	provisioning.VerifyClustersState(s.T(), s.client, clusterIDs)


### PR DESCRIPTION
### Issue: N/A

### Description
At times, there appears to be an intermittent issue with an admin token not being generated. This is suspected due to the `rancherConfig` not being passed properly. Because everything is passed through a configMap, this may explain the issue seen.