### PR TITLE
Refactor RKE2 cluster creation for sanity Rancher

### DIFF
--- a/framework/set/resources/rke2/add-servers.sh
+++ b/framework/set/resources/rke2/add-servers.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
 
 K8S_VERSION=$1
-RKE2_SERVER_IP=$2
+RKE2_SERVER_ONE_IP=$2
 RKE2_NEW_SERVER_IP=$3
-HOSTNAME=$4
-RKE2_TOKEN=$5
-CNI=$6
-CLUSTER_CIDR=${7}
-SERVICE_CIDR=${8}
+RKE2_TOKEN=$4
+CNI=$5
+CLUSTER_CIDR=${6}
+SERVICE_CIDR=${7}
 
 set -e
 
@@ -16,8 +15,9 @@ sudo hostnamectl set-hostname ${RKE2_NEW_SERVER_IP}
 sudo mkdir -p /etc/rancher/rke2
 sudo touch /etc/rancher/rke2/config.yaml
 
-if [ -n "${CLUSTER_CIDR}" ]; then
-  echo "server: https://${RKE2_SERVER_IP}:9345
+createConfigYAML() {
+  if [ -n "${CLUSTER_CIDR}" ]; then
+    echo "server: https://${RKE2_SERVER_IP}:9345
 write-kubeconfig-mode: 644
 node-ip: ${RKE2_NEW_SERVER_IP}
 node-external-ip: ${RKE2_NEW_SERVER_IP}
@@ -26,19 +26,34 @@ token: ${RKE2_TOKEN}
 cluster-cidr: ${CLUSTER_CIDR}
 service-cidr: ${SERVICE_CIDR}
 tls-san:
-  - ${HOSTNAME}" | sudo tee /etc/rancher/rke2/config.yaml > /dev/null
-else
-  echo "server: https://${RKE2_SERVER_IP}:9345
+  - ${RKE2_SERVER_ONE_IP}" | sudo tee /etc/rancher/rke2/config.yaml > /dev/null
+  else
+    echo "server: https://${RKE2_SERVER_ONE_IP}:9345
 cni: ${CNI}
 token: ${RKE2_TOKEN}
 tls-san:
-  - ${HOSTNAME}" | sudo tee /etc/rancher/rke2/config.yaml > /dev/null
-fi
+  - ${RKE2_SERVER_ONE_IP}" | sudo tee /etc/rancher/rke2/config.yaml > /dev/null
+  fi
+}
+
+createConfigYAML
 
 curl -sfL https://get.rke2.io --output install.sh
 sudo chmod +x install.sh
-
 sudo INSTALL_RKE2_VERSION=${K8S_VERSION} INSTALL_RKE2_TYPE='server' sh ./install.sh
 
 sudo systemctl enable rke2-server
-sudo systemctl start rke2-server
+
+if ! sudo systemctl start rke2-server; then
+  sudo /usr/local/bin/rke2-killall.sh
+  sudo /usr/local/bin/rke2-uninstall.sh
+  sudo rm -rf /var/lib/rancher/rke2
+  sudo rm -rf /etc/rancher/rke2
+
+  sudo mkdir -p /etc/rancher/rke2
+  sudo touch /etc/rancher/rke2/config.yaml
+
+  createConfigYAML
+
+  sudo INSTALL_RKE2_VERSION=${K8S_VERSION} INSTALL_RKE2_TYPE='server' ./install.sh
+fi

--- a/framework/set/resources/rke2/createCluster.go
+++ b/framework/set/resources/rke2/createCluster.go
@@ -112,8 +112,7 @@ func createRKE2Server(rootBody *hclwrite.Body, terraformConfig *config.Terraform
 	_, provisionerBlockBody := SSHNullResource(rootBody, terraformConfig, rke2ServerOnePublicIP, rke2ServerOne)
 
 	command := "bash -c '/tmp/init-server.sh " + terraformConfig.Standalone.OSUser + " " + terraformConfig.Standalone.OSGroup + " " +
-		terraformConfig.Standalone.RKE2Version + " " + rke2ServerOnePrivateIP + " " + terraformConfig.Standalone.RancherHostname + " " +
-		rke2Token + " " + terraformConfig.CNI
+		terraformConfig.Standalone.RKE2Version + " " + rke2ServerOnePrivateIP + " " + rke2Token + " " + terraformConfig.CNI
 
 	if terraformConfig.AWSConfig.EnablePrimaryIPv6 {
 		command += " " + terraformConfig.AWSConfig.ClusterCIDR + " " + terraformConfig.AWSConfig.ServiceCIDR
@@ -139,7 +138,7 @@ func addRKE2ServerNodes(rootBody *hclwrite.Body, terraformConfig *config.Terrafo
 		nullResourceBlockBody, provisionerBlockBody := SSHNullResource(rootBody, terraformConfig, instance, host)
 
 		command := "bash -c '/tmp/add-servers.sh " + terraformConfig.Standalone.RKE2Version + " " + rke2ServerOnePrivateIP + " " +
-			instance + " " + terraformConfig.Standalone.RancherHostname + " " + rke2Token + " " + terraformConfig.CNI
+			instance + " " + rke2Token + " " + terraformConfig.CNI
 
 		if terraformConfig.AWSConfig.EnablePrimaryIPv6 {
 			command += " " + terraformConfig.AWSConfig.ClusterCIDR + " " + terraformConfig.AWSConfig.ServiceCIDR

--- a/framework/set/resources/rke2/init-server.sh
+++ b/framework/set/resources/rke2/init-server.sh
@@ -4,11 +4,10 @@ USER=$1
 GROUP=$2
 K8S_VERSION=$3
 RKE2_SERVER_IP=$4
-HOSTNAME=$5
-RKE2_TOKEN=$6
-CNI=$7
-CLUSTER_CIDR=${8}
-SERVICE_CIDR=${9}
+RKE2_TOKEN=$5
+CNI=$6
+CLUSTER_CIDR=${7}
+SERVICE_CIDR=${8}
 
 set -e
 
@@ -17,8 +16,9 @@ sudo hostnamectl set-hostname ${RKE2_SERVER_IP}
 sudo mkdir -p /etc/rancher/rke2
 sudo touch /etc/rancher/rke2/config.yaml
 
-if [ -n "${CLUSTER_CIDR}" ]; then
-  echo "cni: ${CNI}
+createConfigYAML() {
+  if [ -n "${CLUSTER_CIDR}" ]; then
+    echo "cni: ${CNI}
 write-kubeconfig-mode: 644
 node-ip: ${RKE2_SERVER_IP}
 node-external-ip: ${RKE2_SERVER_IP}
@@ -26,20 +26,36 @@ token: ${RKE2_TOKEN}
 cluster-cidr: ${CLUSTER_CIDR}
 service-cidr: ${SERVICE_CIDR}
 tls-san:
-  - ${HOSTNAME}" | sudo tee /etc/rancher/rke2/config.yaml > /dev/null
-else
-  echo "cni: ${CNI}
+  - ${RKE2_SERVER_IP}" | sudo tee /etc/rancher/rke2/config.yaml > /dev/null
+  else
+    echo "cni: ${CNI}
 token: ${RKE2_TOKEN}
 tls-san:
-  - ${HOSTNAME}" | sudo tee /etc/rancher/rke2/config.yaml > /dev/null
-fi
+  - ${RKE2_SERVER_IP}" | sudo tee /etc/rancher/rke2/config.yaml > /dev/null
+  fi
+}
+
+createConfigYAML
 
 curl -sfL https://get.rke2.io --output install.sh
 sudo chmod +x install.sh
 sudo INSTALL_RKE2_VERSION=${K8S_VERSION} INSTALL_RKE2_TYPE='server' ./install.sh
 
 sudo systemctl enable rke2-server
-sudo systemctl start rke2-server
+
+if ! sudo systemctl start rke2-server; then
+  sudo /usr/local/bin/rke2-killall.sh
+  sudo /usr/local/bin/rke2-uninstall.sh
+  sudo rm -rf /var/lib/rancher/rke2
+  sudo rm -rf /etc/rancher/rke2
+
+  sudo mkdir -p /etc/rancher/rke2
+  sudo touch /etc/rancher/rke2/config.yaml
+
+  createConfigYAML
+
+  sudo INSTALL_RKE2_VERSION=${K8S_VERSION} INSTALL_RKE2_TYPE='server' ./install.sh
+fi
 
 if [[ "${USER}" == "root" ]]; then
   sudo mkdir -p /root/.kube


### PR DESCRIPTION
### Issue: N/A

### Description
There is inconsistency with the RKE2 cluster creation when dealing with the sanity Rancher. This job adds retry logic in case it fails and makes sure that we are using the private IP and not the FQDN.