### PR TITLE
Add rancher2 recurring to dispatch workflow

### DIFF
--- a/.github/workflows/dispatch-workflows.yaml
+++ b/.github/workflows/dispatch-workflows.yaml
@@ -21,6 +21,7 @@ jobs:
           - registry-test.yaml
           - airgap-test.yaml
           - airgap-upgrade-test.yaml
+          - rancher2-recurring-test.yaml
 
     steps:
       - name: Trigger test workflow ${{ matrix.workflow }}


### PR DESCRIPTION
### Issue: N/A

### Description
With the latest `check-rancher-tag` run, it was noted that `rancher2-recurring.yaml` did not run. It is not part of the current dispatch workflow list; this was an oversight. This PR simply adds it in when it should've been all along.