### PR TITLE
Update Rancher2 recurring tests to not always run

### DIFF
--- a/.github/actions/get-qase-id/action.yaml
+++ b/.github/actions/get-qase-id/action.yaml
@@ -8,6 +8,9 @@ inputs:
   qase_release_id:
     description: "Qase ID for the release test run"
     required: true
+  qase_rc_id:
+    description: "Qase ID for the RC test run"
+    required: false
   qase_recurring_id:
     description: "Qase ID for the recurring test run"
     required: true
@@ -26,7 +29,11 @@ runs:
         QASE_ID=""
 
         if [[ -n "$TRIGGERED_TAG" ]]; then
-          QASE_ID="${{ inputs.qase_release_id }}"
+          if [[ "$TRIGGERED_TAG" == *"-rc"* ]]; then
+            QASE_ID="${{ inputs.qase_rc_id }}"
+          else
+            QASE_ID="${{ inputs.qase_release_id }}"
+          fi
         else
           QASE_ID="${{ inputs.qase_recurring_id }}"
         fi

--- a/.github/workflows/rancher2-recurring-test.yaml
+++ b/.github/workflows/rancher2-recurring-test.yaml
@@ -64,8 +64,8 @@ jobs:
   v2-12:
     if: |
       github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.12.')) ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.12.'))
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.12.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.12.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-12 }}
     runs-on: ubuntu-latest
     environment: latest
@@ -275,8 +275,8 @@ jobs:
   v2-11:
     if: |
       github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11.')) ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11.'))
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-11 }}
     runs-on: ubuntu-latest
     environment: staging-alpha
@@ -486,8 +486,8 @@ jobs:
   v2-10:
     if: |
       github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.10.')) ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.10.'))
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.10.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.10.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-10 }}
     runs-on: ubuntu-latest
     environment: staging-alpha

--- a/.github/workflows/sanity-test.yaml
+++ b/.github/workflows/sanity-test.yaml
@@ -63,10 +63,10 @@ env:
 
 jobs:
   v2-12:
-    # if: |
-    #   github.event_name == 'schedule' ||
-    #   (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.12.')) ||
-    #   (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.12.'))
+    if: |
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.12.')) ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.12.'))
     name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-12 }}
     runs-on: ubuntu-latest
     environment: latest
@@ -143,6 +143,7 @@ jobs:
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: ${{ vars.QASE_RELEASE_TEST_RUN_ID_2_12 }}
+          qase_rc_id: ${{ vars.QASE_RC_TEST_RUN_ID_2_12 }}
           qase_recurring_id: ${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_12 }}
 
       - name: Create config.yaml
@@ -352,6 +353,7 @@ jobs:
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_11 }}"
+          qase_rc_id: ${{ vars.QASE_RC_TEST_RUN_ID_2_11 }}
           qase_recurring_id: "${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_11 }}"
 
       - name: Create config.yaml
@@ -561,6 +563,7 @@ jobs:
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_10 }}"
+          qase_rc_id: "${{ vars.QASE_RC_TEST_RUN_ID_2_10 }}"
           qase_recurring_id: "${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_10 }}"
 
       - name: Create config.yaml
@@ -771,6 +774,7 @@ jobs:
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_9 }}"
+          qase_rc_id: "${{ vars.QASE_RC_TEST_RUN_ID_2_9 }}"
           qase_recurring_id: "${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_9 }}"
 
       - name: Create config.yaml

--- a/.github/workflows/sanity-upgrade-test.yaml
+++ b/.github/workflows/sanity-upgrade-test.yaml
@@ -143,6 +143,7 @@ jobs:
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_12 }}"
+          qase_rc_id: "${{ vars.QASE_RC_TEST_RUN_ID_2_12 }}"
           qase_recurring_id: "${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_12 }}"
 
       - name: Create config.yaml
@@ -357,6 +358,7 @@ jobs:
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_11 }}"
+          qase_rc_id: ${{ vars.QASE_RC_TEST_RUN_ID_2_11 }}
           qase_recurring_id: "${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_11 }}"
 
       - name: Create config.yaml
@@ -571,6 +573,7 @@ jobs:
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_10 }}"
+          qase_rc_id: ${{ vars.QASE_RC_TEST_RUN_ID_2_10 }}
           qase_recurring_id: "${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_10 }}"
 
       - name: Create config.yaml
@@ -787,6 +790,7 @@ jobs:
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_9 }}"
+          qase_rc_id: "${{ vars.QASE_RC_TEST_RUN_ID_2_9 }}"
           qase_recurring_id: "${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_9 }}"
 
       - name: Create config.yaml


### PR DESCRIPTION
### Issue: N/A

### Description
On a recent run of `check-rancher-tag` against an RC, it was noted that Rancher2 recurring tests ran, when we only expect sanity and sanity upgrade workflows to run. This PR adjusts the if conditional to match proxy workflows and only run against alphas.

Additionally, updated the Qase test run to be able to optionally take in a `qase_rc_id`. So when RCs are cut, sanity runs will report there specifically.