### PR TITLE
Updating workflow_call in the GHA workflows

### DIFF
--- a/.github/workflows/airgap-test.yaml
+++ b/.github/workflows/airgap-test.yaml
@@ -6,6 +6,12 @@ on:
     inputs:
       rancher_version:
         description: "Rancher version"
+  workflow_call:
+    inputs:
+      rancher_version:
+        description: "Rancher tag version provided from check-rancher-tag workflow"
+        required: true
+        type: string
 
 env:
   AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
@@ -27,8 +33,10 @@ permissions:
 
 jobs:
   v2-11:
-    if: (startsWith(github.event.inputs.rancher_version, 'v2.11.') && contains(github.event.inputs.rancher_version, '-alpha'))
-    name: ${{ github.event.inputs.rancher_version }}
+    if: |
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11.')) && contains(inputs.rancher_version, '-alpha')
+    name: ${{ inputs.rancher_version || github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
     environment: alpha
 
@@ -183,8 +191,10 @@ jobs:
           region: "${{ secrets.AWS_REGION }}"
 
   v2-10:
-    if: (startsWith(github.event.inputs.rancher_version, 'v2.10.') && contains(github.event.inputs.rancher_version, '-alpha'))
-    name: ${{ github.event.inputs.rancher_version }}
+    if: |
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.10.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.10.')) && contains(inputs.rancher_version, '-alpha')
+    name: ${{ inputs.rancher_version || github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
     needs: v2-11
     environment: staging-alpha

--- a/.github/workflows/airgap-upgrade-test.yaml
+++ b/.github/workflows/airgap-upgrade-test.yaml
@@ -6,6 +6,12 @@ on:
     inputs:
       rancher_version:
         description: "Rancher version"
+  workflow_call:
+    inputs:
+      rancher_version:
+        description: "Rancher tag version provided from check-rancher-tag workflow"
+        required: true
+        type: string
 
 env:
   AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
@@ -27,8 +33,10 @@ permissions:
 
 jobs:
   v2-11:
-    if: (startsWith(github.event.inputs.rancher_version, 'v2.11.') && contains(github.event.inputs.rancher_version, '-alpha'))
-    name: ${{ vars.RELEASED_RANCHER_VERSION_2_11 }} -> ${{ github.event.inputs.rancher_version }}
+    if: |
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11.')) && contains(inputs.rancher_version, '-alpha')
+    name: ${{ vars.RELEASED_RANCHER_VERSION_2_11 }} -> ${{ inputs.rancher_version || github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
     environment: alpha
 
@@ -188,8 +196,10 @@ jobs:
           region: "${{ secrets.AWS_REGION }}"
 
   v2-10:
-    if: (startsWith(github.event.inputs.rancher_version, 'v2.10.') && contains(github.event.inputs.rancher_version, '-alpha'))
-    name: ${{ vars.RELEASED_RANCHER_VERSION_2_10 }} -> ${{ github.event.inputs.rancher_version }}
+    if: |
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.10.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.10.')) && contains(inputs.rancher_version, '-alpha')
+    name: ${{ vars.RELEASED_RANCHER_VERSION_2_10 }} -> ${{ inputs.rancher_version || github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
     needs: v2-11
     environment: staging-alpha

--- a/.github/workflows/dispatch-workflows.yaml
+++ b/.github/workflows/dispatch-workflows.yaml
@@ -15,12 +15,12 @@ jobs:
       matrix:
         workflow:
           - sanity-test.yaml
-          # - sanity-upgrade-test.yaml
-          # - proxy-test.yaml
-          # - proxy-upgrade-test.yaml
-          # - registry-test.yaml
-          # - airgap-test.yaml
-          # - airgap-upgrade-test.yaml
+          - sanity-upgrade-test.yaml
+          - proxy-test.yaml
+          - proxy-upgrade-test.yaml
+          - registry-test.yaml
+          - airgap-test.yaml
+          - airgap-upgrade-test.yaml
 
     steps:
       - name: Trigger test workflow ${{ matrix.workflow }}

--- a/.github/workflows/proxy-test.yaml
+++ b/.github/workflows/proxy-test.yaml
@@ -40,6 +40,12 @@ on:
         description: "Qase Test Run ID for v2.9.x"
         required: true
         default: "4540"
+  workflow_call:
+    inputs:
+      rancher_version:
+        description: "Rancher tag version provided from check-rancher-tag workflow"
+        required: true
+        type: string
 
 permissions:
   id-token: write
@@ -60,8 +66,11 @@ env:
 
 jobs:
   v2-12:
-    if: ${{ github.event_name == 'schedule' }} || (startsWith(github.event.inputs.rancher_version, 'v2.12.') && contains(github.event.inputs.rancher_version, '-alpha'))
-    name: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-12 }}
+    if: |
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.12.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.12.')) && contains(inputs.rancher_version, '-alpha')
+    name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-12 }}
     runs-on: ubuntu-latest
     environment: latest
 
@@ -231,8 +240,11 @@ jobs:
           region: "${{ secrets.AWS_REGION }}"
 
   v2-11:
-    if: ${{ github.event_name == 'schedule' }} || (startsWith(github.event.inputs.rancher_version, 'v2.11.') && contains(github.event.inputs.rancher_version, '-alpha'))
-    name: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-11 }}
+    if: |
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11.')) && contains(inputs.rancher_version, '-alpha')
+    name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-11 }}
     runs-on: ubuntu-latest
     environment: latest
 
@@ -402,8 +414,11 @@ jobs:
           region: "${{ secrets.AWS_REGION }}"
 
   v2-10:
-    if: ${{ github.event_name == 'schedule' }} || (startsWith(github.event.inputs.rancher_version, 'v2.10.') && contains(github.event.inputs.rancher_version, '-alpha'))
-    name: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-10 }}
+    if: |
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.10.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.10.')) && contains(inputs.rancher_version, '-alpha')
+    name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-12 }}
     runs-on: ubuntu-latest
     environment: staging-latest
 

--- a/.github/workflows/proxy-upgrade-test.yaml
+++ b/.github/workflows/proxy-upgrade-test.yaml
@@ -40,6 +40,12 @@ on:
         description: "Qase Test Run ID for v2.9.x"
         required: true
         default: "4540"
+  workflow_call:
+    inputs:
+      rancher_version:
+        description: "Rancher tag version provided from check-rancher-tag workflow"
+        required: true
+        type: string
 
 permissions:
   id-token: write
@@ -60,8 +66,11 @@ env:
 
 jobs:
   v2-12:
-    if: ${{ github.event_name == 'schedule' }} || (startsWith(github.event.inputs.rancher_version, 'v2.12.') && contains(inputs.rancher_version, '-alpha'))
-    name: ${{ vars.RELEASED_RANCHER_VERSION_2_12 }} -> ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-12 }}
+    if: |
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.12.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.12.')) && contains(inputs.rancher_version, '-alpha')
+    name: ${{ vars.RELEASED_RANCHER_VERSION_2_12 }} -> ${{ inputs.rancher_version || github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
     environment: latest
 
@@ -235,8 +244,11 @@ jobs:
           region: "${{ secrets.AWS_REGION }}"
 
   v2-11:
-    if: ${{ github.event_name == 'schedule' }} || (startsWith(github.event.inputs.rancher_version, 'v2.11.') && contains(inputs.rancher_version, '-alpha'))
-    name: ${{ vars.RELEASED_RANCHER_VERSION_2_11 }} -> ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-11 }}
+    if: |
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11.')) && contains(inputs.rancher_version, '-alpha')
+    name: ${{ vars.RELEASED_RANCHER_VERSION_2_11 }} -> ${{ inputs.rancher_version || github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
     environment: latest
 
@@ -410,8 +422,11 @@ jobs:
           region: "${{ secrets.AWS_REGION }}"
 
   v2-10:
-    if: ${{ github.event_name == 'schedule' }} || (startsWith(github.event.inputs.rancher_version, 'v2.10.') && contains(inputs.rancher_version, '-alpha'))
-    name: ${{ vars.RELEASED_RANCHER_VERSION_2_10 }} -> ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-10 }}
+    if: |
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.10.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.10.')) && contains(inputs.rancher_version, '-alpha')
+    name: ${{ vars.RELEASED_RANCHER_VERSION_2_10 }} -> ${{ inputs.rancher_version || github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
     environment: upgrade-prime-staging
 

--- a/.github/workflows/registry-test.yaml
+++ b/.github/workflows/registry-test.yaml
@@ -6,6 +6,12 @@ on:
     inputs:
       rancher_version:
         description: "Rancher version"
+  workflow_call:
+    inputs:
+      rancher_version:
+        description: "Rancher tag version provided from check-rancher-tag workflow"
+        required: true
+        type: string
 
 env:
   AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
@@ -27,8 +33,10 @@ permissions:
 
 jobs:
   v2-11:
-    if: ((startsWith(github.event.inputs.rancher_version, 'v2.11.')) && contains(github.event.inputs.rancher_version, '-alpha'))
-    name: ${{ github.event.inputs.rancher_version }}
+    if: |
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11.')) && contains(inputs.rancher_version, '-alpha')
+    name: ${{ inputs.rancher_version || github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
     environment: alpha
 
@@ -196,8 +204,10 @@ jobs:
           region: "${{ secrets.AWS_REGION }}"
 
   v2-10:
-    if: ((startsWith(github.event.inputs.rancher_version, 'v2.10.')) && contains(github.event.inputs.rancher_version, '-alpha'))
-    name: ${{ github.event.inputs.rancher_version }}
+    if: |
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.10.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.10.')) && contains(inputs.rancher_version, '-alpha')
+    name: ${{ inputs.rancher_version || github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
     needs: v2-11
     environment: staging-alpha

--- a/.github/workflows/sanity-upgrade-test.yaml
+++ b/.github/workflows/sanity-upgrade-test.yaml
@@ -40,6 +40,12 @@ on:
         description: "Qase Test Run ID for v2.9.x"
         required: true
         default: "4540"
+  workflow_call:
+    inputs:
+      rancher_version:
+        description: "Rancher tag version provided from check-rancher-tag workflow"
+        required: true
+        type: string
 
 permissions:
   id-token: write
@@ -60,8 +66,11 @@ env:
 
 jobs:
   v2-12:
-    if: ${{ github.event_name == 'schedule' }} || (startsWith(github.event.inputs.rancher_version, 'v2.12.'))
-    name: ${{ vars.RELEASED_RANCHER_VERSION_2_12 }} -> ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-12 }}
+    if: |
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.12.')) ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.12.'))
+    name: ${{ vars.RELEASED_RANCHER_VERSION_2_12 }} -> ${{ inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-12 }}
     runs-on: ubuntu-latest
     environment: latest
 
@@ -229,8 +238,11 @@ jobs:
           region: "${{ secrets.AWS_REGION }}"
 
   v2-11:
-    if: ${{ github.event_name == 'schedule' }} || (startsWith(github.event.inputs.rancher_version, 'v2.11.'))
-    name: ${{ vars.RELEASED_RANCHER_VERSION_2_11 }} -> ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-11 }}
+    if: |
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11.')) ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11.'))
+    name: ${{ vars.RELEASED_RANCHER_VERSION_2_11 }} -> ${{ inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-11 }}
     runs-on: ubuntu-latest
     environment: latest
 
@@ -398,8 +410,11 @@ jobs:
           region: "${{ secrets.AWS_REGION }}"
 
   v2-10:
-    if: ${{ github.event_name == 'schedule' }} || (startsWith(github.event.inputs.rancher_version, 'v2.10.'))
-    name: ${{ vars.RELEASED_RANCHER_VERSION_2_10 }} -> ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-10 }}
+    if: |
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.10.')) ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.10.'))
+    name: ${{ vars.RELEASED_RANCHER_VERSION_2_10 }} -> ${{ inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-10 }}
     runs-on: ubuntu-latest
     environment: upgrade-prime-staging
 
@@ -569,8 +584,11 @@ jobs:
           region: "${{ secrets.AWS_REGION }}"
 
   v2-9:
-    if: ${{ github.event_name == 'schedule' }} || (startsWith(github.event.inputs.rancher_version, 'v2.9.'))
-    name: ${{ vars.RELEASED_RANCHER_VERSION_2_9 }} -> ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-9 }}
+    if: |
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.9.')) ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.9.'))
+    name: ${{ vars.RELEASED_RANCHER_VERSION_2_9 }} -> ${{ inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-9 }}
     runs-on: ubuntu-latest
     environment: upgrade-prime-staging
 


### PR DESCRIPTION
### Issue: N/A

### Description
Further isolating down, we were able to get `check-rancher-tag` working. So this PR is updating `workflow_call` in each of the workflows to be able to properly work.