### PR TITLE
Fix check rancher tag, recurring Qase ID and revoking runner IP

### DIFF
--- a/.github/actions/compare-rancher-tag/action.yaml
+++ b/.github/actions/compare-rancher-tag/action.yaml
@@ -2,11 +2,15 @@
 name: Compare Rancher tag
 description: "Compares the latest Rancher tag for specified release lines with cached values"
 inputs:
+  cached-tag-v212:
+    required: true
   cached-tag-v211:
     required: true
   cached-tag-v210:
     required: true
   cached-tag-v29:
+    required: true
+  latest-tag-v212:
     required: true
   latest-tag-v211:
     required: true
@@ -14,12 +18,25 @@ inputs:
     required: true
   latest-tag-v29:
     required: true
+outputs:
+  is_tag_new_v212:
+    value: ${{ steps.compare.outputs.is_tag_new_v212 }}
+  is_tag_new_v211:
+    value: ${{ steps.compare.outputs.is_tag_new_v211 }}
+  is_tag_new_v210:
+    value: ${{ steps.compare.outputs.is_tag_new_v210 }}
+  is_tag_new_v29:
+    value: ${{ steps.compare.outputs.is_tag_new_v29 }}
 runs:
   using: composite
   steps:
-    - run: |
-        for RELEASE_LINE in v211 v210 v29; do
-          if [[ "$RELEASE_LINE" = "v211" ]]; then
+    - id: compare
+      run: |
+        for RELEASE_LINE in v212 v211 v210 v29; do
+          if [[ "$RELEASE_LINE" = "v212" ]]; then
+            TAG_INPUT="${{ inputs.latest-tag-v212 }}"
+            CACHED_TAG="${{ inputs.cached-tag-v212 }}"
+          elif [[ "$RELEASE_LINE" = "v211" ]]; then
             TAG_INPUT="${{ inputs.latest-tag-v211 }}"
             CACHED_TAG="${{ inputs.cached-tag-v211 }}"
           elif [[ "$RELEASE_LINE" = "v210" ]]; then
@@ -35,10 +52,15 @@ runs:
 
           if [ "$CACHED_TAG" != "$TAG_INPUT" ]; then
             echo "New tag for $RELEASE_LINE: $TAG_INPUT"
-            echo "IS_TAG_NEW_$RELEASE_LINE=true" >> $GITHUB_ENV
+            eval "IS_TAG_NEW_$RELEASE_LINE=true"
           else
             echo "No new tag found yet for $RELEASE_LINE..."
-            echo "IS_TAG_NEW_$RELEASE_LINE=false" >> $GITHUB_ENV
+            eval "IS_TAG_NEW_$RELEASE_LINE=false"
           fi
         done
+
+        echo "is_tag_new_v212=$IS_TAG_NEW_v212" >> $GITHUB_OUTPUT
+        echo "is_tag_new_v211=$IS_TAG_NEW_v211" >> $GITHUB_OUTPUT
+        echo "is_tag_new_v210=$IS_TAG_NEW_v210" >> $GITHUB_OUTPUT
+        echo "is_tag_new_v29=$IS_TAG_NEW_v29" >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/actions/get-latest-rancher-tag/action.yaml
+++ b/.github/actions/get-latest-rancher-tag/action.yaml
@@ -8,47 +8,60 @@ inputs:
   prime_artifacts_path:
     description: "Path to prime artifacts"
     required: true
+outputs:
+  latest_tag_v212:
+    description: "Latest tag for v2.12"
+    value: ${{ steps.set-outputs.outputs.latest_tag_v212 }}
+  latest_tag_v211:
+    description: "Latest tag for v2.11"
+    value: ${{ steps.set-outputs.outputs.latest_tag_v211 }}
+  latest_tag_v210:
+    description: "Latest tag for v2.10"
+    value: ${{ steps.set-outputs.outputs.latest_tag_v210 }}
+  latest_tag_v29:
+    description: "Latest tag for v2.9"
+    value: ${{ steps.set-outputs.outputs.latest_tag_v29 }}
 runs:
   using: composite
   steps:
-    - run: |
+    - id: get-tags
+      run: |
         RELEASE_LINES="${{ inputs.release_lines }}"
         TAGS=$(curl -s https://api.github.com/repos/rancher/rancher/releases | jq -r '.[].tag_name')
 
         for RELEASE_LINE in $RELEASE_LINES; do
-          VERSION=$(echo "$TAGS" | grep "^$RELEASE_LINE" | sort -V)
-          LATEST=$(echo "$VERSION" | tail -n 1)
-          GA_RELEASE=$(echo "$VERSION" | grep -Ev -- '-(rc|alpha|hotfix)' | tail -n 1)
-
-          if [ "$(printf "$GA_RELEASE\n$LATEST" | sort -V | tail -n 1)" == "$LATEST" ]; then
-            LATEST_VERSION="$LATEST"
-          else
-            LATEST_VERSION="$GA_RELEASE"
-          fi
+          LATEST_VERSION=$(curl -s https://api.github.com/repos/rancher/rancher/releases | jq -r '.[].tag_name' | grep -E "^$RELEASE_LINE" | head -n 1)
 
           echo "Latest tag for $RELEASE_LINE: $LATEST_VERSION"
 
-          if [[ "$RELEASE_LINE" == "v2.11" ]]; then
+          if [[ "$RELEASE_LINE" == "v2.12" || "$RELEASE_LINE" == "v2.11" ]]; then
             RELEASE_JSON=$(curl -s "https://api.github.com/repos/rancher/rancher/releases/tags/$LATEST_VERSION")
             ASSET_COUNT=$(echo "$RELEASE_JSON" | jq '.assets | length')
 
             echo "Asset count for $LATEST_VERSION: $ASSET_COUNT"
 
-            if [ "$ASSET_COUNT" -ne 20 ]; then
-              echo "Asset count: $ASSET_COUNT. Expected 20 assets..."
+            if [ "$ASSET_COUNT" -lt 19 ]; then
+              echo "Asset count: $ASSET_COUNT. Expected at least 19 assets..."
               continue
             fi
           else
             RELEASE_JSON=$(curl -s ${{ inputs.prime_artifacts_path }}/$RELEASE_LINE/rancher-images.txt)
 
             if [[ $? -ne 0 ]]; then
-              echo "Unable to reach: ${{ inputs.prime_artifacts_path }}"
+              echo "Unable to reach: ${{ inputs.prime_artifacts_path }}/$RELEASE_LINE/rancher-images.txt"
               continue
             fi
           fi
 
           SUFFIX=$(echo "$RELEASE_LINE" | tr -d '.')
-          OUTPUT_NAME="LATEST_TAG_${SUFFIX}"
-          echo "$OUTPUT_NAME=$LATEST_VERSION" >> $GITHUB_ENV
+          eval "LATEST_TAG_${SUFFIX}=$LATEST_VERSION"
+          echo "LATEST_TAG_${SUFFIX}=$LATEST_VERSION" >> $GITHUB_ENV
         done
+      shell: bash
+    - id: set-outputs
+      run: |
+        echo "latest_tag_v212=$LATEST_TAG_v212" >> $GITHUB_OUTPUT
+        echo "latest_tag_v211=$LATEST_TAG_v211" >> $GITHUB_OUTPUT
+        echo "latest_tag_v210=$LATEST_TAG_v210" >> $GITHUB_OUTPUT
+        echo "latest_tag_v29=$LATEST_TAG_v29" >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/actions/revoke-runner-ip/action.yaml
+++ b/.github/actions/revoke-runner-ip/action.yaml
@@ -26,7 +26,7 @@ runs:
           local prefix_list_id=$1
           local cidr=$2
 
-          local max_retries=10
+          local max_retries=37
           local attempt=1
 
           while true; do

--- a/.github/workflows/airgap-test.yaml
+++ b/.github/workflows/airgap-test.yaml
@@ -6,6 +6,22 @@ on:
     inputs:
       rancher_version:
         description: "Rancher version"
+      rancher-version-2-12:
+        description: "Rancher version for v2.12.x"
+        required: true
+        default: "head"
+      rancher-version-2-11:
+        description: "Rancher version for v2.11.x"
+        required: true
+        default: "v2.11-head"
+      rancher-version-2-10:
+        description: "Rancher version for v2.10.x"
+        required: true
+        default: "v2.10-head"
+      rancher-version-2-9:
+        description: "Rancher version for v2.9.x"
+        required: true
+        default: "v2.9-head"
   workflow_call:
     inputs:
       rancher_version:
@@ -32,11 +48,11 @@ permissions:
   contents: read
 
 jobs:
-  v2-11:
+  v2-12:
     if: |
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11.')) && contains(inputs.rancher_version, '-alpha')
-    name: ${{ inputs.rancher_version || github.event.inputs.rancher_version }}
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.12.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.12.')) && contains(inputs.rancher_version, '-alpha')
+    name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-12 }}
     runs-on: ubuntu-latest
     environment: alpha
 
@@ -75,6 +91,12 @@ jobs:
 
       - name: Uniquify hostname prefix
         uses: ./.github/actions/uniquify-hostname
+
+      - name: Set Rancher version
+        uses: ./.github/actions/set-env-var
+        with:
+          key: RANCHER_VERSION
+          value: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-12 }}
 
       - name: Create config.yaml
         run: |
@@ -131,7 +153,171 @@ jobs:
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ github.event.inputs.rancher_version }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
+              repo: "${{ secrets.RANCHER_REPO }}"
+              rke2Version: "${{ vars.RKE2_VERSION_2_11 }}"
+            standaloneRegistry:
+              assetsPath: "${{ secrets.ASSETS_PATH }}"
+              registryName: "${{ secrets.REGISTRY_NAME }}"
+          terratest:
+            pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+          EOF
+
+      - name: Export CATTLE_TEST_CONFIG
+        run: echo "CATTLE_TEST_CONFIG=${{ github.workspace }}/config.yaml" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Set up Go environment
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "./go.mod"
+
+      - name: Build Packages
+        run: ./.github/scripts/build-packages.sh
+
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: ${{ vars.TERRAFORM_VERSION }}
+          terraform_wrapper: false
+
+      - name: Run Airgap Test Suite
+        uses: ./.github/actions/run-test-suite
+        with:
+          package: ${{ env.PACKAGE }}
+          path-to-repo: ${{ secrets.PATH_TO_REPO }}
+          suite: ${{ env.SUITE }}
+          timeout: ${{ env.SUITE_TIMEOUT }}
+
+      - name: Reporting Results to Qase
+        uses: ./.github/actions/report-to-qase
+        with:
+          qase-test-run-id: ${{ vars.QASE_RELEASE_TEST_RUN_ID_2_12 }}
+          qase-automation-token: ${{ secrets.QASE_TOKEN }}
+
+      - name: Reporting Results to Slack
+        uses: ./.github/actions/report-to-slack
+        with:
+          job-status: ${{ job.status }}
+          slack-channel: ${{ secrets.SLACK_CHANNEL }}
+          slack-token: ${{ secrets.SLACK_TOKEN }}
+
+      - name: Revoke Runner IP
+        if: always()
+        uses: ./.github/actions/revoke-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"
+  
+  v2-11:
+    if: |
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11.')) && contains(inputs.rancher_version, '-alpha')
+    name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-11 }}
+    runs-on: ubuntu-latest
+    environment: alpha
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.TFP_IAM_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Get AWS credentials from Secrets Manager
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            AWS_ACCESS_KEY, ${{ secrets.AWS_ACCESS_KEY_ID }}
+            AWS_SECRET_KEY, ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Whitelist Runner IP
+        uses: ./.github/actions/whitelist-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"
+
+      - name: Set up SSH Keys
+        uses: ./.github/actions/setup-ssh-keys
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ssh-private-key-name: ${{ secrets.SSH_PRIVATE_KEY_NAME }}
+          windows-ssh-private-key: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY }}
+          windows-ssh-private-key-name: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}
+
+      - name: Uniquify hostname prefix
+        uses: ./.github/actions/uniquify-hostname
+
+      - name: Set Rancher version
+        uses: ./.github/actions/set-env-var
+        with:
+          key: RANCHER_VERSION
+          value: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-11 }}
+
+      - name: Create config.yaml
+        run: |
+          cat > config.yaml <<EOF
+          rancher:
+            host: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
+            adminPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
+            insecure: true
+          terraform:
+            cni: "${{ secrets.CNI }}"
+            defaultClusterRoleForProjectMembers: "true"
+            enableNetworkPolicy: false
+            provider: "${{ vars.PROVIDER_AMAZON }}"
+            privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
+            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
+            windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
+            privateRegistries:
+              insecure: true
+            awsCredentials:
+              awsAccessKey: "$AWS_ACCESS_KEY"
+              awsSecretKey: "$AWS_SECRET_KEY"
+            awsConfig:
+              ami: "${{ secrets.AWS_AMI }}"
+              awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
+              awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              region: "${{ secrets.AWS_REGION }}"
+              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
+              awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+              awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+              awsVpcID: "${{ secrets.AWS_VPC_ID }}"
+              awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
+              awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
+              registryRootSize: ${{ vars.AWS_ROOT_SIZE_REGISTRY}}
+              awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
+              awsUser: "${{ secrets.AWS_USER }}"
+              sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
+              timeout: "${{ vars.TIMEOUT }}"
+              windowsAMI: "${{ secrets.WINDOWS_AMI }}"
+              windowsAWSUser: "${{ secrets.AWS_WINDOWS_USER }}" 
+              windowsAWSPassword: "${{ secrets.AWS_WINDOWS_PASSWORD }}"
+              windowsInstanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
+              windowsKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}"
+              ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
+              loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
+              targetType: "${{ vars.TARGET_TYPE }}"
+            standalone:
+              airgapInternalFQDN: "${{ env.HOSTNAME_PREFIX }}-internal.${{ secrets.AWS_ROUTE_53_ZONE }}"
+              bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
+              certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
+              osUser: "${{ secrets.OS_USER }}"
+              osGroup: "${{ secrets.OS_GROUP }}"
+              rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
+              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
+              rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
+              rancherImage: "${{ secrets.RANCHER_IMAGE }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_11 }}"
             standaloneRegistry:
@@ -194,7 +380,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.10.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.10.')) && contains(inputs.rancher_version, '-alpha')
-    name: ${{ inputs.rancher_version || github.event.inputs.rancher_version }}
+    name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-10 }}
     runs-on: ubuntu-latest
     needs: v2-11
     environment: staging-alpha
@@ -234,6 +420,12 @@ jobs:
 
       - name: Uniquify hostname prefix
         uses: ./.github/actions/uniquify-hostname
+      
+      - name: Set Rancher version
+        uses: ./.github/actions/set-env-var
+        with:
+          key: RANCHER_VERSION
+          value: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-10 }}
 
       - name: Create config.yaml
         run: |
@@ -290,7 +482,7 @@ jobs:
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ github.event.inputs.rancher_version }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_10 }}"
             standaloneRegistry:

--- a/.github/workflows/airgap-upgrade-test.yaml
+++ b/.github/workflows/airgap-upgrade-test.yaml
@@ -6,6 +6,22 @@ on:
     inputs:
       rancher_version:
         description: "Rancher version"
+      rancher-version-2-12:
+        description: "Rancher version for v2.12.x"
+        required: true
+        default: "head"
+      rancher-version-2-11:
+        description: "Rancher version for v2.11.x"
+        required: true
+        default: "v2.11-head"
+      rancher-version-2-10:
+        description: "Rancher version for v2.10.x"
+        required: true
+        default: "v2.10-head"
+      rancher-version-2-9:
+        description: "Rancher version for v2.9.x"
+        required: true
+        default: "v2.9-head"
   workflow_call:
     inputs:
       rancher_version:
@@ -32,11 +48,11 @@ permissions:
   contents: read
 
 jobs:
-  v2-11:
+  v2-12:
     if: |
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11.')) && contains(inputs.rancher_version, '-alpha')
-    name: ${{ vars.RELEASED_RANCHER_VERSION_2_11 }} -> ${{ inputs.rancher_version || github.event.inputs.rancher_version }}
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.12.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.12.')) && contains(inputs.rancher_version, '-alpha')
+    name: ${{ vars.RELEASED_RANCHER_VERSION_2_12 }} -> ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-12 }}
     runs-on: ubuntu-latest
     environment: alpha
 
@@ -75,6 +91,12 @@ jobs:
 
       - name: Uniquify hostname prefix
         uses: ./.github/actions/uniquify-hostname
+
+      - name: Set Rancher version
+        uses: ./.github/actions/set-env-var
+        with:
+          key: UPGRADED_RANCHER_VERSION
+          value: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-12 }}
 
       - name: Create config.yaml
         run: |
@@ -138,7 +160,176 @@ jobs:
               upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
               upgradedRancherRepo: "${{ secrets.UPGRADED_RANCHER_REPO }}"
               upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherTagVersion: "${{ github.event.inputs.rancher_version }}"
+              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
+            standaloneRegistry:
+              assetsPath: "${{ secrets.ASSETS_PATH }}"
+              registryName: "${{ secrets.REGISTRY_NAME }}"
+          terratest:
+            pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+          EOF
+
+      - name: Export CATTLE_TEST_CONFIG
+        run: echo "CATTLE_TEST_CONFIG=${{ github.workspace }}/config.yaml" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Set up Go environment
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "./go.mod"
+
+      - name: Build Packages
+        run: ./.github/scripts/build-packages.sh
+
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: ${{ vars.TERRAFORM_VERSION }}
+          terraform_wrapper: false
+
+      - name: Run Airgap Upgrade Test Suite
+        uses: ./.github/actions/run-test-suite
+        with:
+          package: ${{ env.PACKAGE }}
+          path-to-repo: ${{ secrets.PATH_TO_REPO }}
+          suite: ${{ env.SUITE }}
+          timeout: ${{ env.SUITE_TIMEOUT }}
+
+      - name: Reporting Results to Qase
+        uses: ./.github/actions/report-to-qase
+        with:
+          qase-test-run-id: ${{ vars.QASE_RELEASE_TEST_RUN_ID_2_12 }}
+          qase-automation-token: ${{ secrets.QASE_TOKEN }}
+
+      - name: Reporting Results to Slack
+        uses: ./.github/actions/report-to-slack
+        with:
+          job-status: ${{ job.status }}
+          slack-channel: ${{ secrets.SLACK_CHANNEL }}
+          slack-token: ${{ secrets.SLACK_TOKEN }}
+
+      - name: Revoke Runner IP
+        if: always()
+        uses: ./.github/actions/revoke-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"
+  
+  v2-11:
+    if: |
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11.')) && contains(inputs.rancher_version, '-alpha')
+    name: ${{ vars.RELEASED_RANCHER_VERSION_2_11 }} -> ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-11 }}
+    runs-on: ubuntu-latest
+    environment: alpha
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.TFP_IAM_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Get AWS credentials from Secrets Manager
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            AWS_ACCESS_KEY, ${{ secrets.AWS_ACCESS_KEY_ID }}
+            AWS_SECRET_KEY, ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Whitelist Runner IP
+        uses: ./.github/actions/whitelist-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"
+
+      - name: Set up SSH Keys
+        uses: ./.github/actions/setup-ssh-keys
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ssh-private-key-name: ${{ secrets.SSH_PRIVATE_KEY_NAME }}
+          windows-ssh-private-key: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY }}
+          windows-ssh-private-key-name: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}
+
+      - name: Uniquify hostname prefix
+        uses: ./.github/actions/uniquify-hostname
+
+      - name: Set Rancher version
+        uses: ./.github/actions/set-env-var
+        with:
+          key: UPGRADED_RANCHER_VERSION
+          value: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-11 }}
+
+      - name: Create config.yaml
+        run: |
+          cat > config.yaml <<EOF
+          rancher:
+            host: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
+            adminPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
+            insecure: true
+          terraform:
+            cni: "${{ secrets.CNI }}"
+            defaultClusterRoleForProjectMembers: "true"
+            enableNetworkPolicy: false
+            provider: "${{ vars.PROVIDER_AMAZON }}"
+            privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
+            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
+            windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
+            privateRegistries:
+              insecure: true
+            awsCredentials:
+              awsAccessKey: "$AWS_ACCESS_KEY"
+              awsSecretKey: "$AWS_SECRET_KEY"
+            awsConfig:
+              ami: "${{ secrets.AWS_AMI }}"
+              awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
+              awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              region: "${{ secrets.AWS_REGION }}"
+              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
+              awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+              awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+              awsVpcID: "${{ secrets.AWS_VPC_ID }}"
+              awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
+              awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
+              registryRootSize: ${{ vars.AWS_ROOT_SIZE_REGISTRY}}
+              awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
+              awsUser: "${{ secrets.AWS_USER }}"
+              sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
+              timeout: "${{ vars.TIMEOUT }}"
+              windowsAMI: "${{ secrets.WINDOWS_AMI }}"
+              windowsAWSUser: "${{ secrets.AWS_WINDOWS_USER }}" 
+              windowsAWSPassword: "${{ secrets.AWS_WINDOWS_PASSWORD }}"
+              windowsInstanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
+              windowsKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}"
+              ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
+              loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
+              targetType: "${{ vars.TARGET_TYPE }}"
+            standalone:
+              airgapInternalFQDN: "${{ env.HOSTNAME_PREFIX }}-internal.${{ secrets.AWS_ROUTE_53_ZONE }}"
+              bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
+              certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
+              osUser: "${{ secrets.OS_USER }}"
+              osGroup: "${{ secrets.OS_GROUP }}"
+              rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
+              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
+              rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
+              rancherImage: "${{ secrets.RANCHER_IMAGE }}"
+              rancherTagVersion: ${{ vars.RELEASED_RANCHER_VERSION_2_11 }}
+              repo: "${{ secrets.RANCHER_REPO }}"
+              rke2Version: "${{ vars.RKE2_VERSION_2_11 }}"
+              upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
+              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
+              upgradedRancherRepo: "${{ secrets.UPGRADED_RANCHER_REPO }}"
+              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
+              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
             standaloneRegistry:
               assetsPath: "${{ secrets.ASSETS_PATH }}"
               registryName: "${{ secrets.REGISTRY_NAME }}"
@@ -199,10 +390,9 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.10.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.10.')) && contains(inputs.rancher_version, '-alpha')
-    name: ${{ vars.RELEASED_RANCHER_VERSION_2_10 }} -> ${{ inputs.rancher_version || github.event.inputs.rancher_version }}
+    name: ${{ vars.RELEASED_RANCHER_VERSION_2_10 }} -> ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-10 }}
     runs-on: ubuntu-latest
-    needs: v2-11
-    environment: staging-alpha
+    environment: alpha
 
     steps:
       - name: Checkout repository
@@ -239,6 +429,12 @@ jobs:
 
       - name: Uniquify hostname prefix
         uses: ./.github/actions/uniquify-hostname
+
+      - name: Set Rancher version
+        uses: ./.github/actions/set-env-var
+        with:
+          key: UPGRADED_RANCHER_VERSION
+          value: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-10 }}
 
       - name: Create config.yaml
         run: |
@@ -302,7 +498,7 @@ jobs:
               upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
               upgradedRancherRepo: "${{ secrets.UPGRADED_RANCHER_REPO }}"
               upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherTagVersion: "${{ github.event.inputs.rancher_version }}"
+              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
             standaloneRegistry:
               assetsPath: "${{ secrets.ASSETS_PATH }}"
               registryName: "${{ secrets.REGISTRY_NAME }}"

--- a/.github/workflows/check-rancher-tag.yaml
+++ b/.github/workflows/check-rancher-tag.yaml
@@ -2,42 +2,44 @@
 name: Check Rancher Tag
 
 on:
-  # schedule:
-  #   - cron: "0 */4 * * 1-5"
+  schedule:
+    - cron: "0 */4 * * 1-5"
   workflow_dispatch:
 
 jobs:
   check-latest-tag:
     runs-on: ubuntu-latest
     outputs:
-      latest_tag_v211: ${{ env.LATEST_TAG_v211 }}
-      latest_tag_v210: ${{ env.LATEST_TAG_v210 }}
-      latest_tag_v29: ${{ env.LATEST_TAG_v29 }}
-      is_tag_new_v211: ${{ env.IS_TAG_NEW_v211 }}
-      is_tag_new_v210: ${{ env.IS_TAG_NEW_v210 }}
-      is_tag_new_v29: ${{ env.IS_TAG_NEW_v29 }}
+      latest_tag_v212: ${{ steps.get-latest-tag.outputs.latest_tag_v212 }}
+      latest_tag_v211: ${{ steps.get-latest-tag.outputs.latest_tag_v211 }}
+      latest_tag_v210: ${{ steps.get-latest-tag.outputs.latest_tag_v210 }}
+      latest_tag_v29: ${{ steps.get-latest-tag.outputs.latest_tag_v29 }}
+      is_tag_new_v212: ${{ steps.compare-rancher-tag.outputs.is_tag_new_v212 }}
+      is_tag_new_v211: ${{ steps.compare-rancher-tag.outputs.is_tag_new_v211 }}
+      is_tag_new_v210: ${{ steps.compare-rancher-tag.outputs.is_tag_new_v210 }}
+      is_tag_new_v29: ${{ steps.compare-rancher-tag.outputs.is_tag_new_v29 }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Cache prior Rancher tag
-        id: cache
+      - name: Restore Rancher tag cache
         uses: actions/cache@v4
         with:
           path: tag
-          key: rancher-tag
+          key: rancher-tag-cache
 
       - name: Get latest Rancher tag
         id: get-latest-tag
         uses: ./.github/actions/get-latest-rancher-tag
         with:
-          release_lines: "v2.11 v2.10 v2.9"
+          release_lines: "v2.12 v2.11 v2.10 v2.9"
           prime_artifacts_path: ${{ secrets.PRIME_ARTIFACTS_PATH }}
 
       - name: Read cached Rancher tags
         id: read-cached-tags
         run: |
+          echo "CACHED_TAG_v212=$(cat tag/tag_v212.txt 2>/dev/null || echo '')" >> $GITHUB_ENV
           echo "CACHED_TAG_v211=$(cat tag/tag_v211.txt 2>/dev/null || echo '')" >> $GITHUB_ENV
           echo "CACHED_TAG_v210=$(cat tag/tag_v210.txt 2>/dev/null || echo '')" >> $GITHUB_ENV
           echo "CACHED_TAG_v29=$(cat tag/tag_v29.txt 2>/dev/null || echo '')" >> $GITHUB_ENV
@@ -46,58 +48,48 @@ jobs:
         id: compare-rancher-tag
         uses: ./.github/actions/compare-rancher-tag
         with:
+          cached-tag-v212: ${{ env.CACHED_TAG_v212 }}
           cached-tag-v211: ${{ env.CACHED_TAG_v211 }}
           cached-tag-v210: ${{ env.CACHED_TAG_v210 }}
           cached-tag-v29: ${{ env.CACHED_TAG_v29 }}
-          latest-tag-v211: ${{ env.LATEST_TAG_v211 }}
-          latest-tag-v210: ${{ env.LATEST_TAG_v210 }}
-          latest-tag-v29: ${{ env.LATEST_TAG_v29 }}
+          latest-tag-v212: ${{ steps.get-latest-tag.outputs.latest_tag_v212 }}
+          latest-tag-v211: ${{ steps.get-latest-tag.outputs.latest_tag_v211 }}
+          latest-tag-v210: ${{ steps.get-latest-tag.outputs.latest_tag_v210 }}
+          latest-tag-v29: ${{ steps.get-latest-tag.outputs.latest_tag_v29 }}
 
-      - name: v2.11 - Write new tag to file
-        if: ${{ env.IS_TAG_NEW_v211 == 'true' }}
+      - name: v2.12 - Write latest tag to file
         run: |
           mkdir -p tag
-          echo "${{ env.LATEST_TAG_v211 }}" > tag/tag_v211.txt
+          echo "${{ steps.get-latest-tag.outputs.latest_tag_v212 }}" > tag/tag_v212.txt
 
-      - name: v2.11 - Cache updated Rancher tag
-        if: ${{ env.IS_TAG_NEW_v211 == 'true' }}
-        uses: actions/cache@v4
-        with:
-          path: tag/tag_v211.txt
-          key: rancher-tag-v211-${{ env.LATEST_TAG_v211 }}
-          restore-keys: |
-            rancher-tag-v211
-
-      - name: v2.10 - Write new tag to file
-        if: ${{ env.IS_TAG_NEW_v210 == 'true' }}
+      - name: v2.11 - Write latest tag to file
         run: |
           mkdir -p tag
-          echo "${{ env.LATEST_TAG_v210 }}" > tag/tag_v210.txt
+          echo "${{ steps.get-latest-tag.outputs.latest_tag_v211 }}" > tag/tag_v211.txt
 
-      - name: v2.10 - Cache updated Rancher tag
-        if: ${{ env.IS_TAG_NEW_v210 == 'true' }}
-        uses: actions/cache@v4
-        with:
-          path: tag/tag_v210.txt
-          key: rancher-tag-v210-${{ env.LATEST_TAG_v210 }}
-          restore-keys: |
-            rancher-tag-v210
-
-      - name: v2.9 - Write new tag to file
-        if: ${{ env.IS_TAG_NEW_v29 == 'true' }}
+      - name: v2.10 - Write latest tag to file
         run: |
           mkdir -p tag
-          echo "${{ env.LATEST_TAG_v29 }}" > tag/tag_v29.txt
+          echo "${{ steps.get-latest-tag.outputs.latest_tag_v210 }}" > tag/tag_v210.txt
 
-      - name: v2.9 - Cache updated Rancher tag
-        if: ${{ env.IS_TAG_NEW_v29 == 'true' }}
+      - name: v2.9 - Write latest tag to file
+        run: |
+          mkdir -p tag
+          echo "${{ steps.get-latest-tag.outputs.latest_tag_v29 }}" > tag/tag_v29.txt
+
+      - name: Save Rancher tag cache
         uses: actions/cache@v4
         with:
-          path: tag/tag_v29.txt
-          key: rancher-tag-v29-${{ env.LATEST_TAG_v29 }}
-          restore-keys: |
-            rancher-tag-v29
+          path: tag
+          key: rancher-tag-cache
 
+  trigger-tests-v212:
+    needs: check-latest-tag
+    if: ${{ needs.check-latest-tag.outputs.is_tag_new_v212 == 'true' }}
+    uses: ./.github/workflows/dispatch-workflows.yaml
+    with:
+      rancher_version: ${{ needs.check-latest-tag.outputs.latest_tag_v212 }}
+  
   trigger-tests-v211:
     needs: check-latest-tag
     if: ${{ needs.check-latest-tag.outputs.is_tag_new_v211 == 'true' }}

--- a/.github/workflows/proxy-arm64-test.yaml
+++ b/.github/workflows/proxy-arm64-test.yaml
@@ -159,7 +159,7 @@ jobs:
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ vars.RANCHER_VERSION_2_12_HEAD }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_12 }}"
             standaloneRegistry:
@@ -322,7 +322,7 @@ jobs:
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ vars.RANCHER_VERSION_2_11_HEAD }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_11 }}"
             standaloneRegistry:
@@ -486,7 +486,7 @@ jobs:
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
-              rancherTagVersion: "${{ vars.RANCHER_VERSION_2_10_HEAD }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_10 }}"
             standaloneRegistry:

--- a/.github/workflows/proxy-test.yaml
+++ b/.github/workflows/proxy-test.yaml
@@ -122,7 +122,7 @@ jobs:
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_12 }}"
-          qase_recurring_id: "${{ github.event.inputs.qase-test-run-id-2-12 }}"
+          qase_recurring_id: "${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_12 }}"
 
       - name: Create config.yaml
         run: |
@@ -176,7 +176,7 @@ jobs:
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ vars.RANCHER_VERSION_2_12_HEAD }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_12 }}"
             standaloneRegistry:
@@ -296,7 +296,7 @@ jobs:
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_11 }}"
-          qase_recurring_id: "${{ github.event.inputs.qase-test-run-id-2-11 }}"
+          qase_recurring_id: "${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_11 }}"
 
       - name: Create config.yaml
         run: |
@@ -350,7 +350,7 @@ jobs:
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ vars.RANCHER_VERSION_2_11_HEAD }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_11 }}"
             standaloneRegistry:
@@ -470,7 +470,7 @@ jobs:
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_10 }}"
-          qase_recurring_id: "${{ github.event.inputs.qase-test-run-id-2-10 }}"
+          qase_recurring_id: "${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_10 }}"
 
       - name: Create config.yaml
         run: |
@@ -525,7 +525,7 @@ jobs:
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
-              rancherTagVersion: "${{ vars.RANCHER_VERSION_2_10_HEAD }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_10 }}"
             standaloneRegistry:

--- a/.github/workflows/proxy-upgrade-arm64-test.yaml
+++ b/.github/workflows/proxy-upgrade-arm64-test.yaml
@@ -165,7 +165,7 @@ jobs:
               upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
               upgradedRancherRepo: "${{ secrets.UPGRADED_RANCHER_REPO }}"
               upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherTagVersion: "${{ vars.RANCHER_VERSION_2_12_HEAD }}"
+              upgradedRancherTagVersion: "${{ vars.UPGRADED_RANCHER_VERSION }}"
             standaloneRegistry:
               registryName: "${{ secrets.REGISTRY_NAME }}"
               registryPassword: "${{ secrets.REGISTRY_PASSWORD }}"
@@ -332,7 +332,7 @@ jobs:
               upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
               upgradedRancherRepo: "${{ secrets.UPGRADED_RANCHER_REPO }}"
               upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherTagVersion: "${{ vars.RANCHER_VERSION_2_11_HEAD }}"
+              upgradedRancherTagVersion: "${{ vars.UPGRADED_RANCHER_VERSION }}"
             standaloneRegistry:
               registryName: "${{ secrets.REGISTRY_NAME }}"
               registryPassword: "${{ secrets.REGISTRY_PASSWORD }}"
@@ -501,7 +501,7 @@ jobs:
               upgradedRancherRepo: "${{ secrets.UPGRADED_RANCHER_REPO }}"
               upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
               upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
-              upgradedRancherTagVersion: "${{ vars.RANCHER_VERSION_2_10_HEAD }}"
+              upgradedRancherTagVersion: "${{ vars.UPGRADED_RANCHER_VERSION }}"
             standaloneRegistry:
               registryName: "${{ secrets.REGISTRY_NAME }}"
               registryPassword: "${{ secrets.REGISTRY_PASSWORD }}"

--- a/.github/workflows/proxy-upgrade-test.yaml
+++ b/.github/workflows/proxy-upgrade-test.yaml
@@ -122,7 +122,7 @@ jobs:
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_12 }}"
-          qase_recurring_id: "${{ github.event.inputs.qase-test-run-id-2-12 }}"
+          qase_recurring_id: "${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_12 }}"
 
       - name: Create config.yaml
         run: |
@@ -182,7 +182,7 @@ jobs:
               upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
               upgradedRancherRepo: "${{ secrets.UPGRADED_RANCHER_REPO }}"
               upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherTagVersion: "${{ vars.RANCHER_VERSION_2_12_HEAD }}"
+              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
             standaloneRegistry:
               registryName: "${{ secrets.REGISTRY_NAME }}"
               registryPassword: "${{ secrets.REGISTRY_PASSWORD }}"
@@ -300,7 +300,7 @@ jobs:
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_11 }}"
-          qase_recurring_id: "${{ github.event.inputs.qase-test-run-id-2-11 }}"
+          qase_recurring_id: "${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_11 }}"
 
       - name: Create config.yaml
         run: |
@@ -360,7 +360,7 @@ jobs:
               upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
               upgradedRancherRepo: "${{ secrets.UPGRADED_RANCHER_REPO }}"
               upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherTagVersion: "${{ vars.RANCHER_VERSION_2_11_HEAD }}"
+              upgradedRancherTagVersion: "${{ vars.UPGRADED_RANCHER_VERSION }}"
             standaloneRegistry:
               registryName: "${{ secrets.REGISTRY_NAME }}"
               registryPassword: "${{ secrets.REGISTRY_PASSWORD }}"
@@ -478,7 +478,7 @@ jobs:
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_10 }}"
-          qase_recurring_id: "${{ github.event.inputs.qase-test-run-id-2-10 }}"
+          qase_recurring_id: "${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_10 }}"
 
       - name: Create config.yaml
         run: |
@@ -540,7 +540,7 @@ jobs:
               upgradedRancherRepo: "${{ secrets.UPGRADED_RANCHER_REPO }}"
               upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
               upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
-              upgradedRancherTagVersion: "${{ vars.RANCHER_VERSION_2_10_HEAD }}"
+              upgradedRancherTagVersion: "${{ vars.UPGRADED_RANCHER_VERSION }}"
             standaloneRegistry:
               registryName: "${{ secrets.REGISTRY_NAME }}"
               registryPassword: "${{ secrets.REGISTRY_PASSWORD }}"

--- a/.github/workflows/rancher2-recurring-test.yaml
+++ b/.github/workflows/rancher2-recurring-test.yaml
@@ -112,7 +112,7 @@ jobs:
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_12 }}"
-          qase_recurring_id: "${{ github.event.inputs.qase-test-run-id-2-12 }}"
+          qase_recurring_id: "${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_12 }}"
 
       - name: Create config.yaml
         run: |
@@ -168,7 +168,7 @@ jobs:
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ vars.RANCHER_VERSION_2_12_HEAD }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_12 }}${{ vars.RKE2_VERSION_SUFFIX }}"
           terratest:
@@ -282,7 +282,7 @@ jobs:
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_11 }}"
-          qase_recurring_id: "${{ github.event.inputs.qase-test-run-id-2-11 }}"
+          qase_recurring_id: "${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_11 }}"
 
       - name: Create config.yaml
         run: |
@@ -338,7 +338,7 @@ jobs:
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ vars.RANCHER_VERSION_2_11_HEAD }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_11 }}${{ vars.RKE2_VERSION_SUFFIX }}"
           terratest:
@@ -452,7 +452,7 @@ jobs:
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_10 }}"
-          qase_recurring_id: "${{ github.event.inputs.qase-test-run-id-2-10 }}"
+          qase_recurring_id: "${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_10 }}"
 
       - name: Create config.yaml
         run: |
@@ -509,7 +509,7 @@ jobs:
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
-              rancherTagVersion: "${{ vars.RANCHER_VERSION_2_10_HEAD }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_10 }}${{ vars.RKE2_VERSION_SUFFIX }}"
           terratest:

--- a/.github/workflows/registry-test.yaml
+++ b/.github/workflows/registry-test.yaml
@@ -6,6 +6,22 @@ on:
     inputs:
       rancher_version:
         description: "Rancher version"
+      rancher-version-2-12:
+        description: "Rancher version for v2.12.x"
+        required: true
+        default: "head"
+      rancher-version-2-11:
+        description: "Rancher version for v2.11.x"
+        required: true
+        default: "v2.11-head"
+      rancher-version-2-10:
+        description: "Rancher version for v2.10.x"
+        required: true
+        default: "v2.10-head"
+      rancher-version-2-9:
+        description: "Rancher version for v2.9.x"
+        required: true
+        default: "v2.9-head"
   workflow_call:
     inputs:
       rancher_version:
@@ -32,11 +48,11 @@ permissions:
   contents: read
 
 jobs:
-  v2-11:
+  v2-12:
     if: |
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11.')) && contains(inputs.rancher_version, '-alpha')
-    name: ${{ inputs.rancher_version || github.event.inputs.rancher_version }}
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.12.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.12.')) && contains(inputs.rancher_version, '-alpha')
+    name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-12 }}
     runs-on: ubuntu-latest
     environment: alpha
 
@@ -75,6 +91,12 @@ jobs:
 
       - name: Uniquify hostname prefix
         uses: ./.github/actions/uniquify-hostname
+
+      - name: Set Rancher version
+        uses: ./.github/actions/set-env-var
+        with:
+          key: RANCHER_VERSION
+          value: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-12 }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -138,7 +160,184 @@ jobs:
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ github.event.inputs.rancher_version }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
+              repo: "${{ secrets.RANCHER_REPO }}"
+              rke2Version: "${{ vars.RKE2_VERSION_2_11 }}${{ vars.RKE2_VERSION_SUFFIX }}"
+            standaloneRegistry:
+              assetsPath: "${{ secrets.ASSETS_PATH }}"
+              registryName: "${{ secrets.REGISTRY_NAME }}"
+              registryPassword: "${{ secrets.REGISTRY_PASSWORD }}"
+              registryUsername: "${{ secrets.REGISTRY_USERNAME }}"
+              ecrUsername: "${{ vars.ECR_USERNAME }}"
+              ecrPassword: "${{ steps.get-ecr-password.outputs.password }}"
+              ecrURI: "${{ secrets.ECR_URI }}"
+              ecrAMI: "${{ secrets.ECR_AMI }}"
+          terratest:
+            pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+          EOF
+
+      - name: Export CATTLE_TEST_CONFIG
+        run: echo "CATTLE_TEST_CONFIG=${{ github.workspace }}/config.yaml" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Set up Go environment
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "./go.mod"
+
+      - name: Build Packages
+        run: ./.github/scripts/build-packages.sh
+
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: "${{ vars.TERRAFORM_VERSION }}"
+          terraform_wrapper: false
+
+      - name: Run Registry Test Suite
+        uses: ./.github/actions/run-test-suite
+        with:
+          package: ${{ env.PACKAGE }}
+          path-to-repo: ${{ secrets.PATH_TO_REPO }}
+          suite: ${{ env.SUITE }}
+          timeout: ${{ env.SUITE_TIMEOUT }}
+
+      - name: Reporting Results to Qase
+        uses: ./.github/actions/report-to-qase
+        with:
+          qase-test-run-id: ${{ vars.QASE_RELEASE_TEST_RUN_ID_2_12 }}
+          qase-automation-token: ${{ secrets.QASE_TOKEN }}
+
+      - name: Reporting Results to Slack
+        uses: ./.github/actions/report-to-slack
+        with:
+          job-status: ${{ job.status }}
+          slack-channel: ${{ secrets.SLACK_CHANNEL }}
+          slack-token: ${{ secrets.SLACK_TOKEN }}
+
+      - name: Revoke Runner IP
+        if: always()
+        uses: ./.github/actions/revoke-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"
+  
+  v2-11:
+    if: |
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11.')) && contains(inputs.rancher_version, '-alpha')
+    name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-11 }}
+    runs-on: ubuntu-latest
+    environment: alpha
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.TFP_IAM_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Get AWS credentials from Secrets Manager
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            AWS_ACCESS_KEY, ${{ secrets.AWS_ACCESS_KEY_ID }}
+            AWS_SECRET_KEY, ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Whitelist Runner IP
+        uses: ./.github/actions/whitelist-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"
+
+      - name: Set up SSH Keys
+        uses: ./.github/actions/setup-ssh-keys
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ssh-private-key-name: ${{ secrets.SSH_PRIVATE_KEY_NAME }}
+          windows-ssh-private-key: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY }}
+          windows-ssh-private-key-name: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}
+
+      - name: Uniquify hostname prefix
+        uses: ./.github/actions/uniquify-hostname
+
+      - name: Set Rancher version
+        uses: ./.github/actions/set-env-var
+        with:
+          key: RANCHER_VERSION
+          value: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-11 }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: "${{ secrets.AWS_REGION }}"
+
+      - name: Retrieve and set ECR password
+        id: get-ecr-password
+        uses: ./.github/actions/get-ecr-password
+
+      - name: Create config.yaml
+        run: |
+          cat > config.yaml <<EOF
+          rancher:
+            host: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
+            adminPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
+            insecure: true
+          terraform:
+            cni: "${{ secrets.CNI }}"
+            defaultClusterRoleForProjectMembers: "true"
+            enableNetworkPolicy: false
+            provider: "${{ vars.PROVIDER_AMAZON }}"
+            privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
+            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
+            windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
+            privateRegistries:
+              authConfigSecretName: "${{ secrets.AUTH_CONFIG_SECRET_NAME }}"
+              insecure: true
+              password: "${{ secrets.REGISTRY_PASSWORD }}"
+              username: "${{ secrets.REGISTRY_USERNAME }}"
+            awsCredentials:
+              awsAccessKey: "$AWS_ACCESS_KEY"
+              awsSecretKey: "$AWS_SECRET_KEY"
+            awsConfig:
+              ami: "${{ secrets.AWS_AMI }}"
+              awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
+              awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              region: "${{ secrets.AWS_REGION }}"
+              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
+              awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+              awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+              awsVpcID: "${{ secrets.AWS_VPC_ID }}"
+              awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
+              awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
+              registryRootSize: ${{ vars.AWS_ROOT_SIZE_REGISTRY}}
+              awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
+              awsUser: "${{ secrets.AWS_USER }}"
+              sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
+              timeout: "${{ vars.TIMEOUT }}"
+              ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
+              loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
+              targetType: "${{ vars.TARGET_TYPE }}"
+            standalone:
+              bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
+              certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
+              osUser: "${{ secrets.OS_USER }}"
+              osGroup: "${{ secrets.OS_GROUP }}"
+              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
+              rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
+              rancherImage: "${{ secrets.RANCHER_IMAGE }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_11 }}${{ vars.RKE2_VERSION_SUFFIX }}"
             standaloneRegistry:
@@ -207,10 +406,9 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.10.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.10.')) && contains(inputs.rancher_version, '-alpha')
-    name: ${{ inputs.rancher_version || github.event.inputs.rancher_version }}
+    name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-10 }}
     runs-on: ubuntu-latest
-    needs: v2-11
-    environment: staging-alpha
+    environment: alpha
 
     steps:
       - name: Checkout repository
@@ -247,6 +445,12 @@ jobs:
 
       - name: Uniquify hostname prefix
         uses: ./.github/actions/uniquify-hostname
+
+      - name: Set Rancher version
+        uses: ./.github/actions/set-env-var
+        with:
+          key: RANCHER_VERSION
+          value: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-10 }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -310,8 +514,7 @@ jobs:
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
-              rancherTagVersion: "${{ github.event.inputs.rancher_version }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_10 }}${{ vars.RKE2_VERSION_SUFFIX }}"
             standaloneRegistry:

--- a/.github/workflows/sanity-arm64-test.yaml
+++ b/.github/workflows/sanity-arm64-test.yaml
@@ -157,7 +157,7 @@ jobs:
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ vars.RANCHER_VERSION_2_12_HEAD }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_12 }}${{ vars.RKE2_VERSION_SUFFIX }}"
           terratest:
@@ -314,7 +314,7 @@ jobs:
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ vars.RANCHER_VERSION_2_11_HEAD }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_11 }}${{ vars.RKE2_VERSION_SUFFIX }}"
           terratest:
@@ -472,7 +472,7 @@ jobs:
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
-              rancherTagVersion: "${{ vars.RANCHER_VERSION_2_10_HEAD }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_10 }}${{ vars.RKE2_VERSION_SUFFIX }}"
           terratest:
@@ -630,7 +630,7 @@ jobs:
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
-              rancherTagVersion: "${{ vars.RANCHER_VERSION_2_9_HEAD }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_9 }}${{ vars.RKE2_VERSION_SUFFIX }}"
           terratest:

--- a/.github/workflows/sanity-test.yaml
+++ b/.github/workflows/sanity-test.yaml
@@ -123,7 +123,7 @@ jobs:
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: ${{ vars.QASE_RELEASE_TEST_RUN_ID_2_12 }}
-          qase_recurring_id: ${{ github.event.inputs.qase-test-run-id-2-12 }}
+          qase_recurring_id: ${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_12 }}
 
       - name: Create config.yaml
         run: |
@@ -175,7 +175,7 @@ jobs:
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ vars.RANCHER_VERSION_2_12_HEAD }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_12 }}${{ vars.RKE2_VERSION_SUFFIX }}"
           terratest:
@@ -291,7 +291,7 @@ jobs:
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_11 }}"
-          qase_recurring_id: "${{ github.event.inputs.qase-test-run-id-2-11 }}"
+          qase_recurring_id: "${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_11 }}"
 
       - name: Create config.yaml
         run: |
@@ -343,7 +343,7 @@ jobs:
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ vars.RANCHER_VERSION_2_11_HEAD }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_11 }}${{ vars.RKE2_VERSION_SUFFIX }}"
           terratest:
@@ -459,7 +459,7 @@ jobs:
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_10 }}"
-          qase_recurring_id: "${{ github.event.inputs.qase-test-run-id-2-10 }}"
+          qase_recurring_id: "${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_10 }}"
 
       - name: Create config.yaml
         run: |
@@ -512,7 +512,7 @@ jobs:
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
-              rancherTagVersion: "${{ vars.RANCHER_VERSION_2_10_HEAD }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_10 }}${{ vars.RKE2_VERSION_SUFFIX }}"
           terratest:
@@ -628,7 +628,7 @@ jobs:
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_9 }}"
-          qase_recurring_id: "${{ github.event.inputs.qase-test-run-id-2-9 }}"
+          qase_recurring_id: "${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_9 }}"
 
       - name: Create config.yaml
         run: |
@@ -681,7 +681,7 @@ jobs:
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
-              rancherTagVersion: "${{ vars.RANCHER_VERSION_2_9_HEAD }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_9 }}${{ vars.RKE2_VERSION_SUFFIX }}"
           terratest:

--- a/.github/workflows/sanity-upgrade-arm64-test.yaml
+++ b/.github/workflows/sanity-upgrade-arm64-test.yaml
@@ -163,7 +163,7 @@ jobs:
               upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL}}"
               upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
               upgradedRancherRepo: "${{ secrets.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ vars.RANCHER_VERSION_2_12_HEAD}}"
+              upgradedRancherTagVersion: "${{ vars.UPGRADED_RANCHER_VERSION}}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             nodeCount: ${{ vars.NODE_COUNT }}
@@ -324,7 +324,7 @@ jobs:
               upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL}}"
               upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
               upgradedRancherRepo: "${{ secrets.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ vars.RANCHER_VERSION_2_11_HEAD }}"
+              upgradedRancherTagVersion: "${{ vars.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             nodeCount: ${{ vars.NODE_COUNT }}
@@ -487,7 +487,7 @@ jobs:
               upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL}}"
               upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
               upgradedRancherRepo: "${{ secrets.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ vars.RANCHER_VERSION_2_10_HEAD }}"
+              upgradedRancherTagVersion: "${{ vars.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             nodeCount: ${{ vars.NODE_COUNT }}
@@ -650,7 +650,7 @@ jobs:
               upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL}}"
               upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
               upgradedRancherRepo: "${{ secrets.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ vars.RANCHER_VERSION_2_9_HEAD }}"
+              upgradedRancherTagVersion: "${{ vars.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             nodeCount: ${{ vars.NODE_COUNT }}

--- a/.github/workflows/sanity-upgrade-test.yaml
+++ b/.github/workflows/sanity-upgrade-test.yaml
@@ -122,7 +122,7 @@ jobs:
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_12 }}"
-          qase_recurring_id: "${{ github.event.inputs.qase-test-run-id-2-12 }}"
+          qase_recurring_id: "${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_12 }}"
 
       - name: Create config.yaml
         run: |
@@ -180,7 +180,7 @@ jobs:
               upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL}}"
               upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
               upgradedRancherRepo: "${{ secrets.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ vars.RANCHER_VERSION_2_12_HEAD}}"
+              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             nodeCount: ${{ vars.NODE_COUNT }}
@@ -294,7 +294,7 @@ jobs:
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_11 }}"
-          qase_recurring_id: "${{ github.event.inputs.qase-test-run-id-2-11 }}"
+          qase_recurring_id: "${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_11 }}"
 
       - name: Create config.yaml
         run: |
@@ -352,7 +352,7 @@ jobs:
               upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL}}"
               upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
               upgradedRancherRepo: "${{ secrets.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ vars.RANCHER_VERSION_2_11_HEAD }}"
+              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             nodeCount: ${{ vars.NODE_COUNT }}
@@ -466,7 +466,7 @@ jobs:
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_10 }}"
-          qase_recurring_id: "${{ github.event.inputs.qase-test-run-id-2-10 }}"
+          qase_recurring_id: "${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_10 }}"
 
       - name: Create config.yaml
         run: |
@@ -526,7 +526,7 @@ jobs:
               upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL}}"
               upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
               upgradedRancherRepo: "${{ secrets.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ vars.RANCHER_VERSION_2_10_HEAD }}"
+              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             nodeCount: ${{ vars.NODE_COUNT }}
@@ -640,7 +640,7 @@ jobs:
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_9 }}"
-          qase_recurring_id: "${{ github.event.inputs.qase-test-run-id-2-9 }}"
+          qase_recurring_id: "${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_9 }}"
 
       - name: Create config.yaml
         run: |
@@ -700,7 +700,7 @@ jobs:
               upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL}}"
               upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
               upgradedRancherRepo: "${{ secrets.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ vars.RANCHER_VERSION_2_9_HEAD }}"
+              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             nodeCount: ${{ vars.NODE_COUNT }}


### PR DESCRIPTION
### Issue: N/A

### Description
This PR addresses the following:
- When running check rancher tag subsequent times, update the cache to the latest version every time. This way, it truly knows when there is a new tag or not
- The recurring Qase ID is broken because it is not covering the scheduled use-case
- Revoking runner IPs needs to have the updated retry amount that we see when whitelisting IPs