### PR TITLE
Temporarily comment out cron job for check rancher tag

### DIFF
--- a/.github/workflows/check-rancher-tag.yaml
+++ b/.github/workflows/check-rancher-tag.yaml
@@ -2,8 +2,8 @@
 name: Check Rancher Tag
 
 on:
-  schedule:
-    - cron: "0 */4 * * 1-5"
+  # schedule:
+  #   - cron: "0 */4 * * 1-5"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
### Description
Now that we have the check rancher tag working, I am going to temporarily disable the cron job. Just until we can fix the caching issue so that once every 4 hours is up, it's not constantly running against every same tag.