### PR TITLE
Remove ssh -o ProxyCommand to fix flaky airgap test

### DIFF
--- a/framework/set/provisioning/airgap/copyScriptToBastion.go
+++ b/framework/set/provisioning/airgap/copyScriptToBastion.go
@@ -30,9 +30,9 @@ func copyScript(provisionerBlockBody *hclwrite.Body, terraformConfig *config.Ter
 	}
 
 	provisionerBlockBody.SetAttributeValue(defaults.Inline, cty.ListVal([]cty.Value{
-		cty.StringVal("cat << 'EOF' > /tmp/register-nodes.sh\n" + string(nodesScriptContent) + "\nEOF"),
+		cty.StringVal("echo '" + string(nodesScriptContent) + "' > /tmp/register-nodes.sh"),
 		cty.StringVal("chmod +x /tmp/register-nodes.sh"),
-		cty.StringVal("cat << 'EOF' > /tmp/register-windows-nodes.sh\n" + string(windowsScriptContent) + "\nEOF"),
+		cty.StringVal("echo '" + string(windowsScriptContent) + "' > /tmp/register-windows-nodes.sh"),
 		cty.StringVal("chmod +x /tmp/register-windows-nodes.sh"),
 	}))
 

--- a/framework/set/provisioning/airgap/registerPrivateNodes.go
+++ b/framework/set/provisioning/airgap/registerPrivateNodes.go
@@ -11,7 +11,7 @@ import (
 )
 
 // registerPrivateNodes is a function that will register the private nodes to the cluster
-func registerPrivateNodes(provisionerBlockBody *hclwrite.Body, terraformConfig *config.TerraformConfig, bastionPublicIP, nodePrivateIP,
+func registerPrivateNodes(provisionerBlockBody *hclwrite.Body, terraformConfig *config.TerraformConfig, nodePrivateIP,
 	registrationCommand string) error {
 	privateKey, err := os.ReadFile(terraformConfig.PrivateKeyPath)
 	if err != nil {
@@ -25,7 +25,7 @@ func registerPrivateNodes(provisionerBlockBody *hclwrite.Body, terraformConfig *
 	provisionerBlockBody.SetAttributeRaw(defaults.Inline, hclwrite.Tokens{
 		{Type: hclsyntax.TokenOQuote, Bytes: []byte(`["`), SpacesBefore: 1},
 		{Type: hclsyntax.TokenStringLit, Bytes: []byte("/tmp/register-nodes.sh " + encodedPEMFile + " " +
-			terraformConfig.Standalone.OSUser + " " + terraformConfig.Standalone.OSGroup + " " + bastionPublicIP + " " +
+			terraformConfig.Standalone.OSUser + " " + terraformConfig.Standalone.OSGroup + " " +
 			nodePrivateIP + " " + newCommand + " " + terraformConfig.PrivateRegistries.SystemDefaultRegistry)},
 		{Type: hclsyntax.TokenCQuote, Bytes: []byte(`"]`), SpacesBefore: 1},
 	})
@@ -34,28 +34,22 @@ func registerPrivateNodes(provisionerBlockBody *hclwrite.Body, terraformConfig *
 }
 
 // registerWindowsPrivateNodes is a function that will register the private  Windows nodes to the cluster
-func registerWindowsPrivateNodes(provisionerBlockBody *hclwrite.Body, terraformConfig *config.TerraformConfig, bastionPublicIP, nodePrivateIP,
+func registerWindowsPrivateNodes(provisionerBlockBody *hclwrite.Body, terraformConfig *config.TerraformConfig, nodePrivateIP,
 	registrationCommand string) error {
-	privateKey, err := os.ReadFile(terraformConfig.PrivateKeyPath)
-	if err != nil {
-		return nil
-	}
-
 	windowsPrivateKey, err := os.ReadFile(terraformConfig.WindowsPrivateKeyPath)
 	if err != nil {
 		return nil
 	}
 
-	encodedPEMFile := base64.StdEncoding.EncodeToString([]byte(privateKey))
 	encodedWindowsPEMFile := base64.StdEncoding.EncodeToString([]byte(windowsPrivateKey))
 
 	newCommand := `\"` + registrationCommand + `\"`
 
 	provisionerBlockBody.SetAttributeRaw(defaults.Inline, hclwrite.Tokens{
 		{Type: hclsyntax.TokenOQuote, Bytes: []byte(`["`), SpacesBefore: 1},
-		{Type: hclsyntax.TokenStringLit, Bytes: []byte("/tmp/register-windows-nodes.sh " + encodedPEMFile + " " + encodedWindowsPEMFile + " " +
+		{Type: hclsyntax.TokenStringLit, Bytes: []byte("/tmp/register-windows-nodes.sh " + encodedWindowsPEMFile + " " +
 			terraformConfig.Standalone.OSUser + " " + terraformConfig.Standalone.OSGroup + " " + terraformConfig.AWSConfig.WindowsAWSUser + " " +
-			bastionPublicIP + " " + nodePrivateIP + " " + newCommand + " " + terraformConfig.PrivateRegistries.SystemDefaultRegistry)},
+			nodePrivateIP + " " + newCommand + " " + terraformConfig.PrivateRegistries.SystemDefaultRegistry)},
 		{Type: hclsyntax.TokenCQuote, Bytes: []byte(`"]`), SpacesBefore: 1},
 	})
 

--- a/framework/set/provisioning/airgap/setRKE1Config.go
+++ b/framework/set/provisioning/airgap/setRKE1Config.go
@@ -51,8 +51,6 @@ func SetAirgapRKE1(terraformConfig *config.TerraformConfig, terratestConfig *con
 		nodeOneExpression := "[" + defaults.NullResource + `.register_` + airgapNodeOne + "_" + terraformConfig.ResourcePrefix + "]"
 		nodeTwoExpression := "[" + defaults.NullResource + `.register_` + airgapNodeTwo + "_" + terraformConfig.ResourcePrefix + "]"
 
-		bastionPublicIP := fmt.Sprintf("${%s.%s.%s}", defaults.AwsInstance, bastion+"_"+terraformConfig.ResourcePrefix, defaults.PublicIp)
-
 		if instance == airgapNodeOne {
 			dependsOn = append(dependsOn, bastionScriptExpression)
 		} else if instance == airgapNodeTwo {
@@ -66,7 +64,7 @@ func SetAirgapRKE1(terraformConfig *config.TerraformConfig, terratestConfig *con
 			return nil, nil, err
 		}
 
-		err = registerPrivateNodes(provisionerBlockBody, terraformConfig, bastionPublicIP, nodePrivateIPs[instance], registrationCommands[instance])
+		err = registerPrivateNodes(provisionerBlockBody, terraformConfig, nodePrivateIPs[instance], registrationCommands[instance])
 		if err != nil {
 			return nil, nil, err
 		}

--- a/framework/set/provisioning/airgap/setRKE2K3SConfig.go
+++ b/framework/set/provisioning/airgap/setRKE2K3SConfig.go
@@ -73,8 +73,6 @@ func SetAirgapRKE2K3s(terraformConfig *config.TerraformConfig, terratestConfig *
 		nodeOneExpression := "[" + defaults.NullResource + `.register_` + airgapNodeOne + "_" + terraformConfig.ResourcePrefix + "]"
 		nodeTwoExpression := "[" + defaults.NullResource + `.register_` + airgapNodeTwo + "_" + terraformConfig.ResourcePrefix + "]"
 
-		bastionPublicIP := fmt.Sprintf("${%s.%s.%s}", defaults.AwsInstance, bastion+"_"+terraformConfig.ResourcePrefix, defaults.PublicIp)
-
 		if instance == airgapNodeOne {
 			dependsOn = append(dependsOn, bastionScriptExpression)
 		} else if instance == airgapNodeTwo {
@@ -88,7 +86,7 @@ func SetAirgapRKE2K3s(terraformConfig *config.TerraformConfig, terratestConfig *
 			return nil, nil, err
 		}
 
-		err = registerPrivateNodes(provisionerBlockBody, terraformConfig, bastionPublicIP, nodePrivateIPs[instance], registrationCommands[instance])
+		err = registerPrivateNodes(provisionerBlockBody, terraformConfig, nodePrivateIPs[instance], registrationCommands[instance])
 		if err != nil {
 			return nil, nil, err
 		}

--- a/framework/set/provisioning/airgap/setWindowsConfig.go
+++ b/framework/set/provisioning/airgap/setWindowsConfig.go
@@ -1,12 +1,10 @@
 package airgap
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/rancher/tfp-automation/config"
-	"github.com/rancher/tfp-automation/framework/set/defaults"
 	"github.com/rancher/tfp-automation/framework/set/provisioning/airgap/nullresource"
 	"github.com/sirupsen/logrus"
 )
@@ -17,10 +15,9 @@ func SetAirgapRKE2Windows(terraformConfig *config.TerraformConfig, terratestConf
 	provisionerBlockBody, err := nullresource.SetAirgapNullResource(rootBody, terraformConfig, "register_"+airgapWindowsNode+"_"+terraformConfig.ResourcePrefix, nil)
 	rootBody.AppendNewline()
 
-	bastionPublicIP := fmt.Sprintf("${%s.%s.%s}", defaults.AwsInstance, bastion+"_"+terraformConfig.ResourcePrefix, defaults.PublicIp)
 	registrationCommands, nodePrivateIPs := GetRKE2K3sRegistrationCommands(terraformConfig)
 
-	err = registerWindowsPrivateNodes(provisionerBlockBody, terraformConfig, bastionPublicIP, nodePrivateIPs[airgapWindowsNode], registrationCommands[airgapWindowsNode])
+	err = registerWindowsPrivateNodes(provisionerBlockBody, terraformConfig, nodePrivateIPs[airgapWindowsNode], registrationCommands[airgapWindowsNode])
 	if err != nil {
 		return nil, nil, err
 	}

--- a/tests/airgap/airgap_provisioning_test.go
+++ b/tests/airgap/airgap_provisioning_test.go
@@ -115,12 +115,10 @@ func (a *TfpAirgapProvisioningTestSuite) TestTfpAirgapProvisioning() {
 
 			clusterIDs, customClusterNames := provisioning.Provision(a.T(), a.client, rancher, terraform, terratest, testUser, testPassword, a.terraformOptions, configMap, newFile, rootBody, file, false, false, true, customClusterNames)
 			provisioning.VerifyClustersState(a.T(), a.client, clusterIDs)
-			provisioning.VerifyRegistry(a.T(), a.client, clusterIDs[0], terraform)
 
 			if strings.Contains(terraform.Module, modules.AirgapRKE2Windows) {
 				clusterIDs, _ = provisioning.Provision(a.T(), a.client, rancher, terraform, terratest, testUser, testPassword, a.terraformOptions, configMap, newFile, rootBody, file, true, true, true, customClusterNames)
 				provisioning.VerifyClustersState(a.T(), a.client, clusterIDs)
-				provisioning.VerifyRegistry(a.T(), a.client, clusterIDs[0], terraform)
 			}
 		})
 	}
@@ -175,12 +173,11 @@ func (a *TfpAirgapProvisioningTestSuite) TestTfpAirgapUpgrading() {
 			defer cleanup.Cleanup(a.T(), a.terraformOptions, keyPath)
 
 			clusterIDs, customClusterNames := provisioning.Provision(a.T(), a.client, rancher, terraform, terratest, testUser, testPassword, a.terraformOptions, configMap, newFile, rootBody, file, tt.isWindows, false, true, customClusterNames)
-			provisioning.VerifyRegistry(a.T(), a.client, clusterIDs[0], terraform)
+			provisioning.VerifyClustersState(a.T(), a.client, clusterIDs)
 
 			if strings.Contains(terraform.Module, modules.AirgapRKE2Windows) {
 				clusterIDs, customClusterNames = provisioning.Provision(a.T(), a.client, rancher, terraform, terratest, testUser, testPassword, a.terraformOptions, configMap, newFile, rootBody, file, tt.isWindows, false, true, customClusterNames)
 				provisioning.VerifyClustersState(a.T(), a.client, clusterIDs)
-				provisioning.VerifyRegistry(a.T(), a.client, clusterIDs[0], terraform)
 			}
 
 			clusterIDs, customClusterNames = provisioning.KubernetesUpgrade(a.T(), a.client, rancher, terraform, terratest, testUser, testPassword, a.terraformOptions, configMap, newFile, rootBody, file, tt.isWindows)

--- a/tests/airgap/airgap_upgrade_rancher_test.go
+++ b/tests/airgap/airgap_upgrade_rancher_test.go
@@ -147,12 +147,10 @@ func (a *TfpAirgapUpgradeRancherTestSuite) provisionAndVerifyCluster(name string
 		a.Run((tt.name), func() {
 			clusterIDs, customClusterNames = provisioning.Provision(a.T(), a.client, rancher, terraform, terratest, testUser, testPassword, a.terraformOptions, configMap, newFile, rootBody, file, false, true, true, customClusterNames)
 			provisioning.VerifyClustersState(a.T(), a.client, clusterIDs)
-			provisioning.VerifyRegistry(a.T(), a.client, clusterIDs[0], terraform)
 
 			if strings.Contains(terraform.Module, modules.AirgapRKE2Windows) {
 				clusterIDs, _ = provisioning.Provision(a.T(), a.client, rancher, terraform, terratest, testUser, testPassword, a.terraformOptions, configMap, newFile, rootBody, file, true, true, true, customClusterNames)
 				provisioning.VerifyClustersState(a.T(), a.client, clusterIDs)
-				provisioning.VerifyRegistry(a.T(), a.client, clusterIDs[0], terraform)
 			}
 		})
 	}


### PR DESCRIPTION
### Issue: N/A

### Description
For a few releases now, the airgap test has been flaky. Specifically, when registering nodes, sometimes it will go without issue, other times, the first airgap node would not even register. Spending some time looking into it, it's because we were using an outdated `ssh` command.

I have updated that and have not seen issues, hoping this fixes it longterm.