### PR TITLE
Fix duplicate time sleep issue with Windows imported clusters

### DIFF
--- a/.github/workflows/sanity-test.yaml
+++ b/.github/workflows/sanity-test.yaml
@@ -692,7 +692,6 @@ jobs:
 
   v2-9:
     if: |
-      github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.9.')) ||
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.9.'))
     name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-9 }}

--- a/.github/workflows/sanity-upgrade-test.yaml
+++ b/.github/workflows/sanity-upgrade-test.yaml
@@ -711,7 +711,6 @@ jobs:
 
   v2-9:
     if: |
-      github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.9.')) ||
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.9.'))
     name: ${{ vars.RELEASED_RANCHER_VERSION_2_9 }} -> ${{ inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-9 }}

--- a/framework/set/provisioning/custom/sleep/setSleep.go
+++ b/framework/set/provisioning/custom/sleep/setSleep.go
@@ -9,8 +9,8 @@ import (
 )
 
 // SetTimeSleep is a function that will set the time_sleep configurations in the main.tf file,
-func SetTimeSleep(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, duration, dependsOnValue string) error {
-	sleepResourceBlock := rootBody.AppendNewBlock(defaults.Resource, []string{defaults.TimeSleep, defaults.TimeSleep + "-" + terraformConfig.ResourcePrefix})
+func SetTimeSleep(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, duration, dependsOnValue, suffix string) error {
+	sleepResourceBlock := rootBody.AppendNewBlock(defaults.Resource, []string{defaults.TimeSleep, defaults.TimeSleep + "-" + terraformConfig.ResourcePrefix + "-" + suffix})
 	sleepResourceBlockBody := sleepResourceBlock.Body()
 
 	sleepResourceBlockBody.SetAttributeValue(defaults.CreateDuration, cty.StringVal(duration))

--- a/framework/set/provisioning/imported/importNodes.go
+++ b/framework/set/provisioning/imported/importNodes.go
@@ -65,7 +65,7 @@ func importNodes(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfi
 		addServerThreeName := addServer + terraformConfig.ResourcePrefix + `_` + serverThree
 		dependsOnServer = `[` + defaults.NullResource + `.` + addServerTwoName + `, ` + defaults.NullResource + `.` + addServerThreeName + `]`
 	} else if terraformConfig.Module == modules.ImportEC2RKE2Windows2019 || terraformConfig.Module == modules.ImportEC2RKE2Windows2022 {
-		dependsOnServer = `[` + defaults.TimeSleep + `.` + defaults.TimeSleep + `-` + terraformConfig.ResourcePrefix + `]`
+		dependsOnServer = `[` + defaults.TimeSleep + `.` + defaults.TimeSleep + `-` + terraformConfig.ResourcePrefix + `-import_wins` + `]`
 	} else {
 		dependsOnServer = `[` + defaults.RKECluster + `.` + terraformConfig.ResourcePrefix + `]`
 	}

--- a/framework/set/provisioning/imported/importedRKE2K3SConfig.go
+++ b/framework/set/provisioning/imported/importedRKE2K3SConfig.go
@@ -60,7 +60,7 @@ func SetImportedRKE2K3s(terraformConfig *config.TerraformConfig, terratestConfig
 		rootBody.AppendNewline()
 		dependsOnValue := fmt.Sprintf("[" + defaults.NullResource + ".add_windows_node" + "]")
 
-		sleep.SetTimeSleep(rootBody, terraformConfig, "10s", dependsOnValue)
+		sleep.SetTimeSleep(rootBody, terraformConfig, "10s", dependsOnValue, "import_wins")
 		rootBody.AppendNewline()
 	}
 

--- a/framework/set/resources/imported/addWindowsNode.go
+++ b/framework/set/resources/imported/addWindowsNode.go
@@ -73,7 +73,9 @@ func addImportedWindowsNode(rootBody *hclwrite.Body, terraformConfig *config.Ter
 
 	provisionerBlockBody.SetAttributeValue(defaults.Inline, cty.ListVal(inlineCommands))
 	nullResourceBlockBody, provisionerBlockBody = nullresource.CreateImportedWindowsNullResource(rootBody, terraformConfig, terratestConfig, windowsNodePublicDNS, addWindowsNode)
+
 	version := terraformConfig.Standalone.RKE2Version
+	version += "+rke2r1"
 
 	command := "powershell.exe -File C:\\\\Windows\\\\Temp\\\\init-server.ps1 -ArgumentList -K8S_VERSION " + version + " -RKE2_SERVER_IP " + serverOnePrivateIP +
 		" -RKE2_TOKEN " + token

--- a/framework/set/resources/imported/createRKE2K3SCluster.go
+++ b/framework/set/resources/imported/createRKE2K3SCluster.go
@@ -77,8 +77,7 @@ func createImportedRKE2K3SServer(rootBody *hclwrite.Body, terraformConfig *confi
 		version = terraformConfig.Standalone.RKE2Version
 
 		command = "bash -c '/tmp/init-server.sh " + terraformConfig.Standalone.OSUser + " " + terraformConfig.Standalone.OSGroup + " " +
-			version + " " + serverOnePrivateIP + " " + terraformConfig.Standalone.RancherHostname + " " + token + " " +
-			terraformConfig.CNI + "'"
+			version + " " + serverOnePrivateIP + " " + token + " " + terraformConfig.CNI + "'"
 	}
 
 	command += " || true"
@@ -128,8 +127,8 @@ func addImportedRKE2K3SServerNodes(rootBody *hclwrite.Body, terraformConfig *con
 		} else if strings.Contains(terraformConfig.Module, clustertypes.RKE2) && strings.Contains(terraformConfig.Module, defaults.Import) {
 			version = terraformConfig.Standalone.RKE2Version
 
-			command = "bash -c '/tmp/add-servers.sh " + version + " " + serverOnePrivateIP + " " + instance + " " + terraformConfig.Standalone.RancherHostname +
-				" " + token + " " + terraformConfig.CNI + "'"
+			command = "bash -c '/tmp/add-servers.sh " + terraformConfig.Standalone.OSUser + " " + version + " " + serverOnePrivateIP + " " +
+				instance + " " + token + " " + terraformConfig.CNI + "'"
 		}
 
 		command += " || true"

--- a/framework/set/resources/providers/aws/windowsInstances.go
+++ b/framework/set/resources/providers/aws/windowsInstances.go
@@ -97,6 +97,13 @@ func CreateWindowsAWSInstances(rootBody *hclwrite.Body, terraformConfig *config.
 	connectionBlockBody.SetAttributeValue(defaults.Timeout, cty.StringVal(terraformConfig.AWSConfig.Timeout))
 	configBlockBody.AppendNewline()
 
+	provisionerBlock := configBlockBody.AppendNewBlock(defaults.Provisioner, []string{defaults.RemoteExec})
+	provisionerBlockBody := provisionerBlock.Body()
+
+	provisionerBlockBody.SetAttributeValue(defaults.Inline, cty.ListVal([]cty.Value{
+		cty.StringVal("echo Connected!!!"),
+	}))
+
 	if terraformConfig.Module == modules.ImportEC2RKE2Windows2019 || terraformConfig.Module == modules.ImportEC2RKE2Windows2022 {
 		serverTwoName := terraformConfig.ResourcePrefix + `_server2`
 		serverThreeName := terraformConfig.ResourcePrefix + `_server3`

--- a/framework/set/resources/rancher2/setProvidersAndUsersTF.go
+++ b/framework/set/resources/rancher2/setProvidersAndUsersTF.go
@@ -231,7 +231,7 @@ func createGlobalRoleBinding(rootBody *hclwrite.Body, testUser string, userID st
 	dependsOnValue := fmt.Sprintf("[" + globalRoleBinding + "." + globalRoleBinding + "]")
 
 	rootBody.AppendNewline()
-	sleep.SetTimeSleep(rootBody, terraformConfig, "5s", dependsOnValue)
+	sleep.SetTimeSleep(rootBody, terraformConfig, "5s", dependsOnValue, "standard_user")
 	rootBody.AppendNewline()
 }
 

--- a/framework/set/resources/rke2/add-servers.sh
+++ b/framework/set/resources/rke2/add-servers.sh
@@ -21,10 +21,7 @@ elif [[ $ARCH == "arm64" || $ARCH == "aarch64" ]]; then
 fi
 
 wget https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2.linux-${ARCH}.tar.gz
-wget https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2.linux-${ARCH}.tar.gz
 wget https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2-images.linux-${ARCH}.tar.zst
-wget https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2-images.linux-${ARCH}.tar.zst
-wget https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/sha256sum-${ARCH}.txt
 wget https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/sha256sum-${ARCH}.txt
 
 sudo mkdir -p /etc/rancher/rke2

--- a/framework/set/resources/rke2/init-server.sh
+++ b/framework/set/resources/rke2/init-server.sh
@@ -21,10 +21,7 @@ elif [[ $ARCH == "arm64" || $ARCH == "aarch64" ]]; then
 fi
 
 wget https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2.linux-${ARCH}.tar.gz
-wget https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2.linux-${ARCH}.tar.gz
 wget https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2-images.linux-${ARCH}.tar.zst
-wget https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2-images.linux-${ARCH}.tar.zst
-wget https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/sha256sum-${ARCH}.txt
 wget https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/sha256sum-${ARCH}.txt
 
 sudo mkdir -p /etc/rancher/rke2


### PR DESCRIPTION
### Issue: N/A

### Description
As part of a recent change to ensure standard users are provisioning clusters, the Windows imported cluster test was overlooked. Specifically, we have a time sleep after creating the standard user. However, there is also a time sleep in the Windows import test.

The solution is adding a `suffix` parameter in the time sleep resource. That way, you will never have two time sleeps that are the exact same.

Outside of that, removing the scheduling of 2.9 sanity as we only need to run it against check rancher tag at this point.