### PR TITLE
Fix get-qase-id action

### DIFF
--- a/.github/actions/get-qase-id/action.yaml
+++ b/.github/actions/get-qase-id/action.yaml
@@ -21,10 +21,11 @@ runs:
   steps:
     - id: set-qase-id
       run: |
+        set -euo pipefail
         TRIGGERED_TAG="${{ inputs.triggered_tag }}"
         QASE_ID=""
 
-        if [[ ! -z "$TRIGGERED_TAG" ]]; then
+        if [[ -n "$TRIGGERED_TAG" && "$TRIGGERED_TAG" != "false" ]]; then
           QASE_ID="${{ inputs.qase_release_id }}"
         else
           QASE_ID="${{ inputs.qase_recurring_id }}"
@@ -32,4 +33,5 @@ runs:
 
         echo "Qase ID for tag: $QASE_ID"
         echo "id=$QASE_ID" >> $GITHUB_OUTPUT
+
       shell: bash

--- a/.github/workflows/proxy-test.yaml
+++ b/.github/workflows/proxy-test.yaml
@@ -113,7 +113,7 @@ jobs:
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_12 }}"
-          qase_recurring_id: "${{ github.event.inputs.rancher-version-2-12 }}"
+          qase_recurring_id: "${{ github.event.inputs.qase-test-run-id-2-12 }}"
 
       - name: Create config.yaml
         run: |
@@ -284,7 +284,7 @@ jobs:
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_11 }}"
-          qase_recurring_id: "${{ github.event.inputs.rancher-version-2-11 }}"
+          qase_recurring_id: "${{ github.event.inputs.qase-test-run-id-2-11 }}"
 
       - name: Create config.yaml
         run: |
@@ -455,7 +455,7 @@ jobs:
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_10 }}"
-          qase_recurring_id: "${{ github.event.inputs.rancher-version-2-10 }}"
+          qase_recurring_id: "${{ github.event.inputs.qase-test-run-id-2-10 }}"
 
       - name: Create config.yaml
         run: |

--- a/.github/workflows/proxy-upgrade-test.yaml
+++ b/.github/workflows/proxy-upgrade-test.yaml
@@ -113,7 +113,7 @@ jobs:
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_12 }}"
-          qase_recurring_id: "${{ github.event.inputs.rancher-version-2-12 }}"
+          qase_recurring_id: "${{ github.event.inputs.qase-test-run-id-2-12 }}"
 
       - name: Create config.yaml
         run: |
@@ -288,7 +288,7 @@ jobs:
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_11 }}"
-          qase_recurring_id: "${{ github.event.inputs.rancher-version-2-11 }}"
+          qase_recurring_id: "${{ github.event.inputs.qase-test-run-id-2-11 }}"
 
       - name: Create config.yaml
         run: |
@@ -463,7 +463,7 @@ jobs:
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_10 }}"
-          qase_recurring_id: "${{ github.event.inputs.rancher-version-2-10 }}"
+          qase_recurring_id: "${{ github.event.inputs.qase-test-run-id-2-10 }}"
 
       - name: Create config.yaml
         run: |

--- a/.github/workflows/rancher2-recurring-test.yaml
+++ b/.github/workflows/rancher2-recurring-test.yaml
@@ -106,21 +106,13 @@ jobs:
           key: RANCHER_VERSION
           value: ${{ github.event.inputs.rancher_version || (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher-version-2-12) || (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_12_HEAD) }}
 
-      - name: Get Release Qase ID
-        if: ${{ github.event.inputs.rancher_version }}
-        id: get-release-qase-id
-        uses: ./.github/actions/get-release-qase-id
+      - name: Get Qase ID
+        id: get-qase-id
+        uses: ./.github/actions/get-qase-id
         with:
-          tag: ${{ github.event.inputs.rancher_version }}
-          qase_test_run_id_2_11: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_11 }}"
-          qase_test_run_id_2_10: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_10 }}"
-          qase_test_run_id_2_9: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_9 }}"
-
-      - name: Set Qase Test Run ID
-        uses: ./.github/actions/set-env-var
-        with:
-          key: QASE_TEST_RUN_ID
-          value: ${{ steps.get-release-qase-id.outputs.id || (github.event_name == 'workflow_dispatch' && github.event.inputs.qase-test-run-id-2-12) || (github.event_name == 'schedule' && vars.QASE_DEFAULT_TEST_RUN_ID_2_12) }}
+          triggered_tag: ${{ github.event.inputs.rancher_version }}
+          qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_12 }}"
+          qase_recurring_id: "${{ github.event.inputs.qase-test-run-id-2-12 }}"
 
       - name: Create config.yaml
         run: |
@@ -219,7 +211,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || (github.event_name == 'workflow_dispatch' && github.event.inputs.qase-test-run-id-2-12) || (github.event_name == 'schedule' && vars.QASE_DEFAULT_TEST_RUN_ID_2_12) }}
+          qase-test-run-id: ${{ steps.get-qase-id.outputs.id }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -284,21 +276,13 @@ jobs:
           key: RANCHER_VERSION
           value: ${{ github.event.inputs.rancher_version || (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher-version-2-11) || (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_11_HEAD) }}
 
-      - name: Get Release Qase ID
-        if: ${{ github.event.inputs.rancher_version }}
-        id: get-release-qase-id
-        uses: ./.github/actions/get-release-qase-id
+      - name: Get Qase ID
+        id: get-qase-id
+        uses: ./.github/actions/get-qase-id
         with:
-          tag: ${{ github.event.inputs.rancher_version }}
-          qase_test_run_id_2_11: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_11 }}"
-          qase_test_run_id_2_10: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_10 }}"
-          qase_test_run_id_2_9: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_9 }}"
-
-      - name: Set Qase Test Run ID
-        uses: ./.github/actions/set-env-var
-        with:
-          key: QASE_TEST_RUN_ID
-          value: ${{ steps.get-release-qase-id.outputs.id || (github.event_name == 'workflow_dispatch' && (github.event_name == 'schedule' && github.event.inputs.qase-test-run-id-2-11) || vars.QASE_DEFAULT_TEST_RUN_ID_2_11) }}
+          triggered_tag: ${{ github.event.inputs.rancher_version }}
+          qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_11 }}"
+          qase_recurring_id: "${{ github.event.inputs.qase-test-run-id-2-11 }}"
 
       - name: Create config.yaml
         run: |
@@ -397,7 +381,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || (github.event_name == 'workflow_dispatch' && github.event.inputs.qase-test-run-id-2-11) || (github.event_name == 'schedule' && vars.QASE_DEFAULT_TEST_RUN_ID_2_11) }}
+          qase-test-run-id: ${{ steps.get-qase-id.outputs.id }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -462,21 +446,13 @@ jobs:
           key: RANCHER_VERSION
           value: ${{ github.event.inputs.rancher_version || (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher-version-2-10) || (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_10_HEAD) }}
 
-      - name: Get Release Qase ID
-        if: ${{ github.event.inputs.rancher_version }}
-        id: get-release-qase-id
-        uses: ./.github/actions/get-release-qase-id
+      - name: Get Qase ID
+        id: get-qase-id
+        uses: ./.github/actions/get-qase-id
         with:
-          tag: ${{ github.event.inputs.rancher_version }}
-          qase_test_run_id_2_11: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_11 }}"
-          qase_test_run_id_2_10: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_10 }}"
-          qase_test_run_id_2_9: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_9 }}"
-
-      - name: Set Qase Test Run ID
-        uses: ./.github/actions/set-env-var
-        with:
-          key: QASE_TEST_RUN_ID
-          value: ${{ steps.get-release-qase-id.outputs.id || (github.event_name == 'workflow_dispatch' && github.event.inputs.qase-test-run-id-2-10) || (github.event_name == 'schedule' && vars.QASE_DEFAULT_TEST_RUN_ID_2_10) }}
+          triggered_tag: ${{ github.event.inputs.rancher_version }}
+          qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_10 }}"
+          qase_recurring_id: "${{ github.event.inputs.qase-test-run-id-2-10 }}"
 
       - name: Create config.yaml
         run: |
@@ -576,7 +552,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || (github.event_name == 'workflow_dispatch' && github.event.inputs.qase-test-run-id-2-10) || (github.event_name == 'schedule' && vars.QASE_DEFAULT_TEST_RUN_ID_2_10) }}
+          qase-test-run-id: ${{ steps.get-qase-id.outputs.id }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -641,21 +617,14 @@ jobs:
           key: RANCHER_VERSION
           value: ${{ github.event.inputs.rancher_version || (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher-version-2-9) || (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_9_HEAD) }}
 
-      - name: Get Release Qase ID
-        if: ${{ github.event.inputs.rancher_version }}
-        id: get-release-qase-id
-        uses: ./.github/actions/get-release-qase-id
+      - name: Get Qase ID
+        id: get-qase-id
+        uses: ./.github/actions/get-qase-id
         with:
-          tag: ${{ github.event.inputs.rancher_version }}
-          qase_test_run_id_2_11: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_11 }}"
-          qase_test_run_id_2_10: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_10 }}"
-          qase_test_run_id_2_9: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_9 }}"
+          triggered_tag: ${{ github.event.inputs.rancher_version }}
+          qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_9 }}"
+          qase_recurring_id: "${{ github.event.inputs.qase-test-run-id-2-9 }}"
 
-      - name: Set Qase Test Run ID
-        uses: ./.github/actions/set-env-var
-        with:
-          key: QASE_TEST_RUN_ID
-          value: ${{ steps.get-release-qase-id.outputs.id || (github.event_name == 'workflow_dispatch' && github.event.inputs.qase-test-run-id-2-9) || (github.event_name == 'schedule' && vars.QASE_DEFAULT_TEST_RUN_ID_2_9) }}
       - name: Create config.yaml
         run: |
           cat > config.yaml <<EOF
@@ -754,7 +723,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id || (github.event_name == 'workflow_dispatch' && github.event.inputs.qase-test-run-id-2-9) || (github.event_name == 'schedule' && vars.QASE_DEFAULT_TEST_RUN_ID_2_9) }}
+          qase-test-run-id: ${{ steps.get-qase-id.outputs.id }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack

--- a/.github/workflows/sanity-test.yaml
+++ b/.github/workflows/sanity-test.yaml
@@ -112,8 +112,8 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_12 }}"
-          qase_recurring_id: "${{ github.event.inputs.rancher-version-2-12 }}"
+          qase_release_id: ${{ vars.QASE_RELEASE_TEST_RUN_ID_2_12 }}
+          qase_recurring_id: ${{ github.event.inputs.qase-test-run-id-2-12 }}
 
       - name: Create config.yaml
         run: |
@@ -278,7 +278,7 @@ jobs:
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_11 }}"
-          qase_recurring_id: "${{ github.event.inputs.rancher-version-2-11 }}"
+          qase_recurring_id: "${{ github.event.inputs.qase-test-run-id-2-11 }}"
 
       - name: Create config.yaml
         run: |
@@ -312,10 +312,10 @@ jobs:
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
               awsUser: "${{ secrets.AWS_USER }}"
-              sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
+              sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}"
               timeout: "${{ vars.TIMEOUT }}"
               windowsAMI: "${{ secrets.WINDOWS_AMI }}"
-              windowsAWSUser: "${{ secrets.AWS_WINDOWS_USER }}" 
+              windowsAWSUser: "${{ secrets.AWS_WINDOWS_USER }}"
               windowsAWSPassword: "${{ secrets.AWS_WINDOWS_PASSWORD }}"
               windowsInstanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
               windowsKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}"
@@ -443,7 +443,7 @@ jobs:
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_10 }}"
-          qase_recurring_id: "${{ github.event.inputs.rancher-version-2-10 }}"
+          qase_recurring_id: "${{ github.event.inputs.qase-test-run-id-2-10 }}"
 
       - name: Create config.yaml
         run: |
@@ -477,10 +477,10 @@ jobs:
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
               awsUser: "${{ secrets.AWS_USER }}"
-              sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
+              sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}"
               timeout: "${{ vars.TIMEOUT }}"
               windowsAMI: "${{ secrets.WINDOWS_AMI }}"
-              windowsAWSUser: "${{ secrets.AWS_WINDOWS_USER }}" 
+              windowsAWSUser: "${{ secrets.AWS_WINDOWS_USER }}"
               windowsAWSPassword: "${{ secrets.AWS_WINDOWS_PASSWORD }}"
               windowsInstanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
               windowsKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}"
@@ -609,7 +609,7 @@ jobs:
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_9 }}"
-          qase_recurring_id: "${{ github.event.inputs.rancher-version-2-9 }}"
+          qase_recurring_id: "${{ github.event.inputs.qase-test-run-id-2-9 }}"
 
       - name: Create config.yaml
         run: |
@@ -643,10 +643,10 @@ jobs:
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
               awsUser: "${{ secrets.AWS_USER }}"
-              sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
+              sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}"
               timeout: "${{ vars.TIMEOUT }}"
               windowsAMI: "${{ secrets.WINDOWS_AMI }}"
-              windowsAWSUser: "${{ secrets.AWS_WINDOWS_USER }}" 
+              windowsAWSUser: "${{ secrets.AWS_WINDOWS_USER }}"
               windowsAWSPassword: "${{ secrets.AWS_WINDOWS_PASSWORD }}"
               windowsInstanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
               windowsKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}"

--- a/.github/workflows/sanity-upgrade-test.yaml
+++ b/.github/workflows/sanity-upgrade-test.yaml
@@ -113,7 +113,7 @@ jobs:
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_12 }}"
-          qase_recurring_id: "${{ github.event.inputs.rancher-version-2-12 }}"
+          qase_recurring_id: "${{ github.event.inputs.qase-test-run-id-2-12 }}"
 
       - name: Create config.yaml
         run: |
@@ -282,7 +282,7 @@ jobs:
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_11 }}"
-          qase_recurring_id: "${{ github.event.inputs.rancher-version-2-11 }}"
+          qase_recurring_id: "${{ github.event.inputs.qase-test-run-id-2-11 }}"
 
       - name: Create config.yaml
         run: |
@@ -451,7 +451,7 @@ jobs:
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_10 }}"
-          qase_recurring_id: "${{ github.event.inputs.rancher-version-2-10 }}"
+          qase_recurring_id: "${{ github.event.inputs.qase-test-run-id-2-10 }}"
 
       - name: Create config.yaml
         run: |
@@ -551,7 +551,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id }}
+          qase-test-run-id: ${{ steps.get-qase-id.outputs.id }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -622,7 +622,7 @@ jobs:
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_9 }}"
-          qase_recurring_id: "${{ github.event.inputs.rancher-version-2-9 }}"
+          qase_recurring_id: "${{ github.event.inputs.qase-test-run-id-2-9 }}"
 
       - name: Create config.yaml
         run: |
@@ -722,7 +722,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ steps.get-release-qase-id.outputs.id }}
+          qase-test-run-id: ${{ steps.get-qase-id.outputs.id }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack


### PR DESCRIPTION
Logic around conditional was not being respected, and always resulted in true; so only recurring qase id's were grabbed.

This pr enhances the conditional to ensure:
a) triggered_tag has a non-zero length
b) triggered_tag is not set to string of "false" 