### PR TITLE
Revert recent changes and remove needs-on

### DIFF
--- a/.github/workflows/airgap-test.yaml
+++ b/.github/workflows/airgap-test.yaml
@@ -42,10 +42,8 @@ permissions:
 jobs:
   v2-12:
     if: |
-      (github.event_name == 'workflow_dispatch' && 
-       ((github.event.inputs.rancher_version != '' && startsWith(github.event.inputs.rancher_version, 'v2.12.') && contains(github.event.inputs.rancher_version, '-alpha')) ||
-        (github.event.inputs.rancher_version == '' && contains(github.event.inputs.rancher-version-2-12, '-alpha')))) ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.12.') && contains(inputs.rancher_version, '-alpha'))
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.12.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.12.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-12 }}
     runs-on: ubuntu-latest
     environment: alpha
@@ -223,13 +221,10 @@ jobs:
   
   v2-11:
     if: |
-      (github.event_name == 'workflow_dispatch' && 
-       ((github.event.inputs.rancher_version != '' && startsWith(github.event.inputs.rancher_version, 'v2.11.') && contains(github.event.inputs.rancher_version, '-alpha')) ||
-        (github.event.inputs.rancher_version == '' && contains(github.event.inputs.rancher-version-2-11, '-alpha')))) ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11.') && contains(inputs.rancher_version, '-alpha'))
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-11 }}
     runs-on: ubuntu-latest
-    needs: v2-12
     environment: staging-alpha
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_11 }}"
@@ -405,13 +400,10 @@ jobs:
 
   v2-10:
     if: |
-      (github.event_name == 'workflow_dispatch' && 
-       ((github.event.inputs.rancher_version != '' && startsWith(github.event.inputs.rancher_version, 'v2.10.') && contains(github.event.inputs.rancher_version, '-alpha')) ||
-        (github.event.inputs.rancher_version == '' && contains(github.event.inputs.rancher-version-2-10, '-alpha')))) ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.10.') && contains(inputs.rancher_version, '-alpha'))
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.10.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.10.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-10 }}
     runs-on: ubuntu-latest
-    needs: v2-11
     environment: staging-alpha
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_10 }}"

--- a/.github/workflows/airgap-upgrade-test.yaml
+++ b/.github/workflows/airgap-upgrade-test.yaml
@@ -45,10 +45,8 @@ permissions:
 jobs:
   v2-12:
     if: |
-      (github.event_name == 'workflow_dispatch' && 
-       ((github.event.inputs.rancher_version != '' && startsWith(github.event.inputs.rancher_version, 'v2.12.') && contains(github.event.inputs.rancher_version, '-alpha')) ||
-        (github.event.inputs.rancher_version == '' && contains(github.event.inputs.rancher-version-2-12, '-alpha')))) ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.12.') && contains(inputs.rancher_version, '-alpha'))
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.12.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.12.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ vars.RELEASED_RANCHER_VERSION_2_12 }} -> ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-12 }}
     runs-on: ubuntu-latest
     environment: alpha
@@ -231,13 +229,10 @@ jobs:
   
   v2-11:
     if: |
-      (github.event_name == 'workflow_dispatch' && 
-       ((github.event.inputs.rancher_version != '' && startsWith(github.event.inputs.rancher_version, 'v2.11.') && contains(github.event.inputs.rancher_version, '-alpha')) ||
-        (github.event.inputs.rancher_version == '' && contains(github.event.inputs.rancher-version-2-11, '-alpha')))) ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11.') && contains(inputs.rancher_version, '-alpha'))
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ vars.RELEASED_RANCHER_VERSION_2_11 }} -> ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-11 }}
     runs-on: ubuntu-latest
-    needs: v2-12
     environment: upgrade-prime-staging
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_11 }}"
@@ -418,13 +413,10 @@ jobs:
 
   v2-10:
     if: |
-      (github.event_name == 'workflow_dispatch' && 
-       ((github.event.inputs.rancher_version != '' && startsWith(github.event.inputs.rancher_version, 'v2.10.') && contains(github.event.inputs.rancher_version, '-alpha')) ||
-        (github.event.inputs.rancher_version == '' && contains(github.event.inputs.rancher-version-2-10, '-alpha')))) ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.10.') && contains(inputs.rancher_version, '-alpha'))
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.10.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.10.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ vars.RELEASED_RANCHER_VERSION_2_10 }} -> ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-10 }}
     runs-on: ubuntu-latest
-    needs: v2-11
     environment: upgrade-prime-staging
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_10 }}"

--- a/.github/workflows/registry-test.yaml
+++ b/.github/workflows/registry-test.yaml
@@ -42,10 +42,8 @@ permissions:
 jobs:
   v2-12:
     if: |
-      (github.event_name == 'workflow_dispatch' && 
-       ((github.event.inputs.rancher_version != '' && startsWith(github.event.inputs.rancher_version, 'v2.12.') && contains(github.event.inputs.rancher_version, '-alpha')) ||
-        (github.event.inputs.rancher_version == '' && contains(github.event.inputs.rancher-version-2-12, '-alpha')))) ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.12.') && contains(inputs.rancher_version, '-alpha'))
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.12.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.12.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-12 }}
     runs-on: ubuntu-latest
     environment: alpha
@@ -229,13 +227,10 @@ jobs:
   
   v2-11:
     if: |
-      (github.event_name == 'workflow_dispatch' && 
-       ((github.event.inputs.rancher_version != '' && startsWith(github.event.inputs.rancher_version, 'v2.11.') && contains(github.event.inputs.rancher_version, '-alpha')) ||
-        (github.event.inputs.rancher_version == '' && contains(github.event.inputs.rancher-version-2-11, '-alpha')))) ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11.') && contains(inputs.rancher_version, '-alpha'))
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-11 }}
     runs-on: ubuntu-latest
-    needs: v2-12
     environment: staging-alpha
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_11 }}"
@@ -417,13 +412,10 @@ jobs:
 
   v2-10:
     if: |
-      (github.event_name == 'workflow_dispatch' && 
-       ((github.event.inputs.rancher_version != '' && startsWith(github.event.inputs.rancher_version, 'v2.10.') && contains(github.event.inputs.rancher_version, '-alpha')) ||
-        (github.event.inputs.rancher_version == '' && contains(github.event.inputs.rancher-version-2-10, '-alpha')))) ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.10.') && contains(inputs.rancher_version, '-alpha'))
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.10.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.10.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-10 }}
     runs-on: ubuntu-latest
-    needs: v2-11
     environment: staging-alpha
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_10 }}"


### PR DESCRIPTION
### Issue: N/A

### Description
As title, says reverting recent changes done during this release testing cycle. Additionally, removing the `needs-on` in each subsequent step for airgap and registry workflows. Realistically, we aren't going to receive all of the alphas at the same time.