### PR TITLE
Dynamically get upgraded K8s version for import test

### DIFF
--- a/.github/workflows/rancher2-recurring-test.yaml
+++ b/.github/workflows/rancher2-recurring-test.yaml
@@ -131,9 +131,6 @@ jobs:
             host: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
             adminPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
             insecure: true
-          upgradeInput:
-            clusters:
-              -  versionToUpgrade: ${{ vars.RKE2_VERSION_2_12 }}
           terraform:
             cni: "${{ secrets.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
@@ -318,9 +315,6 @@ jobs:
             host: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
             adminPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
             insecure: true
-          upgradeInput:
-            clusters:
-              -  versionToUpgrade: ${{ vars.RKE2_VERSION_2_11 }}
           terraform:
             cni: "${{ secrets.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
@@ -505,9 +499,6 @@ jobs:
             host: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
             adminPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
             insecure: true
-          upgradeInput:
-            clusters:
-              -  versionToUpgrade: ${{ vars.RKE2_VERSION_2_10 }}
           terraform:
             cni: "${{ secrets.CNI }}"
             defaultClusterRoleForProjectMembers: "true"

--- a/tests/rancher2/provisioning/README.md
+++ b/tests/rancher2/provisioning/README.md
@@ -100,10 +100,6 @@ rancher:
   adminToken: ""
   cleanup: true
 
-upgradeInput:
-  clusters:
-    -  versionToUpgrade: ""         # Leave off the suffix; the test will add it for K3s and RKE2
-
 terraform:
   cni: ""
   defaultClusterRoleForProjectMembers: "true"


### PR DESCRIPTION
### Issue: N/A

### Description:
Currently, the imported tests need you to have to specify the K8s version to upgrade to. This is a huge pain as it should just fetch the latest available version in Rancher UI. That way, we only need to specify the version when initially creating the standalone cluster to import into Rancher.