### PR TITLE
Enhance Qase reporter to implement retry logic

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,29 +1,27 @@
 linters:
   disable-all: true
   enable:
-  - goimports
-  - govet
-  - misspell
-  - revive
-  - goconst
-  - forbidigo
-  - predeclared
+    - goimports
+    - govet
+    - misspell
+    - revive
+    - goconst
+    - forbidigo
+    - predeclared
 linters-settings:
   revive:
     rules:
-    - name: confusing-naming
-      disabled: true
-    - name: exported
-      disabled: false
-  goconst: 
+      - name: confusing-naming
+        disabled: true
+      - name: exported
+        disabled: false
+  goconst:
     min-len: 2
     min-occurrences: 10
     match-constant: true
     ignore-strings: "metadata.+"
   forbidigo:
     forbid:
-      - p: ^*\.Sleep.*$
-        msg: "No sleeps please use the appropriate polls and watch"
       - p: ^fmt\.Print.*$
         msg: "No format prints, please testing or logrus packages"
 run:


### PR DESCRIPTION
In recent testing, there have been numerous occurrences of status code 429 -- to many requests, being hit from Qase API.  

As a result, the reporter fails to publish results to Qase, and the remote VMs are torn down (which hold the test results).

This PR aims to make this more robust by implementing retry logic, in the event status code 429 is encountered when reporting test results to Qase.