### PR TITLE
Update v2.11 release to prime only release

### DIFF
--- a/.github/actions/get-latest-rancher-tag/action.yaml
+++ b/.github/actions/get-latest-rancher-tag/action.yaml
@@ -34,7 +34,7 @@ runs:
 
           echo "Latest tag for $RELEASE_LINE: $LATEST_VERSION"
 
-          if [[ "$RELEASE_LINE" == "v2.12" || "$RELEASE_LINE" == "v2.11" ]]; then
+          if [[ "$RELEASE_LINE" == "v2.12" ]]; then
             RELEASE_JSON=$(curl -s "https://api.github.com/repos/rancher/rancher/releases/tags/$LATEST_VERSION")
             ASSET_COUNT=$(echo "$RELEASE_JSON" | jq '.assets | length')
 


### PR DESCRIPTION
### Issue: N/A

### Description
Now that we are release testing v2.12, v2.11 is now officially considered a prime only release. As such, we need to do a small maintenance update to account for that.