### PR TITLE
Remove continue and replace with empty LATEST_VERSION

### DIFF
--- a/.github/actions/get-latest-rancher-tag/action.yaml
+++ b/.github/actions/get-latest-rancher-tag/action.yaml
@@ -42,14 +42,14 @@ runs:
 
             if [ "$ASSET_COUNT" -lt 19 ]; then
               echo "Asset count: $ASSET_COUNT. Expected at least 19 assets..."
-              continue
+              LATEST_VERSION=""
             fi
           else
             RELEASE_JSON=$(curl -s ${{ inputs.prime_artifacts_path }}/$RELEASE_LINE/rancher-images.txt)
 
             if [[ $? -ne 0 ]]; then
               echo "Unable to reach: ${{ inputs.prime_artifacts_path }}/$RELEASE_LINE/rancher-images.txt"
-              continue
+              LATEST_VERSION=""
             fi
           fi
 


### PR DESCRIPTION
### Issue: N/A

### Description
There is an issue with check-rancher-tag where if the assets are not correct, then it will skip over the release line. This is an issue because we need to make sure the cached value is constantly updating. It does not do so in this scenario.