### PR TITLE
Enhance imported clusters to support ARM64

### DIFF
--- a/framework/set/provisioning/imported/import-nodes.sh
+++ b/framework/set/provisioning/imported/import-nodes.sh
@@ -9,7 +9,15 @@ RKE_KUBE_CONFIG_FILE=${6}
 
 set -ex
 
-curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+ARCH=$(uname -m)
+if [[ $ARCH == "x86_64" ]]; then
+    KUBECTL_ARCH="amd64"
+elif [[ $ARCH == "arm64" || $ARCH == "aarch64" ]]; then
+    KUBECTL_ARCH="arm64"
+fi
+
+echo "Installing kubectl"
+curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/${KUBECTL_ARCH}/kubectl"
 sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 mkdir -p ~/.kube
 rm kubectl

--- a/tests/airgap/airgap_provisioning_test.go
+++ b/tests/airgap/airgap_provisioning_test.go
@@ -132,14 +132,13 @@ func (a *TfpAirgapProvisioningTestSuite) TestTfpAirgapProvisioning() {
 
 func (a *TfpAirgapProvisioningTestSuite) TestTfpAirgapUpgrading() {
 	tests := []struct {
-		name      string
-		module    string
-		isWindows bool
+		name   string
+		module string
 	}{
-		{"Upgrading Airgap RKE2", modules.AirgapRKE2, false},
-		{"Upgrading Airgap RKE2 Windows 2019", modules.AirgapRKE2Windows2019, true},
-		{"Upgrading Airgap RKE2 Windows 2022", modules.AirgapRKE2Windows2022, true},
-		{"Upgrading Airgap K3S", modules.AirgapK3S, false},
+		{"Upgrading Airgap RKE2", modules.AirgapRKE2},
+		{"Upgrading Airgap RKE2 Windows 2019", modules.AirgapRKE2Windows2019},
+		{"Upgrading Airgap RKE2 Windows 2022", modules.AirgapRKE2Windows2022},
+		{"Upgrading Airgap K3S", modules.AirgapK3S},
 	}
 
 	customClusterNames := []string{}

--- a/tests/rancher2/recurring/recurring_test.go
+++ b/tests/rancher2/recurring/recurring_test.go
@@ -1,4 +1,4 @@
-package sanity
+package recurring
 
 import (
 	"os"


### PR DESCRIPTION
### Issue: N/A

### Description
This PR mainly updates the `import-nodes.sh` used in the import cluster tests to support both `x86` and `arm64` architectures; ARM64 images fail without this fix. Also, fixing misc. petty changes in airgap and recurring runs test.