### PR TITLE
Add additional cleanup logic if EULA step fails

### DIFF
--- a/tests/airgap/airgap_provisioning_test.go
+++ b/tests/airgap/airgap_provisioning_test.go
@@ -62,7 +62,9 @@ func (a *TfpAirgapProvisioningTestSuite) SetupSuite() {
 	a.session = testSession
 
 	client, err := infrastructure.PostRancherSetup(a.T(), a.rancherConfig, testSession, a.terraformConfig.Standalone.AirgapInternalFQDN, false, true)
-	require.NoError(a.T(), err)
+	if err != nil && *a.rancherConfig.Cleanup {
+		cleanup.Cleanup(a.T(), a.standaloneTerraformOptions, keyPath)
+	}
 
 	a.client = client
 

--- a/tests/airgap/airgap_upgrade_rancher_test.go
+++ b/tests/airgap/airgap_upgrade_rancher_test.go
@@ -74,7 +74,9 @@ func (a *TfpAirgapUpgradeRancherTestSuite) SetupSuite() {
 	a.session = testSession
 
 	client, err := infrastructure.PostRancherSetup(a.T(), a.rancherConfig, testSession, a.terraformConfig.Standalone.AirgapInternalFQDN, false, true)
-	require.NoError(a.T(), err)
+	if err != nil && *a.rancherConfig.Cleanup {
+		cleanup.Cleanup(a.T(), a.standaloneTerraformOptions, keyPath)
+	}
 
 	a.client = client
 

--- a/tests/proxy/proxy_provisioning_test.go
+++ b/tests/proxy/proxy_provisioning_test.go
@@ -62,7 +62,9 @@ func (p *TfpProxyProvisioningTestSuite) SetupSuite() {
 	p.session = testSession
 
 	client, err := infrastructure.PostRancherSetup(p.T(), p.rancherConfig, testSession, p.terraformConfig.Standalone.RancherHostname, false, false)
-	require.NoError(p.T(), err)
+	if err != nil && *p.rancherConfig.Cleanup {
+		cleanup.Cleanup(p.T(), p.standaloneTerraformOptions, keyPath)
+	}
 
 	p.client = client
 	_, keyPath = rancher2.SetKeyPath(keypath.RancherKeyPath, p.terratestConfig.PathToRepo, "")

--- a/tests/proxy/proxy_upgrade_rancher_test.go
+++ b/tests/proxy/proxy_upgrade_rancher_test.go
@@ -74,7 +74,9 @@ func (p *TfpProxyUpgradeRancherTestSuite) SetupSuite() {
 	p.session = testSession
 
 	client, err := infrastructure.PostRancherSetup(p.T(), p.rancherConfig, testSession, p.terraformConfig.Standalone.RancherHostname, false, false)
-	require.NoError(p.T(), err)
+	if err != nil && *p.rancherConfig.Cleanup {
+		cleanup.Cleanup(p.T(), p.standaloneTerraformOptions, keyPath)
+	}
 
 	p.client = client
 

--- a/tests/registries/registries_test.go
+++ b/tests/registries/registries_test.go
@@ -64,7 +64,9 @@ func (r *TfpRegistriesTestSuite) SetupSuite() {
 	r.session = testSession
 
 	client, err := infrastructure.PostRancherSetup(r.T(), r.rancherConfig, testSession, r.terraformConfig.Standalone.RancherHostname, false, false)
-	require.NoError(r.T(), err)
+	if err != nil && *r.rancherConfig.Cleanup {
+		cleanup.Cleanup(r.T(), r.standaloneTerraformOptions, keyPath)
+	}
 
 	r.client = client
 

--- a/tests/sanity/sanity_provisioning_rke1_test.go
+++ b/tests/sanity/sanity_provisioning_rke1_test.go
@@ -56,7 +56,9 @@ func (s *TfpSanityRKE1ProvisioningTestSuite) SetupSuite() {
 	s.session = testSession
 
 	client, err := infrastructure.PostRancherSetup(s.T(), s.rancherConfig, testSession, s.terraformConfig.Standalone.RancherHostname, false, false)
-	require.NoError(s.T(), err)
+	if err != nil && *s.rancherConfig.Cleanup {
+		cleanup.Cleanup(s.T(), s.standaloneTerraformOptions, keyPath)
+	}
 
 	s.client = client
 

--- a/tests/sanity/sanity_provisioning_test.go
+++ b/tests/sanity/sanity_provisioning_test.go
@@ -59,7 +59,9 @@ func (s *TfpSanityProvisioningTestSuite) SetupSuite() {
 	s.session = testSession
 
 	client, err := infrastructure.PostRancherSetup(s.T(), s.rancherConfig, testSession, s.terraformConfig.Standalone.RancherHostname, false, false)
-	require.NoError(s.T(), err)
+	if err != nil && *s.rancherConfig.Cleanup {
+		cleanup.Cleanup(s.T(), s.standaloneTerraformOptions, keyPath)
+	}
 
 	s.client = client
 

--- a/tests/sanity/sanity_upgrade_rancher_test.go
+++ b/tests/sanity/sanity_upgrade_rancher_test.go
@@ -72,7 +72,9 @@ func (s *TfpSanityUpgradeRancherTestSuite) SetupSuite() {
 	s.session = testSession
 
 	client, err := infrastructure.PostRancherSetup(s.T(), s.rancherConfig, testSession, s.terraformConfig.Standalone.RancherHostname, false, false)
-	require.NoError(s.T(), err)
+	if err != nil && *s.rancherConfig.Cleanup {
+		cleanup.Cleanup(s.T(), s.standaloneTerraformOptions, keyPath)
+	}
 
 	s.client = client
 


### PR DESCRIPTION
### Issue: N/A

### Description
In a prior PR, we added cleanup logic in each stage of creating a Rancher server. This is to ensure that if a step fails, we will cleanup if enabled to not waste resources. However, if for whatever reason the `PostRancherSetup` function fails, we need to make sure we have the same safety measure.