### PR TITLE
Fix caching issue when PRs are open

### DIFF
--- a/.github/workflows/check-rancher-tag.yaml
+++ b/.github/workflows/check-rancher-tag.yaml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   check-latest-rancher-tag:
+    if: github.ref == 'refs/heads/main' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
     outputs:
       latest_tag_v212: ${{ steps.get-latest-tag.outputs.latest_tag_v212 }}
@@ -28,7 +29,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: tag
-          key: rancher-tag-cache
+          key: rancher-tag-cache-${{ github.ref_name }}
+          restore-keys: |
+            rancher-tag-cache-
 
       - name: Get latest Rancher tag
         id: get-latest-tag
@@ -82,7 +85,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: tag
-          key: rancher-tag-cache
+          key: rancher-tag-cache-${{ github.ref_name }}
 
   set-latest-chart-version:
     needs: check-latest-rancher-tag


### PR DESCRIPTION
### Issue: N/A

### Description
`check-rancher-tag` has an interesting issue where it appears randomly that the `actions/cache` is not properly acknowledging saved cached versions. Looking deeper into this, I noted there is a critical pattern; when PRs are open, subsequent `check-rancher-tag` workflows kicked off don't respect the prior caching.

This PR does a couple of things:
- Prohibits `check-rancher-tag` from running unless it's explicitly by the main branch, or from the schedule
- Updates the static name from `rancher-tag-cache` to `rancher-tag-cache-`; this is to add more safeguards that unique caches are created and do not overwrite the main cache