### PR TITLE
Fix trigger tests

### DIFF
--- a/.github/actions/dispatch-workflow/action.yaml
+++ b/.github/actions/dispatch-workflow/action.yaml
@@ -2,6 +2,8 @@
 name: Dispatch Workflow
 description: "Dispatches a workflow"
 inputs:
+  token:
+    required: true
   workflow:
     required: true
   tag:
@@ -11,7 +13,7 @@ runs:
   steps:
     - run: |
         curl -X POST https://api.github.com/repos/rancher/tfp-automation/actions/workflows/${{ inputs.workflow }}/dispatches \
-          -H "Authorization: Bearer ${{ secrets.GHA_TOKEN }}" \
+          -H "Authorization: Bearer ${{ inputs.token }}" \
           -H "Accept: application/vnd.github+json" \
           -d "{\"ref\": \"main\", \"inputs\": { \"rancher_version\": \"${{ inputs.tag }}\" }}"
       shell: bash

--- a/.github/workflows/airgap-test.yaml
+++ b/.github/workflows/airgap-test.yaml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   v2-11:
-    if: (startsWith(inputs.rancher_version, 'v2.11.')) && !contains(inputs.rancher_version, '-rc') && !contains(inputs.rancher_version, '-hotfix') && contains(inputs.rancher_version, '-alpha')
+    if: (startsWith(inputs.rancher_version, 'v2.11.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
     environment: alpha
@@ -183,7 +183,7 @@ jobs:
           region: "${{ secrets.AWS_REGION }}"
 
   v2-10:
-    if: (startsWith(inputs.rancher_version, 'v2.10.')) && !contains(inputs.rancher_version, '-rc') && !contains(inputs.rancher_version, '-hotfix') && contains(inputs.rancher_version, '-alpha')
+    if: (startsWith(inputs.rancher_version, 'v2.10.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
     needs: v2-11

--- a/.github/workflows/airgap-upgrade-test.yaml
+++ b/.github/workflows/airgap-upgrade-test.yaml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   v2-11:
-    if: (startsWith(inputs.rancher_version, 'v2.11.')) && !contains(inputs.rancher_version, '-rc') && !contains(inputs.rancher_version, '-hotfix') && contains(inputs.rancher_version, '-alpha')
+    if: (startsWith(inputs.rancher_version, 'v2.11.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ vars.RELEASED_RANCHER_VERSION_2_11 }} -> ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
     environment: alpha
@@ -188,7 +188,7 @@ jobs:
           region: "${{ secrets.AWS_REGION }}"
 
   v2-10:
-    if: (startsWith(inputs.rancher_version, 'v2.10.')) && !contains(inputs.rancher_version, '-rc') && !contains(inputs.rancher_version, '-hotfix') && contains(inputs.rancher_version, '-alpha')
+    if: (startsWith(inputs.rancher_version, 'v2.10.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ vars.RELEASED_RANCHER_VERSION_2_10 }} -> ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
     needs: v2-11

--- a/.github/workflows/check-rancher-tag.yaml
+++ b/.github/workflows/check-rancher-tag.yaml
@@ -120,6 +120,7 @@ jobs:
       - name: Trigger workflow dispatch for ${{ matrix.workflow }}
         uses: ./.github/actions/dispatch-workflow
         with:
+          token: ${{ secrets.GHA_TOKEN }}
           workflow: ${{ matrix.workflow }}
           tag: ${{ needs.check-latest-tag.outputs.latest_tag_v211 }}
 
@@ -145,6 +146,7 @@ jobs:
       - name: Trigger workflow dispatch for ${{ matrix.workflow }}
         uses: ./.github/actions/dispatch-workflow
         with:
+          token: ${{ secrets.GHA_TOKEN }}
           workflow: ${{ matrix.workflow }}
           tag: ${{ needs.check-latest-tag.outputs.latest_tag_v210 }}
 
@@ -170,5 +172,6 @@ jobs:
       - name: Trigger workflow dispatch for ${{ matrix.workflow }}
         uses: ./.github/actions/dispatch-workflow
         with:
+          token: ${{ secrets.GHA_TOKEN }}
           workflow: ${{ matrix.workflow }}
           tag: ${{ needs.check-latest-tag.outputs.latest_tag_v29 }}

--- a/.github/workflows/proxy-arm64-test.yaml
+++ b/.github/workflows/proxy-arm64-test.yaml
@@ -60,7 +60,7 @@ env:
 
 jobs:
   v2-12:
-    if: ${{ github.event_name == 'schedule' }} || (startsWith(inputs.rancher_version, 'v2.12.')) && !contains(inputs.rancher_version, '-rc') && !contains(inputs.rancher_version, '-hotfix') && contains(inputs.rancher_version, '-alpha')
+    if: ${{ github.event_name == 'schedule' }}
     name: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-12 }}
     runs-on: ubuntu-latest
     environment: latest
@@ -223,7 +223,7 @@ jobs:
           region: "${{ secrets.AWS_REGION }}"
 
   v2-11:
-    if: ${{ github.event_name == 'schedule' }} || (startsWith(inputs.rancher_version, 'v2.11.')) && !contains(inputs.rancher_version, '-rc') && !contains(inputs.rancher_version, '-hotfix') && contains(inputs.rancher_version, '-alpha')
+    if: ${{ github.event_name == 'schedule' }}
     name: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-11 }}
     runs-on: ubuntu-latest
     environment: latest
@@ -386,7 +386,7 @@ jobs:
           region: "${{ secrets.AWS_REGION }}"
 
   v2-10:
-    if: ${{ github.event_name == 'schedule' }} || (startsWith(inputs.rancher_version, 'v2.10.')) && !contains(inputs.rancher_version, '-rc') && !contains(inputs.rancher_version, '-hotfix') && contains(inputs.rancher_version, '-alpha')
+    if: ${{ github.event_name == 'schedule' }}
     name: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-10 }}
     runs-on: ubuntu-latest
     environment: staging-latest

--- a/.github/workflows/proxy-test.yaml
+++ b/.github/workflows/proxy-test.yaml
@@ -60,7 +60,7 @@ env:
 
 jobs:
   v2-12:
-    if: ${{ github.event_name == 'schedule' }} || (startsWith(inputs.rancher_version, 'v2.12.')) && !contains(inputs.rancher_version, '-rc') && !contains(inputs.rancher_version, '-hotfix') && contains(inputs.rancher_version, '-alpha')
+    if: ${{ github.event_name == 'schedule' }} || ((startsWith(inputs.rancher_version, 'v2.12.')) && contains(inputs.rancher_version, '-alpha'))
     name: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-12 }}
     runs-on: ubuntu-latest
     environment: latest
@@ -231,7 +231,7 @@ jobs:
           region: "${{ secrets.AWS_REGION }}"
 
   v2-11:
-    if: ${{ github.event_name == 'schedule' }} || (startsWith(inputs.rancher_version, 'v2.11.')) && !contains(inputs.rancher_version, '-rc') && !contains(inputs.rancher_version, '-hotfix') && contains(inputs.rancher_version, '-alpha')
+    if: ${{ github.event_name == 'schedule' }} || ((startsWith(inputs.rancher_version, 'v2.11.')) && contains(inputs.rancher_version, '-alpha'))
     name: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-11 }}
     runs-on: ubuntu-latest
     environment: latest
@@ -402,7 +402,7 @@ jobs:
           region: "${{ secrets.AWS_REGION }}"
 
   v2-10:
-    if: ${{ github.event_name == 'schedule' }} || (startsWith(inputs.rancher_version, 'v2.10.')) && !contains(inputs.rancher_version, '-rc') && !contains(inputs.rancher_version, '-hotfix') && contains(inputs.rancher_version, '-alpha')
+    if: ${{ github.event_name == 'schedule' }} || ((startsWith(inputs.rancher_version, 'v2.10.')) && contains(inputs.rancher_version, '-alpha'))
     name: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-10 }}
     runs-on: ubuntu-latest
     environment: staging-latest

--- a/.github/workflows/proxy-upgrade-arm64-test.yaml
+++ b/.github/workflows/proxy-upgrade-arm64-test.yaml
@@ -60,7 +60,7 @@ env:
 
 jobs:
   v2-12:
-    if: ${{ github.event_name == 'schedule' }} || (startsWith(inputs.rancher_version, 'v2.12.')) && !contains(inputs.rancher_version, '-rc') && !contains(inputs.rancher_version, '-hotfix') && contains(inputs.rancher_version, '-alpha')
+    if: ${{ github.event_name == 'schedule' }}
     name: ${{ vars.RELEASED_RANCHER_VERSION_2_12 }} -> ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-12 }}
     runs-on: ubuntu-latest
     environment: latest
@@ -227,7 +227,7 @@ jobs:
           region: "${{ secrets.AWS_REGION }}"
 
   v2-11:
-    if: ${{ github.event_name == 'schedule' }} || (startsWith(inputs.rancher_version, 'v2.11.')) && !contains(inputs.rancher_version, '-rc') && !contains(inputs.rancher_version, '-hotfix') && contains(inputs.rancher_version, '-alpha')
+    if: ${{ github.event_name == 'schedule' }}
     name: ${{ vars.RELEASED_RANCHER_VERSION_2_11 }} -> ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-11 }}
     runs-on: ubuntu-latest
     environment: latest
@@ -394,7 +394,7 @@ jobs:
           region: "${{ secrets.AWS_REGION }}"
 
   v2-10:
-    if: ${{ github.event_name == 'schedule' }} || (startsWith(inputs.rancher_version, 'v2.10.')) && !contains(inputs.rancher_version, '-rc') && !contains(inputs.rancher_version, '-hotfix') && contains(inputs.rancher_version, '-alpha')
+    if: ${{ github.event_name == 'schedule' }}
     name: ${{ vars.RELEASED_RANCHER_VERSION_2_10 }} -> ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-10 }}
     runs-on: ubuntu-latest
     environment: upgrade-prime-staging

--- a/.github/workflows/rancher2-recurring-test.yaml
+++ b/.github/workflows/rancher2-recurring-test.yaml
@@ -59,7 +59,7 @@ env:
 
 jobs:
   v2-12:
-    if: ${{ github.event_name == 'schedule' }} || (startsWith(inputs.rancher_version, 'v2.12.'))
+    if: ${{ github.event_name == 'schedule' }} || ((startsWith(inputs.rancher_version, 'v2.12.')) && contains(inputs.rancher_version, '-alpha'))
     name: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-12 }}
     runs-on: ubuntu-latest
     environment: latest
@@ -229,7 +229,7 @@ jobs:
           region: "${{ secrets.AWS_REGION }}"
 
   v2-11:
-    if: ${{ github.event_name == 'schedule' }} || (startsWith(inputs.rancher_version, 'v2.11.'))
+    if: ${{ github.event_name == 'schedule' }} || ((startsWith(inputs.rancher_version, 'v2.11.')) && contains(inputs.rancher_version, '-alpha'))
     name: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-11 }}
     runs-on: ubuntu-latest
     environment: latest
@@ -399,7 +399,7 @@ jobs:
           region: "${{ secrets.AWS_REGION }}"
 
   v2-10:
-    if: ${{ github.event_name == 'schedule' }} || (startsWith(inputs.rancher_version, 'v2.10.'))
+    if: ${{ github.event_name == 'schedule' }} || ((startsWith(inputs.rancher_version, 'v2.10.')) && contains(inputs.rancher_version, '-alpha'))
     name: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-10 }}
     runs-on: ubuntu-latest
     environment: staging-latest
@@ -512,177 +512,6 @@ jobs:
               rancherTagVersion: "${{ vars.RANCHER_VERSION_2_10_HEAD }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_10 }}${{ vars.RKE2_VERSION_SUFFIX }}"
-          terratest:
-            pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            nodeCount: ${{ vars.NODE_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
-            snapshotInput: {}
-          EOF
-
-      - name: Export CATTLE_TEST_CONFIG
-        run: echo "CATTLE_TEST_CONFIG=${{ github.workspace }}/config.yaml" >> $GITHUB_ENV
-        shell: bash
-
-      - name: Set up Go environment
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: "./go.mod"
-
-      - name: Build Packages
-        run: ./.github/scripts/build-packages.sh
-
-      - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@latest
-
-      - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v2
-        with:
-          terraform_version: "${{ vars.TERRAFORM_VERSION }}"
-          terraform_wrapper: false
-
-      - name: Run Rancher2 Test Suite
-        uses: ./.github/actions/run-test-suite
-        with:
-          package: ${{ env.PACKAGE }}
-          path-to-repo: ${{ secrets.PATH_TO_REPO }}
-          suite: ${{ env.SUITE }}
-          timeout: ${{ env.TIMEOUT }}
-
-      - name: Reporting Results to Qase
-        if: always()
-        uses: ./.github/actions/report-to-qase
-        with:
-          qase-test-run-id: ${{ steps.get-qase-id.outputs.id }}
-          qase-automation-token: ${{ secrets.QASE_TOKEN }}
-
-      - name: Reporting Results to Slack
-        uses: ./.github/actions/report-to-slack
-        with:
-          job-status: ${{ job.status }}
-          slack-channel: ${{ secrets.SLACK_CHANNEL }}
-          slack-token: ${{ secrets.SLACK_TOKEN }}
-
-      - name: Revoke Runner IP
-        if: always()
-        uses: ./.github/actions/revoke-runner-ip
-        with:
-          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
-
-  v2-9:
-    if: ${{ github.event_name == 'schedule' }} || (startsWith(inputs.rancher_version, 'v2.9.'))
-    name: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-9 }}
-    runs-on: ubuntu-latest
-    environment: staging-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.TFP_IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
-
-      - name: Get AWS credentials from Secrets Manager
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
-        with:
-          secret-ids: |
-            AWS_ACCESS_KEY, ${{ secrets.AWS_ACCESS_KEY_ID }}
-            AWS_SECRET_KEY, ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-      - name: Whitelist Runner IP
-        uses: ./.github/actions/whitelist-runner-ip
-        with:
-          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
-
-      - name: Set up SSH Keys
-        uses: ./.github/actions/setup-ssh-keys
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-          ssh-private-key-name: ${{ secrets.SSH_PRIVATE_KEY_NAME }}
-          windows-ssh-private-key: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY }}
-          windows-ssh-private-key-name: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}
-
-      - name: Uniquify hostname prefix
-        uses: ./.github/actions/uniquify-hostname
-
-      - name: Set Rancher version
-        uses: ./.github/actions/set-env-var
-        with:
-          key: RANCHER_VERSION
-          value: ${{ github.event.inputs.rancher_version || (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher-version-2-9) || (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_9_HEAD) }}
-
-      - name: Get Qase ID
-        id: get-qase-id
-        uses: ./.github/actions/get-qase-id
-        with:
-          triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_9 }}"
-          qase_recurring_id: "${{ github.event.inputs.qase-test-run-id-2-9 }}"
-
-      - name: Create config.yaml
-        run: |
-          cat > config.yaml <<EOF
-          rancher:
-            host: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
-            adminPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
-            insecure: true
-          upgradeInput:
-            clusters:
-              -  versionToUpgrade: ${{ vars.RKE2_VERSION_2_9 }}
-          terraform:
-            cni: "${{ secrets.CNI }}"
-            defaultClusterRoleForProjectMembers: "true"
-            enableNetworkPolicy: false
-            provider: "${{ vars.PROVIDER_AMAZON }}"
-            privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
-            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
-            awsCredentials:
-              awsAccessKey: "$AWS_ACCESS_KEY"
-              awsSecretKey: "$AWS_SECRET_KEY"
-            awsConfig:
-              ami: "${{ secrets.AWS_AMI }}"
-              awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
-              awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
-              awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
-              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
-              awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
-              awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
-              awsVpcID: "${{ secrets.AWS_VPC_ID }}"
-              awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
-              awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
-              awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.AWS_USER }}"
-              sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
-              timeout: "${{ vars.TIMEOUT }}"
-              windowsAMI: "${{ secrets.WINDOWS_AMI }}"
-              windowsAWSUser: "${{ secrets.AWS_WINDOWS_USER }}" 
-              windowsAWSPassword: "${{ secrets.AWS_WINDOWS_PASSWORD }}"
-              windowsInstanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
-              windowsKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}"
-              ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
-              loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
-              targetType: "${{ vars.TARGET_TYPE }}"
-            standalone:
-              bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
-              certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              k3sVersion: "${{ vars.K3S_VERSION_2_9 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ secrets.OS_USER }}"
-              osGroup: "${{ secrets.OS_GROUP }}"
-              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
-              rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
-              rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
-              rancherTagVersion: "${{ vars.RANCHER_VERSION_2_9_HEAD }}"
-              repo: "${{ secrets.RANCHER_REPO }}"
-              rke2Version: "${{ vars.RKE2_VERSION_2_9 }}${{ vars.RKE2_VERSION_SUFFIX }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             nodeCount: ${{ vars.NODE_COUNT }}

--- a/.github/workflows/registry-test.yaml
+++ b/.github/workflows/registry-test.yaml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   v2-11:
-    if: (startsWith(inputs.rancher_version, 'v2.11.')) && !contains(inputs.rancher_version, '-rc') && !contains(inputs.rancher_version, '-hotfix') && contains(inputs.rancher_version, '-alpha')
+    if: (startsWith(inputs.rancher_version, 'v2.11.')) && ((startsWith(inputs.rancher_version, 'v2.11.')) && contains(inputs.rancher_version, '-alpha'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
     environment: alpha
@@ -196,7 +196,7 @@ jobs:
           region: "${{ secrets.AWS_REGION }}"
 
   v2-10:
-    if: (startsWith(inputs.rancher_version, 'v2.10.')) && !contains(inputs.rancher_version, '-rc') && !contains(inputs.rancher_version, '-hotfix') && contains(inputs.rancher_version, '-alpha')
+    if: (startsWith(inputs.rancher_version, 'v2.10.')) && ((startsWith(inputs.rancher_version, 'v2.10.')) && contains(inputs.rancher_version, '-alpha'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
     needs: v2-11

--- a/.github/workflows/sanity-arm64-test.yaml
+++ b/.github/workflows/sanity-arm64-test.yaml
@@ -60,7 +60,7 @@ env:
 
 jobs:
   v2-12:
-    if: ${{ github.event_name == 'schedule' }} || (startsWith(inputs.rancher_version, 'v2.12.'))
+    if: ${{ github.event_name == 'schedule' }}
     name: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-12 }}
     runs-on: ubuntu-latest
     environment: latest
@@ -217,7 +217,7 @@ jobs:
           region: "${{ secrets.AWS_REGION }}"
 
   v2-11:
-    if: ${{ github.event_name == 'schedule' }} || (startsWith(inputs.rancher_version, 'v2.11.'))
+    if: ${{ github.event_name == 'schedule' }}
     name: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-11 }}
     runs-on: ubuntu-latest
     environment: latest
@@ -374,7 +374,7 @@ jobs:
           region: "${{ secrets.AWS_REGION }}"
 
   v2-10:
-    if: ${{ github.event_name == 'schedule' }} || (startsWith(inputs.rancher_version, 'v2.10.'))
+    if: ${{ github.event_name == 'schedule' }}
     name: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-10 }}
     runs-on: ubuntu-latest
     environment: staging-latest
@@ -532,7 +532,7 @@ jobs:
           region: "${{ secrets.AWS_REGION }}"
 
   v2-9:
-    if: ${{ github.event_name == 'schedule' }} || (startsWith(inputs.rancher_version, 'v2.9.'))
+    if: ${{ github.event_name == 'schedule' }}
     name: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-9 }}
     runs-on: ubuntu-latest
     environment: staging-latest

--- a/.github/workflows/sanity-upgrade-arm64-test.yaml
+++ b/.github/workflows/sanity-upgrade-arm64-test.yaml
@@ -60,7 +60,7 @@ env:
 
 jobs:
   v2-12:
-    if: ${{ github.event_name == 'schedule' }} || (startsWith(inputs.rancher_version, 'v2.12.'))
+    if: ${{ github.event_name == 'schedule' }}
     name: ${{ vars.RELEASED_RANCHER_VERSION_2_12 }} -> ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-12 }}
     runs-on: ubuntu-latest
     environment: latest
@@ -221,7 +221,7 @@ jobs:
           region: "${{ secrets.AWS_REGION }}"
 
   v2-11:
-    if: ${{ github.event_name == 'schedule' }} || (startsWith(inputs.rancher_version, 'v2.11.'))
+    if: ${{ github.event_name == 'schedule' }}
     name: ${{ vars.RELEASED_RANCHER_VERSION_2_11 }} -> ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-11 }}
     runs-on: ubuntu-latest
     environment: latest
@@ -382,7 +382,7 @@ jobs:
           region: "${{ secrets.AWS_REGION }}"
 
   v2-10:
-    if: ${{ github.event_name == 'schedule' }} || (startsWith(inputs.rancher_version, 'v2.10.'))
+    if: ${{ github.event_name == 'schedule' }}
     name: ${{ vars.RELEASED_RANCHER_VERSION_2_10 }} -> ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-10 }}
     runs-on: ubuntu-latest
     environment: upgrade-prime-staging
@@ -545,7 +545,7 @@ jobs:
           region: "${{ secrets.AWS_REGION }}"
 
   v2-9:
-    if: ${{ github.event_name == 'schedule' }} || (startsWith(inputs.rancher_version, 'v2.9.'))
+    if: ${{ github.event_name == 'schedule' }}
     name: ${{ vars.RELEASED_RANCHER_VERSION_2_9 }} -> ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-9 }}
     runs-on: ubuntu-latest
     environment: upgrade-prime-staging


### PR DESCRIPTION
### Issue: N/A

### Description
The first part of `check-rancher-tag` workflow is working now. The trigger-tests need to be updated to have the GHA token be read in as a parameter. In addition, we will need to update the job inputs to only be read when an alpha kicks off for all non-sanity tests.