### PR TITLE
Update cache to artifact

### DIFF
--- a/.github/workflows/check-rancher-tag.yaml
+++ b/.github/workflows/check-rancher-tag.yaml
@@ -21,12 +21,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Cache prior Rancher tag
-        id: cache
-        uses: actions/cache@v4
+      - name: Download prior Rancher tag artifacts
+        uses: actions/download-artifact@v4
         with:
+          name: rancher-tags
           path: tag
-          key: rancher-tag
 
       - name: Get latest Rancher tag
         id: get-latest-tag
@@ -53,50 +52,26 @@ jobs:
           latest-tag-v210: ${{ env.LATEST_TAG_v210 }}
           latest-tag-v29: ${{ env.LATEST_TAG_v29 }}
 
-      - name: v2.11 - Write new tag to file
-        if: ${{ env.IS_TAG_NEW_v211 == 'true' }}
+      - name: v2.11 - Write tag to file
         run: |
           mkdir -p tag
           echo "${{ env.LATEST_TAG_v211 }}" > tag/tag_v211.txt
 
-      - name: v2.11 - Cache updated Rancher tag
-        if: ${{ env.IS_TAG_NEW_v211 == 'true' }}
-        uses: actions/cache@v4
-        with:
-          path: tag/tag_v211.txt
-          key: rancher-tag-v211-${{ env.LATEST_TAG_v211 }}
-          restore-keys: |
-            rancher-tag-v211
-
-      - name: v2.10 - Write new tag to file
-        if: ${{ env.IS_TAG_NEW_v210 == 'true' }}
+      - name: v2.10 - Write tag to file
         run: |
           mkdir -p tag
           echo "${{ env.LATEST_TAG_v210 }}" > tag/tag_v210.txt
 
-      - name: v2.10 - Cache updated Rancher tag
-        if: ${{ env.IS_TAG_NEW_v210 == 'true' }}
-        uses: actions/cache@v4
-        with:
-          path: tag/tag_v210.txt
-          key: rancher-tag-v210-${{ env.LATEST_TAG_v210 }}
-          restore-keys: |
-            rancher-tag-v210
-
-      - name: v2.9 - Write new tag to file
-        if: ${{ env.IS_TAG_NEW_v29 == 'true' }}
+      - name: v2.9 - Write tag to file
         run: |
           mkdir -p tag
           echo "${{ env.LATEST_TAG_v29 }}" > tag/tag_v29.txt
 
-      - name: v2.9 - Cache updated Rancher tag
-        if: ${{ env.IS_TAG_NEW_v29 == 'true' }}
-        uses: actions/cache@v4
+      - name: Upload Rancher tag artifacts
+        uses: actions/upload-artifact@v4
         with:
-          path: tag/tag_v29.txt
-          key: rancher-tag-v29-${{ env.LATEST_TAG_v29 }}
-          restore-keys: |
-            rancher-tag-v29
+          name: rancher-tags
+          path: tag
 
   trigger-tests-v211:
     needs: check-latest-tag


### PR DESCRIPTION
### Issue: N/A

### Description
Further research indicates that `actions/cache` is not a viable way for us to make sure we aren't running the same tests every time an alpha is cut. We can try changing to `actions/upload-artifact` and `actions/download-artifact` to see if that is better.