### PR TITLE
Fix various issues noted during release testing

### DIFF
--- a/.github/actions/set-rancher-repo/action.yml
+++ b/.github/actions/set-rancher-repo/action.yml
@@ -8,6 +8,9 @@ inputs:
   fallback-repo:
     description: "The fallback repo to use if no RC/alpha detected"
     default: ""
+  env-var-name:
+    description: "The name of the environment variable to set"
+    default: "RANCHER_REPO"
 outputs:
   repo:
     description: "The determined repo"
@@ -35,5 +38,5 @@ runs:
     - name: Set environment variable
       uses: ./.github/actions/set-env-var
       with:
-        key: RANCHER_REPO
+        key: ${{ inputs.env-var-name }}
         value: ${{ steps.determine-repo.outputs.repo }}

--- a/.github/workflows/airgap-test.yaml
+++ b/.github/workflows/airgap-test.yaml
@@ -38,9 +38,6 @@ on:
         type: string
 
 env:
-  AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
-  AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
-  AWS_DEFAULT_REGION: "${{ secrets.AWS_REGION }}"
   CLOUD_PROVIDER_VERSION: "5.95.0"
   HOSTNAME_PREFIX: "tfp-airgap"
   LOCALS_PROVIDER_VERSION: "${{ vars.LOCALS_PROVIDER_VERSION }}"
@@ -173,6 +170,7 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               certType: "${{ vars.CERT_TYPE }}"
+              letsEncryptEmail: "${{ secrets.LETS_ENCRYPT_EMAIL }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
@@ -368,6 +366,7 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              letsEncryptEmail: "${{ secrets.LETS_ENCRYPT_EMAIL }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
@@ -563,6 +562,7 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              letsEncryptEmail: "${{ secrets.LETS_ENCRYPT_EMAIL }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"

--- a/.github/workflows/airgap-upgrade-test.yaml
+++ b/.github/workflows/airgap-upgrade-test.yaml
@@ -36,9 +36,6 @@ on:
         type: string
 
 env:
-  AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
-  AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
-  AWS_DEFAULT_REGION: "${{ secrets.AWS_REGION }}"
   CLOUD_PROVIDER_VERSION: "5.95.0"
   HOSTNAME_PREFIX: "tfp-airgap"
   LOCALS_PROVIDER_VERSION: "${{ vars.LOCALS_PROVIDER_VERSION }}"
@@ -171,6 +168,7 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_12 }}"
+              letsEncryptEmail: "${{ secrets.LETS_ENCRYPT_EMAIL }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
@@ -372,6 +370,7 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_11 }}"
+              letsEncryptEmail: "${{ secrets.LETS_ENCRYPT_EMAIL }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
@@ -573,6 +572,7 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_10 }}"
+              letsEncryptEmail: "${{ secrets.LETS_ENCRYPT_EMAIL }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"

--- a/.github/workflows/pr-sanity-test.yaml
+++ b/.github/workflows/pr-sanity-test.yaml
@@ -8,9 +8,6 @@ on:
   workflow_dispatch:
 
 env:
-  AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
-  AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
-  AWS_DEFAULT_REGION: "${{ secrets.AWS_REGION }}"
   CLOUD_PROVIDER_VERSION: "5.95.0"
   HOSTNAME_PREFIX: tfp-sanity
   LOCALS_PROVIDER_VERSION: "${{ vars.LOCALS_PROVIDER_VERSION }}"
@@ -126,8 +123,9 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               certType: "${{ vars.CERT_TYPE }}"
+              chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              letsEncryptEmail: "${{ secrets.LETS_ENCRYPT_EMAIL }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"

--- a/.github/workflows/proxy-arm64-test.yaml
+++ b/.github/workflows/proxy-arm64-test.yaml
@@ -22,9 +22,6 @@ permissions:
   contents: read
 
 env:
-  AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
-  AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
-  AWS_DEFAULT_REGION: "${{ secrets.AWS_REGION }}"
   CLOUD_PROVIDER_VERSION: "5.95.0"
   HOSTNAME_PREFIX: "tfp-proxy"
   LOCALS_PROVIDER_VERSION: "${{ vars.LOCALS_PROVIDER_VERSION }}"
@@ -158,6 +155,7 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              letsEncryptEmail: "${{ secrets.LETS_ENCRYPT_EMAIL }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"

--- a/.github/workflows/proxy-test.yaml
+++ b/.github/workflows/proxy-test.yaml
@@ -50,9 +50,6 @@ permissions:
   contents: read
 
 env:
-  AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
-  AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
-  AWS_DEFAULT_REGION: "${{ secrets.AWS_REGION }}"
   CLOUD_PROVIDER_VERSION: "5.95.0"
   HOSTNAME_PREFIX: "tfp-proxy"
   LOCALS_PROVIDER_VERSION: "${{ vars.LOCALS_PROVIDER_VERSION }}"
@@ -197,6 +194,7 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              letsEncryptEmail: "${{ secrets.LETS_ENCRYPT_EMAIL }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
@@ -412,6 +410,7 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              letsEncryptEmail: "${{ secrets.LETS_ENCRYPT_EMAIL }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
@@ -627,6 +626,7 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              letsEncryptEmail: "${{ secrets.LETS_ENCRYPT_EMAIL }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"

--- a/.github/workflows/proxy-upgrade-arm64-test.yaml
+++ b/.github/workflows/proxy-upgrade-arm64-test.yaml
@@ -22,9 +22,6 @@ permissions:
   contents: read
 
 env:
-  AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
-  AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
-  AWS_DEFAULT_REGION: "${{ secrets.AWS_REGION }}"
   CLOUD_PROVIDER_VERSION: "5.95.0"
   HOSTNAME_PREFIX: "tfp-proxy-up"
   LOCALS_PROVIDER_VERSION: "${{ vars.LOCALS_PROVIDER_VERSION }}"
@@ -105,6 +102,7 @@ jobs:
         with:
           rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
           fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
+          env-var-name: UPGRADED_RANCHER_REPO
 
       - name: Create config.yaml
         run: |
@@ -158,6 +156,7 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_12 }}"
+              letsEncryptEmail: "${{ secrets.LETS_ENCRYPT_EMAIL }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"

--- a/.github/workflows/proxy-upgrade-test.yaml
+++ b/.github/workflows/proxy-upgrade-test.yaml
@@ -50,9 +50,6 @@ permissions:
   contents: read
 
 env:
-  AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
-  AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
-  AWS_DEFAULT_REGION: "${{ secrets.AWS_REGION }}"
   CLOUD_PROVIDER_VERSION: "5.95.0"
   HOSTNAME_PREFIX: "tfp-proxy-up"
   LOCALS_PROVIDER_VERSION: "${{ vars.LOCALS_PROVIDER_VERSION }}"
@@ -136,6 +133,7 @@ jobs:
         with:
           rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
           fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
+          env-var-name: UPGRADED_RANCHER_REPO
 
       - name: Get Qase ID
         id: get-qase-id
@@ -197,6 +195,7 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_12 }}"
+              letsEncryptEmail: "${{ secrets.LETS_ENCRYPT_EMAIL }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
@@ -356,6 +355,7 @@ jobs:
         with:
           rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
           fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
+          env-var-name: UPGRADED_RANCHER_REPO
 
       - name: Get Qase ID
         id: get-qase-id
@@ -417,6 +417,7 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_11 }}"
+              letsEncryptEmail: "${{ secrets.LETS_ENCRYPT_EMAIL }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
@@ -576,6 +577,7 @@ jobs:
         with:
           rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
           fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
+          env-var-name: UPGRADED_RANCHER_REPO
 
       - name: Get Qase ID
         id: get-qase-id
@@ -637,6 +639,7 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_10 }}"
+              letsEncryptEmail: "${{ secrets.LETS_ENCRYPT_EMAIL }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"

--- a/.github/workflows/rancher2-recurring-test.yaml
+++ b/.github/workflows/rancher2-recurring-test.yaml
@@ -50,8 +50,6 @@ permissions:
   contents: read
 
 env:
-  AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
-  AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
   CLOUD_PROVIDER_VERSION: "5.95.0"
   HOSTNAME_PREFIX: "tfp-recur"
   LOCALS_PROVIDER_VERSION: "${{ vars.LOCALS_PROVIDER_VERSION }}"
@@ -194,6 +192,7 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              letsEncryptEmail: "${{ secrets.LETS_ENCRYPT_EMAIL }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_12 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
@@ -405,6 +404,7 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              letsEncryptEmail: "${{ secrets.LETS_ENCRYPT_EMAIL }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_11 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
@@ -616,6 +616,7 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              letsEncryptEmail: "${{ secrets.LETS_ENCRYPT_EMAIL }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_10 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"

--- a/.github/workflows/registry-test.yaml
+++ b/.github/workflows/registry-test.yaml
@@ -38,9 +38,6 @@ on:
         type: string
 
 env:
-  AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
-  AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
-  AWS_DEFAULT_REGION: "${{ secrets.AWS_REGION }}"
   CLOUD_PROVIDER_VERSION: "5.95.0"
   HOSTNAME_PREFIX: tfp-registry
   LOCALS_PROVIDER_VERSION: "${{ vars.LOCALS_PROVIDER_VERSION }}"
@@ -172,6 +169,7 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              letsEncryptEmail: "${{ secrets.LETS_ENCRYPT_EMAIL }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
@@ -371,6 +369,7 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              letsEncryptEmail: "${{ secrets.LETS_ENCRYPT_EMAIL }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
@@ -569,6 +568,8 @@ jobs:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               certType: "${{ vars.CERT_TYPE }}"
+              chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              letsEncryptEmail: "${{ secrets.LETS_ENCRYPT_EMAIL }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"

--- a/.github/workflows/sanity-arm64-test.yaml
+++ b/.github/workflows/sanity-arm64-test.yaml
@@ -22,9 +22,6 @@ permissions:
   contents: read
 
 env:
-  AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
-  AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
-  AWS_DEFAULT_REGION: "${{ secrets.AWS_REGION }}"
   CLOUD_PROVIDER_VERSION: "5.95.0"
   HOSTNAME_PREFIX: "tfp-sanity"
   LOCALS_PROVIDER_VERSION: "${{ vars.LOCALS_PROVIDER_VERSION }}"
@@ -155,6 +152,7 @@ jobs:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               certType: "${{ vars.CERT_TYPE }}"
+              letsEncryptEmail: "${{ secrets.LETS_ENCRYPT_EMAIL }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"

--- a/.github/workflows/sanity-test.yaml
+++ b/.github/workflows/sanity-test.yaml
@@ -50,9 +50,6 @@ permissions:
   contents: read
 
 env:
-  AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
-  AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
-  AWS_DEFAULT_REGION: "${{ secrets.AWS_REGION }}"
   CLOUD_PROVIDER_VERSION: "5.95.0"
   HOSTNAME_PREFIX: "tfp-sanity"
   LOCALS_PROVIDER_VERSION: "${{ vars.LOCALS_PROVIDER_VERSION }}"
@@ -84,6 +81,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.TFP_IAM_ROLE }}
           aws-region: ${{ secrets.AWS_REGION }}
+          role-duration-seconds: 14400
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@v2
@@ -196,6 +194,7 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              letsEncryptEmail: "${{ secrets.LETS_ENCRYPT_EMAIL }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
@@ -264,6 +263,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.TFP_IAM_ROLE }}
           aws-region: ${{ secrets.AWS_REGION }}
+          role-duration-seconds: 14400
 
       - name: Revoke Runner IP
         if: always()
@@ -294,6 +294,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.TFP_IAM_ROLE }}
           aws-region: ${{ secrets.AWS_REGION }}
+          role-duration-seconds: 14400
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@v2
@@ -404,8 +405,9 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               certType: "${{ vars.CERT_TYPE }}"
+              chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              letsEncryptEmail: "${{ secrets.LETS_ENCRYPT_EMAIL }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
@@ -474,6 +476,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.TFP_IAM_ROLE }}
           aws-region: ${{ secrets.AWS_REGION }}
+          role-duration-seconds: 14400
 
       - name: Revoke Runner IP
         if: always()
@@ -504,6 +507,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.TFP_IAM_ROLE }}
           aws-region: ${{ secrets.AWS_REGION }}
+          role-duration-seconds: 14400
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@v2
@@ -616,6 +620,7 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              letsEncryptEmail: "${{ secrets.LETS_ENCRYPT_EMAIL }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
@@ -685,6 +690,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.TFP_IAM_ROLE }}
           aws-region: ${{ secrets.AWS_REGION }}
+          role-duration-seconds: 14400
 
       - name: Revoke Runner IP
         if: always()
@@ -715,6 +721,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.TFP_IAM_ROLE }}
           aws-region: ${{ secrets.AWS_REGION }}
+          role-duration-seconds: 14400
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@v2
@@ -825,8 +832,9 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               certType: "${{ vars.CERT_TYPE }}"
+              chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              letsEncryptEmail: "${{ secrets.LETS_ENCRYPT_EMAIL }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
@@ -896,6 +904,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.TFP_IAM_ROLE }}
           aws-region: ${{ secrets.AWS_REGION }}
+          role-duration-seconds: 14400
 
       - name: Revoke Runner IP
         if: always()

--- a/.github/workflows/sanity-upgrade-arm64-test.yaml
+++ b/.github/workflows/sanity-upgrade-arm64-test.yaml
@@ -22,9 +22,6 @@ permissions:
   contents: read
 
 env:
-  AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
-  AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
-  AWS_DEFAULT_REGION: "${{ secrets.AWS_REGION }}"
   CLOUD_PROVIDER_VERSION: "5.95.0"
   HOSTNAME_PREFIX: "tfp-sanity-up"
   LOCALS_PROVIDER_VERSION: "${{ vars.LOCALS_PROVIDER_VERSION }}"
@@ -105,6 +102,7 @@ jobs:
         with:
           rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
           fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
+          env-var-name: UPGRADED_RANCHER_REPO
 
       - name: Create config.yaml
         run: |
@@ -156,6 +154,7 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_12 }}"
+              letsEncryptEmail: "${{ secrets.LETS_ENCRYPT_EMAIL }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"

--- a/.github/workflows/sanity-upgrade-test.yaml
+++ b/.github/workflows/sanity-upgrade-test.yaml
@@ -50,9 +50,6 @@ permissions:
   contents: read
 
 env:
-  AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
-  AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
-  AWS_DEFAULT_REGION: "${{ secrets.AWS_REGION }}"
   CLOUD_PROVIDER_VERSION: "5.95.0"
   HOSTNAME_PREFIX: "tfp-sanity-up"
   LOCALS_PROVIDER_VERSION: "${{ vars.LOCALS_PROVIDER_VERSION }}"
@@ -136,6 +133,7 @@ jobs:
         with:
           rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
           fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
+          env-var-name: UPGRADED_RANCHER_REPO
 
       - name: Get Qase ID
         id: get-qase-id
@@ -196,6 +194,7 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_12 }}"
+              letsEncryptEmail: "${{ secrets.LETS_ENCRYPT_EMAIL }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
@@ -351,6 +350,7 @@ jobs:
         with:
           rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
           fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
+          env-var-name: UPGRADED_RANCHER_REPO
 
       - name: Get Qase ID
         id: get-qase-id
@@ -411,6 +411,7 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_11 }}"
+              letsEncryptEmail: "${{ secrets.LETS_ENCRYPT_EMAIL }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
@@ -566,6 +567,7 @@ jobs:
         with:
           rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
           fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
+          env-var-name: UPGRADED_RANCHER_REPO
 
       - name: Get Qase ID
         id: get-qase-id
@@ -626,6 +628,7 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_10 }}"
+              letsEncryptEmail: "${{ secrets.LETS_ENCRYPT_EMAIL }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
@@ -783,6 +786,7 @@ jobs:
         with:
           rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
           fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
+          env-var-name: UPGRADED_RANCHER_REPO
 
       - name: Get Qase ID
         id: get-qase-id
@@ -843,6 +847,7 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_9 }}"
+              letsEncryptEmail: "${{ secrets.LETS_ENCRYPT_EMAIL }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"

--- a/config/config.go
+++ b/config/config.go
@@ -131,6 +131,7 @@ type Standalone struct {
 	CertManagerVersion             string `json:"certManagerVersion,omitempty" yaml:"certManagerVersion,omitempty"`
 	CertType                       string `json:"certType,omitempty" yaml:"certType,omitempty"`
 	ChartVersion                   string `json:"chartVersion,omitempty" yaml:"chartVersion,omitempty"`
+	LetsEncryptEmail               string `json:"letsEncryptEmail,omitempty" yaml:"letsEncryptEmail,omitempty"`
 	K3SVersion                     string `json:"k3sVersion,omitempty" yaml:"k3sVersion,omitempty"`
 	RancherAgentImage              string `json:"rancherAgentImage,omitempty" yaml:"rancherAgentImage,omitempty"`
 	RancherChartRepository         string `json:"rancherChartRepository,omitempty" yaml:"rancherChartRepository,omitempty"`

--- a/framework/set/resources/airgap/rancher/setup.sh
+++ b/framework/set/resources/airgap/rancher/setup.sh
@@ -11,7 +11,8 @@ CHART_VERSION=$8
 BOOTSTRAP_PASSWORD=$9
 RANCHER_IMAGE=${10}
 REGISTRY=${11}
-RANCHER_AGENT_IMAGE=${12}
+LETS_ENCRYPT_EMAIL=${12}
+RANCHER_AGENT_IMAGE=${13}
 
 set -ex
 
@@ -62,9 +63,6 @@ if [ "$CERT_TYPE" == "self-signed" ]; then
                                                                                   --devel
   fi
 elif [ "$CERT_TYPE" == "lets-encrypt" ]; then
-    RAND_STR=$(LC_ALL=C tr -dc 'a-z0-9' </dev/urandom | head -c 12)
-    LETS_ENCRYPT_EMAIL="${RAND_STR}@gmail.com"
-
     if [ -n "$RANCHER_AGENT_IMAGE" ]; then
         helm upgrade --install rancher rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
                                                                                      --set hostname=${HOSTNAME} \

--- a/framework/set/resources/airgap/rancher/setupAirgapRancher.go
+++ b/framework/set/resources/airgap/rancher/setupAirgapRancher.go
@@ -37,7 +37,7 @@ func CreateAirgapRancher(file *os.File, newFile *hclwrite.File, rootBody *hclwri
 		terraformConfig.Standalone.CertType + " " + terraformConfig.Standalone.RancherHostname + " " +
 		terraformConfig.Standalone.AirgapInternalFQDN + " " + terraformConfig.Standalone.RancherTagVersion + " " +
 		terraformConfig.Standalone.ChartVersion + " " + terraformConfig.Standalone.BootstrapPassword + " " +
-		terraformConfig.Standalone.RancherImage + " " + registryPublicDNS
+		terraformConfig.Standalone.RancherImage + " " + registryPublicDNS + " " + terraformConfig.Standalone.LetsEncryptEmail
 
 	if terraformConfig.Standalone.RancherAgentImage != "" {
 		command += " " + terraformConfig.Standalone.RancherAgentImage

--- a/framework/set/resources/airgap/rancher/upgrade.sh
+++ b/framework/set/resources/airgap/rancher/upgrade.sh
@@ -9,7 +9,8 @@ RANCHER_TAG_VERSION=$6
 CHART_VERSION=$7
 RANCHER_IMAGE=$8
 REGISTRY=$9
-RANCHER_AGENT_IMAGE=${10}
+LETS_ENCRYPT_EMAIL=${10}
+RANCHER_AGENT_IMAGE=${11}
 
 set -ex
 
@@ -19,7 +20,7 @@ helm repo add upgraded-rancher-${REPO} ${RANCHER_CHART_REPO}${REPO}
 echo "Upgrading Rancher"
 if [ "$CERT_TYPE" == "self-signed" ]; then
   if [ -n "$RANCHER_AGENT_IMAGE" ]; then
-      helm upgrade --install rancher rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
+      helm upgrade --install rancher upgraded-rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
                                                                                   --version ${CHART_VERSION} \
                                                                                   --set hostname=${HOSTNAME} \
                                                                                   --set rancherImageTag=${RANCHER_TAG_VERSION} \
@@ -31,7 +32,7 @@ if [ "$CERT_TYPE" == "self-signed" ]; then
                                                                                   --devel
 
   else
-      helm upgrade --install rancher rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
+      helm upgrade --install rancher upgraded-rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
                                                                                   --version ${CHART_VERSION} \
                                                                                   --set hostname=${HOSTNAME} \
                                                                                   --set rancherImage=${REGISTRY}/${RANCHER_IMAGE} \
@@ -41,11 +42,8 @@ if [ "$CERT_TYPE" == "self-signed" ]; then
                                                                                   --devel
   fi
 elif [ "$CERT_TYPE" == "lets-encrypt" ]; then
-    RAND_STR=$(LC_ALL=C tr -dc 'a-z0-9' </dev/urandom | head -c 12)
-    LETS_ENCRYPT_EMAIL="${RAND_STR}@gmail.com"
-
     if [ -n "$RANCHER_AGENT_IMAGE" ]; then
-        helm upgrade --install rancher rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
+        helm upgrade --install rancher upgraded-rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
                                                                                      --version ${CHART_VERSION} \
                                                                                      --set hostname=${HOSTNAME} \
                                                                                      --set rancherImageTag=${RANCHER_TAG_VERSION} \
@@ -59,7 +57,7 @@ elif [ "$CERT_TYPE" == "lets-encrypt" ]; then
                                                                                      --set agentTLSMode=system-store \
                                                                                      --devel
     else
-        helm upgrade --install rancher rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
+        helm upgrade --install rancher upgraded-rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
                                                                                      --version ${CHART_VERSION} \
                                                                                      --set hostname=${HOSTNAME} \
                                                                                      --set rancherImage=${REGISTRY}/${RANCHER_IMAGE} \

--- a/framework/set/resources/airgap/rancher/upgradeAirgapRancher.go
+++ b/framework/set/resources/airgap/rancher/upgradeAirgapRancher.go
@@ -36,7 +36,7 @@ func UpgradeAirgapRancher(file *os.File, newFile *hclwrite.File, rootBody *hclwr
 		terraformConfig.Standalone.UpgradedRancherRepo + " " + terraformConfig.Standalone.CertType + " " +
 		terraformConfig.Standalone.RancherHostname + " " + terraformConfig.Standalone.AirgapInternalFQDN + " " +
 		terraformConfig.Standalone.UpgradedRancherTagVersion + " " + terraformConfig.Standalone.UpgradedRancherChartVersion + " " +
-		terraformConfig.Standalone.UpgradedRancherImage + " " + registryPublicDNS
+		terraformConfig.Standalone.UpgradedRancherImage + " " + registryPublicDNS + " " + terraformConfig.Standalone.LetsEncryptEmail
 
 	if terraformConfig.Standalone.UpgradedRancherAgentImage != "" {
 		command += " " + terraformConfig.Standalone.UpgradedRancherAgentImage

--- a/framework/set/resources/proxy/rancher/createRancher.go
+++ b/framework/set/resources/proxy/rancher/createRancher.go
@@ -41,7 +41,8 @@ func CreateProxiedRancher(file *os.File, newFile *hclwrite.File, rootBody *hclwr
 		terraformConfig.Standalone.Repo + " " + terraformConfig.Standalone.CertManagerVersion + " " +
 		terraformConfig.Standalone.CertType + " " + terraformConfig.Standalone.RancherHostname + " " +
 		terraformConfig.Standalone.RancherTagVersion + " " + terraformConfig.Standalone.ChartVersion + " " +
-		terraformConfig.Standalone.BootstrapPassword + " " + terraformConfig.Standalone.RancherImage + " " + rke2BastionPrivateIP
+		terraformConfig.Standalone.BootstrapPassword + " " + terraformConfig.Standalone.RancherImage + " " + rke2BastionPrivateIP +
+		" " + terraformConfig.Standalone.LetsEncryptEmail
 
 	if terraformConfig.Standalone.RancherAgentImage != "" {
 		command += " " + terraformConfig.Standalone.RancherAgentImage

--- a/framework/set/resources/proxy/rancher/setup.sh
+++ b/framework/set/resources/proxy/rancher/setup.sh
@@ -10,7 +10,8 @@ CHART_VERSION=$7
 BOOTSTRAP_PASSWORD=$8
 RANCHER_IMAGE=$9
 BASTION=${10}
-RANCHER_AGENT_IMAGE=${11}
+LETS_ENCRYPT_EMAIL=${11}
+RANCHER_AGENT_IMAGE=${12}
 PROXY_PORT="3228"
 NO_PROXY="localhost\\,127.0.0.0/8\\,10.0.0.0/8\\,172.0.0.0/8\\,192.168.0.0/16\\,.svc\\,.cluster.local\\,cattle-system.svc\\,169.254.169.254"
 
@@ -83,9 +84,6 @@ if [ "$CERT_TYPE" == "self-signed" ]; then
                                                                                     --devel
     fi
 elif [ "$CERT_TYPE" == "lets-encrypt" ]; then
-    RAND_STR=$(LC_ALL=C tr -dc 'a-z0-9' </dev/urandom | head -c 12)
-    LETS_ENCRYPT_EMAIL="${RAND_STR}@gmail.com"
-
     if [ -n "$RANCHER_AGENT_IMAGE" ]; then
         helm upgrade --install rancher rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
                                                                                      --set hostname=${HOSTNAME} \

--- a/framework/set/resources/proxy/rancher/upgrade.sh
+++ b/framework/set/resources/proxy/rancher/upgrade.sh
@@ -8,7 +8,8 @@ RANCHER_TAG_VERSION=$5
 CHART_VERSION=$6
 RANCHER_IMAGE=$7
 BASTION=$8
-RANCHER_AGENT_IMAGE=${9}
+LETS_ENCRYPT_EMAIL=$9
+RANCHER_AGENT_IMAGE=${10}
 PROXY_PORT="3228"
 NO_PROXY="localhost\\,127.0.0.0/8\\,10.0.0.0/8\\,172.0.0.0/8\\,192.168.0.0/16\\,.svc\\,.cluster.local\\,cattle-system.svc\\,169.254.169.254"
 
@@ -20,7 +21,7 @@ helm repo add upgraded-rancher-${REPO} ${RANCHER_CHART_REPO}${REPO}
 echo "Upgrading Rancher"
 if [ "$CERT_TYPE" == "self-signed" ]; then
     if [ -n "$RANCHER_AGENT_IMAGE" ]; then
-        helm upgrade --install rancher rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
+        helm upgrade --install rancher upgraded-rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
                                                                                     --version ${CHART_VERSION} \
                                                                                     --set hostname=${HOSTNAME} \
                                                                                     --set rancherImageTag=${RANCHER_TAG_VERSION} \
@@ -33,7 +34,7 @@ if [ "$CERT_TYPE" == "self-signed" ]; then
                                                                                     --devel
 
     else
-        helm upgrade --install rancher rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
+        helm upgrade --install rancher upgraded-rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
                                                                                     --version ${CHART_VERSION} \
                                                                                     --set hostname=${HOSTNAME} \
                                                                                     --set rancherImage=${RANCHER_IMAGE} \
@@ -44,11 +45,8 @@ if [ "$CERT_TYPE" == "self-signed" ]; then
                                                                                     --devel
     fi
 elif [ "$CERT_TYPE" == "lets-encrypt" ]; then
-    RAND_STR=$(LC_ALL=C tr -dc 'a-z0-9' </dev/urandom | head -c 12)
-    LETS_ENCRYPT_EMAIL="${RAND_STR}@gmail.com"
-
     if [ -n "$RANCHER_AGENT_IMAGE" ]; then
-        helm upgrade --install rancher rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
+        helm upgrade --install rancher upgraded-rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
                                                                                      --version ${CHART_VERSION} \
                                                                                      --set hostname=${HOSTNAME} \
                                                                                      --set rancherImageTag=${RANCHER_TAG_VERSION} \
@@ -63,7 +61,7 @@ elif [ "$CERT_TYPE" == "lets-encrypt" ]; then
                                                                                      --set agentTLSMode=system-store \
                                                                                      --devel
     else
-        helm upgrade --install rancher rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
+        helm upgrade --install rancher upgraded-rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
                                                                                      --version ${CHART_VERSION} \
                                                                                      --set hostname=${HOSTNAME} \
                                                                                      --set rancherImage=${RANCHER_IMAGE} \

--- a/framework/set/resources/proxy/rancher/upgradeRancher.go
+++ b/framework/set/resources/proxy/rancher/upgradeRancher.go
@@ -36,7 +36,7 @@ func UpgradeProxiedRancher(file *os.File, newFile *hclwrite.File, rootBody *hclw
 		terraformConfig.Standalone.UpgradedRancherRepo + " " + terraformConfig.Standalone.RancherHostname + " " +
 		terraformConfig.Standalone.CertType + " " + terraformConfig.Standalone.UpgradedRancherTagVersion + " " +
 		terraformConfig.Standalone.UpgradedRancherChartVersion + " " + terraformConfig.Standalone.UpgradedRancherImage + " " +
-		proxyPrivateIP
+		proxyPrivateIP + " " + terraformConfig.Standalone.LetsEncryptEmail
 
 	if terraformConfig.Standalone.UpgradedRancherAgentImage != "" {
 		command += " " + terraformConfig.Standalone.UpgradedRancherAgentImage

--- a/framework/set/resources/registries/rancher/createRancher.go
+++ b/framework/set/resources/registries/rancher/createRancher.go
@@ -36,7 +36,8 @@ func CreateRancher(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Bod
 		terraformConfig.Standalone.Repo + " " + terraformConfig.Standalone.CertManagerVersion + " " +
 		terraformConfig.Standalone.CertType + " " + terraformConfig.Standalone.RancherHostname + " " +
 		terraformConfig.Standalone.RancherTagVersion + " " + terraformConfig.Standalone.ChartVersion + " " +
-		terraformConfig.Standalone.BootstrapPassword + " " + terraformConfig.Standalone.RancherImage + " " + registryPublicDNS
+		terraformConfig.Standalone.BootstrapPassword + " " + terraformConfig.Standalone.RancherImage + " " + registryPublicDNS +
+		" " + terraformConfig.Standalone.LetsEncryptEmail
 
 	if terraformConfig.Standalone.RancherAgentImage != "" {
 		command += " " + terraformConfig.Standalone.RancherAgentImage

--- a/framework/set/resources/registries/rancher/setup.sh
+++ b/framework/set/resources/registries/rancher/setup.sh
@@ -10,7 +10,8 @@ CHART_VERSION=$7
 BOOTSTRAP_PASSWORD=$8
 RANCHER_IMAGE=$9
 REGISTRY=${10}
-RANCHER_AGENT_IMAGE=${11}
+LETS_ENCRYPT_EMAIL=${11}
+RANCHER_AGENT_IMAGE=${12}
 
 set -ex
 
@@ -74,9 +75,6 @@ if [ "$CERT_TYPE" == "self-signed" ]; then
                                                                                     --devel
     fi
 elif [ "$CERT_TYPE" == "lets-encrypt" ]; then
-    RAND_STR=$(LC_ALL=C tr -dc 'a-z0-9' </dev/urandom | head -c 12)
-    LETS_ENCRYPT_EMAIL="${RAND_STR}@gmail.com"
-
     if [ -n "$RANCHER_AGENT_IMAGE" ]; then
         helm upgrade --install rancher rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
                                                                                      --set hostname=${HOSTNAME} \

--- a/framework/set/resources/sanity/rancher/createRancher.go
+++ b/framework/set/resources/sanity/rancher/createRancher.go
@@ -40,7 +40,8 @@ func CreateRancher(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Bod
 		terraformConfig.Standalone.Repo + " " + terraformConfig.Standalone.CertManagerVersion + " " +
 		terraformConfig.Standalone.CertType + " " + terraformConfig.Standalone.RancherHostname + " " +
 		terraformConfig.Standalone.RancherTagVersion + " " + terraformConfig.Standalone.ChartVersion + " " +
-		terraformConfig.Standalone.BootstrapPassword + " " + terraformConfig.Standalone.RancherImage
+		terraformConfig.Standalone.BootstrapPassword + " " + terraformConfig.Standalone.RancherImage +
+		" " + terraformConfig.Standalone.LetsEncryptEmail
 
 	if terraformConfig.Standalone.RancherAgentImage != "" {
 		command += " " + terraformConfig.Standalone.RancherAgentImage

--- a/framework/set/resources/sanity/rancher/setup.sh
+++ b/framework/set/resources/sanity/rancher/setup.sh
@@ -9,7 +9,8 @@ RANCHER_TAG_VERSION=$6
 CHART_VERSION=$7
 BOOTSTRAP_PASSWORD=$8
 RANCHER_IMAGE=$9
-RANCHER_AGENT_IMAGE=${10}
+LETS_ENCRYPT_EMAIL=${10}
+RANCHER_AGENT_IMAGE=${11}
 
 set -ex
 
@@ -70,9 +71,6 @@ if [ "$CERT_TYPE" == "self-signed" ]; then
                                                                                      --devel
     fi
 elif [ "$CERT_TYPE" == "lets-encrypt" ]; then
-    RAND_STR=$(LC_ALL=C tr -dc 'a-z0-9' </dev/urandom | head -c 12)
-    LETS_ENCRYPT_EMAIL="${RAND_STR}@gmail.com"
-
     if [ -n "$RANCHER_AGENT_IMAGE" ]; then
         helm upgrade --install rancher rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
                                                                                      --set hostname=${HOSTNAME} \

--- a/framework/set/resources/sanity/rancher/upgrade.sh
+++ b/framework/set/resources/sanity/rancher/upgrade.sh
@@ -7,7 +7,8 @@ HOSTNAME=$4
 RANCHER_TAG_VERSION=$5
 CHART_VERSION=$6
 RANCHER_IMAGE=$7
-RANCHER_AGENT_IMAGE=${8}
+LETS_ENCRYPT_EMAIL=$8
+RANCHER_AGENT_IMAGE=${9}
 
 set -ex
 
@@ -37,11 +38,8 @@ if [ "$CERT_TYPE" == "self-signed" ]; then
                                                                                     --devel
     fi
 elif [ "$CERT_TYPE" == "lets-encrypt" ]; then
-    RAND_STR=$(LC_ALL=C tr -dc 'a-z0-9' </dev/urandom | head -c 12)
-    LETS_ENCRYPT_EMAIL="${RAND_STR}@gmail.com"
-
     if [ -n "$RANCHER_AGENT_IMAGE" ]; then
-        helm upgrade --install rancher rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
+        helm upgrade --install rancher upgraded-rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
                                                                                      --version ${CHART_VERSION} \
                                                                                      --set hostname=${HOSTNAME} \
                                                                                      --set rancherImageTag=${RANCHER_TAG_VERSION} \
@@ -54,7 +52,7 @@ elif [ "$CERT_TYPE" == "lets-encrypt" ]; then
                                                                                      --set agentTLSMode=system-store \
                                                                                      --devel
     else
-        helm upgrade --install rancher rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
+        helm upgrade --install rancher upgraded-rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
                                                                                      --version ${CHART_VERSION} \
                                                                                      --set hostname=${HOSTNAME} \
                                                                                      --set rancherImage=${RANCHER_IMAGE} \

--- a/framework/set/resources/sanity/rancher/upgradeRancher.go
+++ b/framework/set/resources/sanity/rancher/upgradeRancher.go
@@ -35,7 +35,8 @@ func UpgradeRancher(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Bo
 	command := "bash -c '/tmp/upgrade.sh " + terraformConfig.Standalone.UpgradedRancherChartRepository + " " +
 		terraformConfig.Standalone.UpgradedRancherRepo + " " + terraformConfig.Standalone.CertType + " " +
 		terraformConfig.Standalone.RancherHostname + " " + terraformConfig.Standalone.UpgradedRancherTagVersion + " " +
-		terraformConfig.Standalone.UpgradedRancherChartVersion + " " + terraformConfig.Standalone.UpgradedRancherImage
+		terraformConfig.Standalone.UpgradedRancherChartVersion + " " + terraformConfig.Standalone.UpgradedRancherImage +
+		" " + terraformConfig.Standalone.LetsEncryptEmail
 
 	if terraformConfig.Standalone.UpgradedRancherAgentImage != "" {
 		command += " " + terraformConfig.Standalone.UpgradedRancherAgentImage

--- a/tests/extensions/provisioning/verify.go
+++ b/tests/extensions/provisioning/verify.go
@@ -110,15 +110,13 @@ func VerifyKubernetesVersion(t *testing.T, client *rancher.Client, clusterID, ex
 	case module == clustertypes.AKS || module == clustertypes.GKE:
 		expectedKubernetesVersion = `v` + expectedKubernetesVersion
 		require.Equal(t, expectedKubernetesVersion, cluster.Version.GitVersion)
-
-	// Terraform requires that we input the entire RKE1 version. However, Rancher client clips the `-rancher` suffix.
+	case strings.Contains(module, clustertypes.EKS):
+		require.Equal(t, expectedKubernetesVersion, cluster.Version.GitVersion[1:5])
 	case strings.Contains(module, clustertypes.RKE1):
 		expectedKubernetesVersion = expectedKubernetesVersion[:len(expectedKubernetesVersion)-11]
 		require.Equal(t, expectedKubernetesVersion, cluster.Version.GitVersion)
-
-	case strings.Contains(module, clustertypes.EKS):
-		require.Equal(t, expectedKubernetesVersion, cluster.Version.GitVersion[1:5])
-
+	case strings.Contains(module, clustertypes.RKE2) || strings.Contains(module, clustertypes.K3S):
+		require.Equal(t, expectedKubernetesVersion, cluster.Version.GitVersion)
 	default:
 		logrus.Errorf("Invalid module provided")
 	}

--- a/tests/sanity/sanity_upgrade_rancher_test.go
+++ b/tests/sanity/sanity_upgrade_rancher_test.go
@@ -136,7 +136,7 @@ func (s *TfpSanityUpgradeRancherTestSuite) provisionAndVerifyCluster(name string
 		_, err = operations.ReplaceValue([]string{"terraform", "module"}, tt.module, configMap[0])
 		require.NoError(s.T(), err)
 
-		provisioning.GetK8sVersion(s.T(), s.client, s.terratestConfig, s.terraformConfig, configs.DefaultK8sVersion, configMap)
+		provisioning.GetK8sVersion(s.T(), s.client, s.terratestConfig, s.terraformConfig, configs.SecondHighestVersion, configMap)
 
 		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
 
@@ -150,6 +150,12 @@ func (s *TfpSanityUpgradeRancherTestSuite) provisionAndVerifyCluster(name string
 			if strings.Contains(terraform.Module, clustertypes.WINDOWS) {
 				clusterIDs, customClusterNames = provisioning.Provision(s.T(), s.client, rancher, terraform, terratest, testUser, testPassword, s.terraformOptions, configMap, newFile, rootBody, file, true, true, true, customClusterNames)
 				provisioning.VerifyClustersState(s.T(), s.client, clusterIDs)
+			}
+
+			if deleteClusters {
+				provisioning.KubernetesUpgrade(s.T(), s.client, rancher, terraform, terratest, testUser, testPassword, s.terraformOptions, configMap, newFile, rootBody, file, false)
+				provisioning.VerifyClustersState(s.T(), s.client, clusterIDs)
+				provisioning.VerifyKubernetesVersion(s.T(), s.client, clusterIDs[0], terratest.KubernetesVersion, s.terraformConfig.Module)
 			}
 		})
 	}


### PR DESCRIPTION
### Issue: N/A

### Description
From this past release testing, there are a number of issues that were found. As such, this PR is addressing the following:
- Upgrading from release lines supports upgrading to different types (i.e. prime to community, prime to staging, etc)
     - Made the necessary GHA edits to this as well
- Updated `lets-encrypt` to use a fixed GHA secret email instead of generating a random email
     - This was causing DNS propagation issues
- For `sanity_upgrade_rancher_test.go`, upgrade downstream K8s clusters for post-upgrade clusters