### PR TITLE
Make rancher-tag key unique per release

### DIFF
--- a/.github/workflows/airgap-test.yaml
+++ b/.github/workflows/airgap-test.yaml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   v2-11:
-    if: ((startsWith(github.event.inputs.rancher_version, 'v2.11.')) && contains(github.event.inputs.rancher_version, '-alpha'))
+    if: (startsWith(github.event.inputs.rancher_version, 'v2.11.') && contains(github.event.inputs.rancher_version, '-alpha'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
     environment: alpha
@@ -183,7 +183,7 @@ jobs:
           region: "${{ secrets.AWS_REGION }}"
 
   v2-10:
-    if: ((startsWith(github.event.inputs.rancher_version, 'v2.10.')) && contains(github.event.inputs.rancher_version, '-alpha'))
+    if: (startsWith(github.event.inputs.rancher_version, 'v2.10.') && contains(github.event.inputs.rancher_version, '-alpha'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
     needs: v2-11

--- a/.github/workflows/airgap-upgrade-test.yaml
+++ b/.github/workflows/airgap-upgrade-test.yaml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   v2-11:
-    if: ((startsWith(github.event.inputs.rancher_version, 'v2.11.')) && contains(github.event.inputs.rancher_version, '-alpha'))
+    if: (startsWith(github.event.inputs.rancher_version, 'v2.11.') && contains(github.event.inputs.rancher_version, '-alpha'))
     name: ${{ vars.RELEASED_RANCHER_VERSION_2_11 }} -> ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
     environment: alpha
@@ -188,7 +188,7 @@ jobs:
           region: "${{ secrets.AWS_REGION }}"
 
   v2-10:
-    if: ((startsWith(github.event.inputs.rancher_version, 'v2.10.')) && contains(github.event.inputs.rancher_version, '-alpha'))
+    if: (startsWith(github.event.inputs.rancher_version, 'v2.10.') && contains(github.event.inputs.rancher_version, '-alpha'))
     name: ${{ vars.RELEASED_RANCHER_VERSION_2_10 }} -> ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
     needs: v2-11

--- a/.github/workflows/check-rancher-tag.yaml
+++ b/.github/workflows/check-rancher-tag.yaml
@@ -64,9 +64,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: tag/tag_v211.txt
-          key: rancher-tag
+          key: rancher-tag-v211-${{ env.LATEST_TAG_v211 }}
           restore-keys: |
-            rancher-tag
+            rancher-tag-v211
 
       - name: v2.10 - Write new tag to file
         if: ${{ env.IS_TAG_NEW_v210 == 'true' }}
@@ -79,9 +79,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: tag/tag_v210.txt
-          key: rancher-tag
+          key: rancher-tag-v210-${{ env.LATEST_TAG_v210 }}
           restore-keys: |
-            rancher-tag
+            rancher-tag-v210
 
       - name: v2.9 - Write new tag to file
         if: ${{ env.IS_TAG_NEW_v29 == 'true' }}
@@ -94,9 +94,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: tag/tag_v29.txt
-          key: rancher-tag-v29
+          key: rancher-tag-v29-${{ env.LATEST_TAG_v29 }}
           restore-keys: |
-            rancher-tag
+            rancher-tag-v29
 
   trigger-tests-v211:
     needs: check-latest-tag

--- a/.github/workflows/proxy-test.yaml
+++ b/.github/workflows/proxy-test.yaml
@@ -60,7 +60,7 @@ env:
 
 jobs:
   v2-12:
-    if: ${{ github.event_name == 'schedule' }} || ((startsWith(github.event.inputs.rancher_version, 'v2.12.')) && contains(github.event.inputs.rancher_version, '-alpha'))
+    if: ${{ github.event_name == 'schedule' }} || (startsWith(github.event.inputs.rancher_version, 'v2.12.') && contains(github.event.inputs.rancher_version, '-alpha'))
     name: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-12 }}
     runs-on: ubuntu-latest
     environment: latest
@@ -231,7 +231,7 @@ jobs:
           region: "${{ secrets.AWS_REGION }}"
 
   v2-11:
-    if: ${{ github.event_name == 'schedule' }} || ((startsWith(github.event.inputs.rancher_version, 'v2.11.')) && contains(github.event.inputs.rancher_version, '-alpha'))
+    if: ${{ github.event_name == 'schedule' }} || (startsWith(github.event.inputs.rancher_version, 'v2.11.') && contains(github.event.inputs.rancher_version, '-alpha'))
     name: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-11 }}
     runs-on: ubuntu-latest
     environment: latest
@@ -402,7 +402,7 @@ jobs:
           region: "${{ secrets.AWS_REGION }}"
 
   v2-10:
-    if: ${{ github.event_name == 'schedule' }} || ((startsWith(github.event.inputs.rancher_version, 'v2.10.')) && contains(github.event.inputs.rancher_version, '-alpha'))
+    if: ${{ github.event_name == 'schedule' }} || (startsWith(github.event.inputs.rancher_version, 'v2.10.') && contains(github.event.inputs.rancher_version, '-alpha'))
     name: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-10 }}
     runs-on: ubuntu-latest
     environment: staging-latest

--- a/.github/workflows/proxy-upgrade-test.yaml
+++ b/.github/workflows/proxy-upgrade-test.yaml
@@ -60,7 +60,7 @@ env:
 
 jobs:
   v2-12:
-    if: ${{ github.event_name == 'schedule' }} || ((startsWith(github.event.inputs.rancher_version, 'v2.12.')) && contains(inputs.rancher_version, '-alpha'))
+    if: ${{ github.event_name == 'schedule' }} || (startsWith(github.event.inputs.rancher_version, 'v2.12.') && contains(inputs.rancher_version, '-alpha'))
     name: ${{ vars.RELEASED_RANCHER_VERSION_2_12 }} -> ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-12 }}
     runs-on: ubuntu-latest
     environment: latest
@@ -235,7 +235,7 @@ jobs:
           region: "${{ secrets.AWS_REGION }}"
 
   v2-11:
-    if: ${{ github.event_name == 'schedule' }} || ((startsWith(github.event.inputs.rancher_version, 'v2.11.')) && contains(inputs.rancher_version, '-alpha'))
+    if: ${{ github.event_name == 'schedule' }} || (startsWith(github.event.inputs.rancher_version, 'v2.11.') && contains(inputs.rancher_version, '-alpha'))
     name: ${{ vars.RELEASED_RANCHER_VERSION_2_11 }} -> ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-11 }}
     runs-on: ubuntu-latest
     environment: latest
@@ -410,7 +410,7 @@ jobs:
           region: "${{ secrets.AWS_REGION }}"
 
   v2-10:
-    if: ${{ github.event_name == 'schedule' }} || ((startsWith(github.event.inputs.rancher_version, 'v2.10.')) && contains(inputs.rancher_version, '-alpha'))
+    if: ${{ github.event_name == 'schedule' }} || (startsWith(github.event.inputs.rancher_version, 'v2.10.') && contains(inputs.rancher_version, '-alpha'))
     name: ${{ vars.RELEASED_RANCHER_VERSION_2_10 }} -> ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-10 }}
     runs-on: ubuntu-latest
     environment: upgrade-prime-staging


### PR DESCRIPTION
### Issue: N/A

### Description
Every time `check-rancher-tag` runs, it is not saving the cached Rancher version. This is an issue because every time it runs, it is not supposed to run unless a new tag is found. Additionally, this is trying to fix all workflows running despite the conditionals as the last PR didn't fix it.