### PR TITLE
Update GHA workflow environments + check rancher tag scheduling

### DIFF
--- a/.github/workflows/airgap-test.yaml
+++ b/.github/workflows/airgap-test.yaml
@@ -8,20 +8,13 @@ on:
         description: "Rancher version"
       rancher-version-2-12:
         description: "Rancher version for v2.12.x"
-        required: true
-        default: "head"
+        default: "v2.12.0"
       rancher-version-2-11:
         description: "Rancher version for v2.11.x"
-        required: true
-        default: "v2.11-head"
+        default: "v2.11.3"
       rancher-version-2-10:
         description: "Rancher version for v2.10.x"
-        required: true
-        default: "v2.10-head"
-      rancher-version-2-9:
-        description: "Rancher version for v2.9.x"
-        required: true
-        default: "v2.9-head"
+        default: "v2.10.7"
   workflow_call:
     inputs:
       rancher_version:
@@ -233,7 +226,7 @@ jobs:
     name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-11 }}
     runs-on: ubuntu-latest
     needs: v2-12
-    environment: alpha
+    environment: staging-alpha
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_11 }}"
 

--- a/.github/workflows/airgap-upgrade-test.yaml
+++ b/.github/workflows/airgap-upgrade-test.yaml
@@ -9,19 +9,15 @@ on:
       rancher-version-2-12:
         description: "Rancher version for v2.12.x"
         required: true
-        default: "head"
+        default: "v2.12.0"
       rancher-version-2-11:
         description: "Rancher version for v2.11.x"
         required: true
-        default: "v2.11-head"
+        default: "v2.11.3"
       rancher-version-2-10:
         description: "Rancher version for v2.10.x"
         required: true
-        default: "v2.10-head"
-      rancher-version-2-9:
-        description: "Rancher version for v2.9.x"
-        required: true
-        default: "v2.9-head"
+        default: "v2.10.7"
   workflow_call:
     inputs:
       rancher_version:
@@ -238,7 +234,7 @@ jobs:
     name: ${{ vars.RELEASED_RANCHER_VERSION_2_11 }} -> ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-11 }}
     runs-on: ubuntu-latest
     needs: v2-12
-    environment: alpha
+    environment: upgrade-prime-staging
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_11 }}"
 
@@ -423,7 +419,7 @@ jobs:
     name: ${{ vars.RELEASED_RANCHER_VERSION_2_10 }} -> ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-10 }}
     runs-on: ubuntu-latest
     needs: v2-11
-    environment: alpha
+    environment: upgrade-prime-staging
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_10 }}"
 

--- a/.github/workflows/check-rancher-tag.yaml
+++ b/.github/workflows/check-rancher-tag.yaml
@@ -3,7 +3,8 @@ name: Check Rancher Tag
 
 on:
   schedule:
-    - cron: "0 */4 * * 1-5"
+    - cron: "0 16,20 * * 1-5"
+    - cron: "0 0 * * 2-6"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/proxy-arm64-test.yaml
+++ b/.github/workflows/proxy-arm64-test.yaml
@@ -10,36 +10,25 @@ on:
         description: "Rancher tag version provided from check-rancher-tag workflow"
       rancher-version-2-12:
         description: "Rancher version for v2.12.x"
-        required: true
         default: "head"
       rancher-version-2-11:
         description: "Rancher version for v2.11.x"
-        required: true
         default: "v2.11-head"
       rancher-version-2-10:
         description: "Rancher version for v2.10.x"
-        required: true
         default: "v2.10-head"
       rancher-version-2-9:
         description: "Rancher version for v2.9.x"
-        required: true
         default: "v2.9-head"
       qase-test-run-id-2-12:
         description: "Qase Test Run ID for v2.12.x"
-        required: true
         default: "4512"
       qase-test-run-id-2-11:
         description: "Qase Test Run ID for v2.11.x"
-        required: true
         default: "4541"
       qase-test-run-id-2-10:
         description: "Qase Test Run ID for v2.10.x"
-        required: true
         default: "4542"
-      qase-test-run-id-2-9:
-        description: "Qase Test Run ID for v2.9.x"
-        required: true
-        default: "4540"
 
 permissions:
   id-token: write
@@ -240,7 +229,7 @@ jobs:
     if: ${{ github.event_name == 'schedule' }}
     name: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-11 }}
     runs-on: ubuntu-latest
-    environment: latest
+    environment: staging-alpha
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_11 }}"
 
@@ -418,7 +407,7 @@ jobs:
     if: ${{ github.event_name == 'schedule' }}
     name: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-10 }}
     runs-on: ubuntu-latest
-    environment: staging-latest
+    environment: staging-alpha
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_10 }}"
 

--- a/.github/workflows/proxy-test.yaml
+++ b/.github/workflows/proxy-test.yaml
@@ -10,36 +10,25 @@ on:
         description: "Rancher tag version provided from check-rancher-tag workflow"
       rancher-version-2-12:
         description: "Rancher version for v2.12.x"
-        required: true
         default: "head"
       rancher-version-2-11:
         description: "Rancher version for v2.11.x"
-        required: true
         default: "v2.11-head"
       rancher-version-2-10:
         description: "Rancher version for v2.10.x"
-        required: true
         default: "v2.10-head"
       rancher-version-2-9:
         description: "Rancher version for v2.9.x"
-        required: true
         default: "v2.9-head"
       qase-test-run-id-2-12:
         description: "Qase Test Run ID for v2.12.x"
-        required: true
         default: "4512"
       qase-test-run-id-2-11:
         description: "Qase Test Run ID for v2.11.x"
-        required: true
         default: "4541"
       qase-test-run-id-2-10:
         description: "Qase Test Run ID for v2.10.x"
-        required: true
         default: "4542"
-      qase-test-run-id-2-9:
-        description: "Qase Test Run ID for v2.9.x"
-        required: true
-        default: "4540"
   workflow_call:
     inputs:
       rancher_version:
@@ -260,7 +249,7 @@ jobs:
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-11 }}
     runs-on: ubuntu-latest
-    environment: latest
+    environment: staging-alpha
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_11 }}"
 
@@ -449,7 +438,7 @@ jobs:
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.10.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-12 }}
     runs-on: ubuntu-latest
-    environment: staging-latest
+    environment: staging-alpha
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_10 }}"
 

--- a/.github/workflows/proxy-upgrade-arm64-test.yaml
+++ b/.github/workflows/proxy-upgrade-arm64-test.yaml
@@ -10,36 +10,25 @@ on:
         description: "Rancher tag version provided from check-rancher-tag workflow"
       upgraded-rancher-version-2-12:
         description: "Upgraded Rancher version for v2.12.x"
-        required: true
         default: "head"
       upgraded-rancher-version-2-11:
         description: "Upgraded Rancher version for v2.11.x"
-        required: true
         default: "v2.11-head"
       upgraded-rancher-version-2-10:
         description: "Upgraded Rancher version for v2.10.x"
-        required: true
         default: "v2.10-head"
       upgraded-rancher-version-2-9:
         description: "Upgraded Rancher version for v2.9.x"
-        required: true
         default: "v2.9-head"
       qase-test-run-id-2-12:
         description: "Qase Test Run ID for v2.12.x"
-        required: true
         default: "4512"
       qase-test-run-id-2-11:
         description: "Qase Test Run ID for v2.11.x"
-        required: true
         default: "4541"
       qase-test-run-id-2-10:
         description: "Qase Test Run ID for v2.10.x"
-        required: true
         default: "4542"
-      qase-test-run-id-2-9:
-        description: "Qase Test Run ID for v2.9.x"
-        required: true
-        default: "4540"
 
 permissions:
   id-token: write
@@ -244,7 +233,7 @@ jobs:
     if: ${{ github.event_name == 'schedule' }}
     name: ${{ vars.RELEASED_RANCHER_VERSION_2_11 }} -> ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-11 }}
     runs-on: ubuntu-latest
-    environment: latest
+    environment: upgrade-prime-staging
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_11 }}"
 

--- a/.github/workflows/proxy-upgrade-test.yaml
+++ b/.github/workflows/proxy-upgrade-test.yaml
@@ -10,36 +10,25 @@ on:
         description: "Rancher tag version provided from check-rancher-tag workflow"
       upgraded-rancher-version-2-12:
         description: "Upgraded Rancher version for v2.12.x"
-        required: true
         default: "head"
       upgraded-rancher-version-2-11:
         description: "Upgraded Rancher version for v2.11.x"
-        required: true
         default: "v2.11-head"
       upgraded-rancher-version-2-10:
         description: "Upgraded Rancher version for v2.10.x"
-        required: true
         default: "v2.10-head"
       upgraded-rancher-version-2-9:
         description: "Upgraded Rancher version for v2.9.x"
-        required: true
         default: "v2.9-head"
       qase-test-run-id-2-12:
         description: "Qase Test Run ID for v2.12.x"
-        required: true
         default: "4512"
       qase-test-run-id-2-11:
         description: "Qase Test Run ID for v2.11.x"
-        required: true
         default: "4541"
       qase-test-run-id-2-10:
         description: "Qase Test Run ID for v2.10.x"
-        required: true
         default: "4542"
-      qase-test-run-id-2-9:
-        description: "Qase Test Run ID for v2.9.x"
-        required: true
-        default: "4540"
   workflow_call:
     inputs:
       rancher_version:
@@ -264,7 +253,7 @@ jobs:
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ vars.RELEASED_RANCHER_VERSION_2_11 }} -> ${{ inputs.rancher_version || github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
-    environment: latest
+    environment: upgrade-prime-staging
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_11 }}"
 

--- a/.github/workflows/rancher2-recurring-test.yaml
+++ b/.github/workflows/rancher2-recurring-test.yaml
@@ -10,36 +10,25 @@ on:
         description: "Rancher tag version provided from check-rancher-tag workflow"
       rancher-version-2-12:
         description: "Rancher version for v2.12-head"
-        required: true
         default: "head"
       rancher-version-2-11:
         description: "Rancher version for v2.11-head"
-        required: true
         default: "v2.11-head"
       rancher-version-2-10:
         description: "Rancher version for v2.10-head"
-        required: true
         default: "v2.10-head"
       rancher-version-2-9:
         description: "Rancher version for v2.9-head"
-        required: true
         default: "v2.9-head"
       qase-test-run-id-2-12:
         description: "Qase Test Run ID for v2.12-head"
-        required: true
         default: "4512"
       qase-test-run-id-2-11:
         description: "Qase Test Run ID for v2.11-head"
-        required: true
         default: "4541"
       qase-test-run-id-2-10:
         description: "Qase Test Run ID for v2.10-head"
-        required: true
         default: "4542"
-      qase-test-run-id-2-9:
-        description: "Qase Test Run ID for v2.9-head"
-        required: true
-        default: "4540"
   workflow_call:
     inputs:
       rancher_version:
@@ -255,7 +244,7 @@ jobs:
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11.'))
     name: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-11 }}
     runs-on: ubuntu-latest
-    environment: latest
+    environment: staging-alpha
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_11 }}"
 
@@ -440,7 +429,7 @@ jobs:
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.10.'))
     name: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-10 }}
     runs-on: ubuntu-latest
-    environment: staging-latest
+    environment: staging-alpha
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_10 }}"
 

--- a/.github/workflows/registry-test.yaml
+++ b/.github/workflows/registry-test.yaml
@@ -238,7 +238,8 @@ jobs:
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-11 }}
     runs-on: ubuntu-latest
-    environment: alpha
+    needs: v2-12
+    environment: staging-alpha
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_11 }}"
 
@@ -423,7 +424,8 @@ jobs:
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.10.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-10 }}
     runs-on: ubuntu-latest
-    environment: alpha
+    needs: v2-11
+    environment: staging-alpha
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_10 }}"
 

--- a/.github/workflows/sanity-arm64-test.yaml
+++ b/.github/workflows/sanity-arm64-test.yaml
@@ -10,35 +10,27 @@ on:
         description: "Rancher tag version provided from check-rancher-tag workflow"
       rancher-version-2-12:
         description: "Rancher version for v2.12.x"
-        required: true
         default: "head"
       rancher-version-2-11:
         description: "Rancher version for v2.11.x"
-        required: true
         default: "v2.11.2"
       rancher-version-2-10:
         description: "Rancher version for v2.10.x"
-        required: true
         default: "v2.10.6"
       rancher-version-2-9:
         description: "Rancher version for v2.9.x"
-        required: true
         default: "v2.9.10"
       qase-test-run-id-2-12:
         description: "Qase Test Run ID for v2.12.x"
-        required: true
         default: "4512"
       qase-test-run-id-2-11:
         description: "Qase Test Run ID for v2.11.x"
-        required: true
         default: "4541"
       qase-test-run-id-2-10:
         description: "Qase Test Run ID for v2.10.x"
-        required: true
         default: "4542"
       qase-test-run-id-2-9:
         description: "Qase Test Run ID for v2.9.x"
-        required: true
         default: "4540"
 
 permissions:
@@ -234,7 +226,7 @@ jobs:
     if: ${{ github.event_name == 'schedule' }}
     name: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-11 }}
     runs-on: ubuntu-latest
-    environment: latest
+    environment: staging-alpha
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_11 }}"
 
@@ -406,7 +398,7 @@ jobs:
     if: ${{ github.event_name == 'schedule' }}
     name: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-10 }}
     runs-on: ubuntu-latest
-    environment: staging-latest
+    environment: staging-alpha
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_10 }}"
 
@@ -579,7 +571,7 @@ jobs:
     if: ${{ github.event_name == 'schedule' }}
     name: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-9 }}
     runs-on: ubuntu-latest
-    environment: staging-latest
+    environment: staging-alpha
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_10 }}"
 

--- a/.github/workflows/sanity-test.yaml
+++ b/.github/workflows/sanity-test.yaml
@@ -8,38 +8,29 @@ on:
     inputs:
       rancher_version:
         description: "Rancher tag version provided from check-rancher-tag workflow"
-        required: true
       rancher-version-2-12:
         description: "Rancher version for v2.12.x"
-        required: true
         default: "head"
       rancher-version-2-11:
         description: "Rancher version for v2.11.x"
-        required: true
         default: "v2.11.2"
       rancher-version-2-10:
         description: "Rancher version for v2.10.x"
-        required: true
         default: "v2.10.6"
       rancher-version-2-9:
         description: "Rancher version for v2.9.x"
-        required: true
         default: "v2.9.10"
       qase-test-run-id-2-12:
         description: "Qase Test Run ID for v2.12.x"
-        required: true
         default: "4512"
       qase-test-run-id-2-11:
         description: "Qase Test Run ID for v2.11.x"
-        required: true
         default: "4541"
       qase-test-run-id-2-10:
         description: "Qase Test Run ID for v2.10.x"
-        required: true
         default: "4542"
       qase-test-run-id-2-9:
         description: "Qase Test Run ID for v2.9.x"
-        required: true
         default: "4540"
   workflow_call:
     inputs:
@@ -255,7 +246,7 @@ jobs:
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11.'))
     name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-11 }}
     runs-on: ubuntu-latest
-    environment: latest
+    environment: staging-latest
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_11 }}"
 

--- a/.github/workflows/sanity-upgrade-arm64-test.yaml
+++ b/.github/workflows/sanity-upgrade-arm64-test.yaml
@@ -10,35 +10,27 @@ on:
         description: "Rancher tag version provided from check-rancher-tag workflow"
       upgraded-rancher-version-2-12:
         description: "Upgraded Rancher version for v2.12.x"
-        required: true
         default: "head"
       upgraded-rancher-version-2-11:
         description: "Upgraded Rancher version for v2.11.x"
-        required: true
         default: "v2.11-head"
       upgraded-rancher-version-2-10:
         description: "Upgraded Rancher version for v2.10.x"
-        required: true
         default: "v2.10-head"
       upgraded-rancher-version-2-9:
         description: "Upgraded Rancher version for v2.9.x"
-        required: true
         default: "v2.9-head"
       qase-test-run-id-2-12:
         description: "Qase Test Run ID for v2.12.x"
-        required: true
         default: "4512"
       qase-test-run-id-2-11:
         description: "Qase Test Run ID for v2.11.x"
-        required: true
         default: "4541"
       qase-test-run-id-2-10:
         description: "Qase Test Run ID for v2.10.x"
-        required: true
         default: "4542"
       qase-test-run-id-2-9:
         description: "Qase Test Run ID for v2.9.x"
-        required: true
         default: "4540"
 
 permissions:
@@ -238,7 +230,7 @@ jobs:
     if: ${{ github.event_name == 'schedule' }}
     name: ${{ vars.RELEASED_RANCHER_VERSION_2_11 }} -> ${{ github.event.inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-11 }}
     runs-on: ubuntu-latest
-    environment: latest
+    environment: upgrade-prime-staging
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_11 }}"
 

--- a/.github/workflows/sanity-upgrade-test.yaml
+++ b/.github/workflows/sanity-upgrade-test.yaml
@@ -10,35 +10,27 @@ on:
         description: "Rancher tag version provided from check-rancher-tag workflow"
       upgraded-rancher-version-2-12:
         description: "Upgraded Rancher version for v2.12.x"
-        required: true
         default: "head"
       upgraded-rancher-version-2-11:
         description: "Upgraded Rancher version for v2.11.x"
-        required: true
         default: "v2.11-head"
       upgraded-rancher-version-2-10:
         description: "Upgraded Rancher version for v2.10.x"
-        required: true
         default: "v2.10-head"
       upgraded-rancher-version-2-9:
         description: "Upgraded Rancher version for v2.9.x"
-        required: true
         default: "v2.9-head"
       qase-test-run-id-2-12:
         description: "Qase Test Run ID for v2.12.x"
-        required: true
         default: "4512"
       qase-test-run-id-2-11:
         description: "Qase Test Run ID for v2.11.x"
-        required: true
         default: "4541"
       qase-test-run-id-2-10:
         description: "Qase Test Run ID for v2.10.x"
-        required: true
         default: "4542"
       qase-test-run-id-2-9:
         description: "Qase Test Run ID for v2.9.x"
-        required: true
         default: "4540"
   workflow_call:
     inputs:
@@ -258,7 +250,7 @@ jobs:
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11.'))
     name: ${{ vars.RELEASED_RANCHER_VERSION_2_11 }} -> ${{ inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-11 }}
     runs-on: ubuntu-latest
-    environment: latest
+    environment: upgrade-prime-staging
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_11 }}"
 


### PR DESCRIPTION
### Issue: N/A

### Description
Couple of issues that came up during release testing that this PR is addressing. See the list below:
- Update 2.11 steps to no longer use `latest` environment as it is now a Prime only release
- Remove the `required` field in each of the workflows; this should not be the case
- Update check rancher tag to run at 8AM, 12PM, 4PM PST Monday through Friday only
     - It should not run every 4 hours, this is causing extreme resource waste when a test fails.