### PR TITLE
Enhance tests to verify rancher server version

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -27,8 +27,9 @@ type Role string
 type PSACT string
 
 const (
-	TerraformConfigurationFileKey = "terraform"
-	TerratestConfigurationFileKey = "terratest"
+	TerraformConfigurationFileKey  = "terraform"
+	TerratestConfigurationFileKey  = "terratest"
+	StandaloneConfigurationFileKey = "standalone"
 
 	AdminClientName    TestClientName = "Admin User"
 	StandardClientName TestClientName = "Standard User"
@@ -234,7 +235,7 @@ type TerratestConfig struct {
 }
 
 // LoadTFPConfigs loads the TFP configurations from the provided map
-func LoadTFPConfigs(cattleConfig map[string]any) (*rancher.Config, *TerraformConfig, *TerratestConfig) {
+func LoadTFPConfigs(cattleConfig map[string]any) (*rancher.Config, *TerraformConfig, *TerratestConfig, *Standalone) {
 	rancherConfig := new(rancher.Config)
 	operations.LoadObjectFromMap(configs.Rancher, cattleConfig, rancherConfig)
 
@@ -244,7 +245,12 @@ func LoadTFPConfigs(cattleConfig map[string]any) (*rancher.Config, *TerraformCon
 	terratestConfig := new(TerratestConfig)
 	operations.LoadObjectFromMap(TerratestConfigurationFileKey, cattleConfig, terratestConfig)
 
-	return rancherConfig, terraformConfig, terratestConfig
+	standaloneConfig := terraformConfig.Standalone
+	if standaloneConfig == nil {
+		standaloneConfig = new(Standalone)
+	}
+
+	return rancherConfig, terraformConfig, terratestConfig, standaloneConfig
 }
 
 // LoadPackageDefaults loads the specified filename in the same package as the test

--- a/framework/set/setAuthConfig.go
+++ b/framework/set/setAuthConfig.go
@@ -23,7 +23,7 @@ func AuthConfig(rancherConfig *rancher.Config, testUser, testPassword string, co
 
 	newFile, rootBody = resources.SetProvidersAndUsersTF(rancherConfig, testUser, testPassword, true, newFile, rootBody, configMap, false)
 
-	rancherConfig, terraform, _ := config.LoadTFPConfigs(configMap[0])
+	rancherConfig, terraform, _, _ := config.LoadTFPConfigs(configMap[0])
 	authProvider := terraform.AuthProvider
 
 	switch {

--- a/framework/set/setConfigTF.go
+++ b/framework/set/setConfigTF.go
@@ -47,7 +47,7 @@ func ConfigTF(client *rancher.Client, rancherConfig *rancher.Config, terratestCo
 	containsCustomModule := false
 
 	for i, cattleConfig := range configMap {
-		_, terraform, terratest := config.LoadTFPConfigs(cattleConfig)
+		_, terraform, terratest, _ := config.LoadTFPConfigs(cattleConfig)
 
 		kubernetesVersion := terratest.KubernetesVersion
 		nodePools := terratest.Nodepools

--- a/tests/airgap/airgap_provisioning_test.go
+++ b/tests/airgap/airgap_provisioning_test.go
@@ -31,6 +31,7 @@ type TfpAirgapProvisioningTestSuite struct {
 	rancherConfig              *rancher.Config
 	terraformConfig            *config.TerraformConfig
 	terratestConfig            *config.TerratestConfig
+	standaloneConfig           *config.Standalone
 	standaloneTerraformOptions *terraform.Options
 	terraformOptions           *terraform.Options
 	registry                   string
@@ -46,7 +47,9 @@ func (a *TfpAirgapProvisioningTestSuite) SetupSuite() {
 	a.session = testSession
 
 	a.client, a.registry, _, a.standaloneTerraformOptions, a.terraformOptions, a.cattleConfig = infrastructure.SetupAirgapRancher(a.T(), a.session, keypath.AirgapKeyPath)
-	a.rancherConfig, a.terraformConfig, a.terratestConfig = config.LoadTFPConfigs(a.cattleConfig)
+	a.rancherConfig, a.terraformConfig, a.terratestConfig, a.standaloneConfig = config.LoadTFPConfigs(a.cattleConfig)
+
+	provisioning.VerifyRancherVersion(a.T(), a.rancherConfig.Host, a.standaloneConfig.RancherTagVersion)
 }
 
 func (a *TfpAirgapProvisioningTestSuite) TestTfpAirgapProvisioning() {
@@ -84,7 +87,7 @@ func (a *TfpAirgapProvisioningTestSuite) TestTfpAirgapProvisioning() {
 
 		provisioning.GetK8sVersion(a.T(), a.client, a.terratestConfig, a.terraformConfig, configs.DefaultK8sVersion, configMap)
 
-		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, terratest, _ := config.LoadTFPConfigs(configMap[0])
 
 		currentDate := time.Now().Format("2006-01-02 03:04PM")
 		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion + " " + currentDate

--- a/tests/extensions/provisioning/rancherVersion.go
+++ b/tests/extensions/provisioning/rancherVersion.go
@@ -1,0 +1,61 @@
+package provisioning
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/rancher/shepherd/extensions/rancherversion"
+)
+
+const (
+	head = "head"
+)
+
+type Commit struct {
+	SHA string `json:"sha"`
+}
+
+// RequestRancherVersion Requests the rancher version from the rancher server, parses the returned json and returns a
+// Config object, or an error.
+func RequestRancherVersion(rancherURL string) (*rancherversion.Config, error) {
+	httpURL := "https://" + rancherURL + "/rancherversion"
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	client := &http.Client{Transport: tr}
+
+	resp, err := client.Get(httpURL)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	byteObject, err := io.ReadAll(resp.Body)
+	if err != nil || byteObject == nil {
+		return nil, err
+	}
+
+	var jsonObject map[string]interface{}
+	err = json.Unmarshal(byteObject, &jsonObject)
+	if err != nil {
+		return nil, err
+	}
+
+	configObject := new(rancherversion.Config)
+	configObject.IsPrime, _ = strconv.ParseBool(jsonObject["RancherPrime"].(string))
+	configObject.RancherVersion = jsonObject["Version"].(string)
+	configObject.GitCommit = jsonObject["GitCommit"].(string)
+
+	if strings.Contains(configObject.RancherVersion, head) {
+		if i := strings.Index(configObject.RancherVersion, "-"); i != -1 {
+			configObject.RancherVersion = configObject.RancherVersion[:i] + "-" + head
+		}
+	}
+
+	return configObject, nil
+}

--- a/tests/extensions/provisioning/uniquify.go
+++ b/tests/extensions/provisioning/uniquify.go
@@ -30,7 +30,7 @@ func UniquifyTerraform(cattleConfigs []map[string]any) ([]map[string]any, error)
 
 func uniquifyField(keyPath []string, cattleConfig map[string]any) (map[string]any, error) {
 	cattleConfig = shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
-	_, terraformConfig, _ := config.LoadTFPConfigs(cattleConfig)
+	_, terraformConfig, _, _ := config.LoadTFPConfigs(cattleConfig)
 
 	keyPathValue := terraformConfig.ResourcePrefix
 

--- a/tests/extensions/provisioning/verify.go
+++ b/tests/extensions/provisioning/verify.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rancher/tfp-automation/defaults/clustertypes"
 	waitState "github.com/rancher/tfp-automation/framework/wait/state"
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -107,6 +108,14 @@ func VerifyRegistry(t *testing.T, client *rancher.Client, clusterID string, terr
 		_, err := registries.CheckAllClusterPodsForRegistryPrefix(client, clusterID, terraformConfig.PrivateRegistries.URL)
 		require.NoError(t, err)
 	}
+}
+
+// VerifyRancherVersion validates that the expected rancher version matches the version of the rancher server.
+func VerifyRancherVersion(t *testing.T, hostURL string, expectedVersion string) {
+	resp, err := RequestRancherVersion(hostURL)
+	require.NoError(t, err)
+
+	assert.Equal(t, expectedVersion, resp.RancherVersion, "rancher version does not match the expected version")
 }
 
 // VerifyNodeCount validates that a cluster has the expected number of nodes.

--- a/tests/infrastructure/createRancher.go
+++ b/tests/infrastructure/createRancher.go
@@ -23,7 +23,7 @@ import (
 func SetupAirgapRancher(t *testing.T, session *session.Session, moduleKeyPath string) (*rancher.Client, string, string, *terraform.Options,
 	*terraform.Options, map[string]any) {
 	cattleConfig := shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
-	rancherConfig, terraformConfig, terratestConfig := config.LoadTFPConfigs(cattleConfig)
+	rancherConfig, terraformConfig, terratestConfig, _ := config.LoadTFPConfigs(cattleConfig)
 
 	_, keyPath := rancher2.SetKeyPath(moduleKeyPath, terratestConfig.PathToRepo, terraformConfig.Provider)
 	standaloneTerraformOptions := framework.Setup(t, terraformConfig, terratestConfig, keyPath)
@@ -44,7 +44,7 @@ func SetupAirgapRancher(t *testing.T, session *session.Session, moduleKeyPath st
 func SetupProxyRancher(t *testing.T, session *session.Session, moduleKeyPath string) (*rancher.Client, string, string,
 	*terraform.Options, *terraform.Options, map[string]any) {
 	cattleConfig := shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
-	rancherConfig, terraformConfig, terratestConfig := config.LoadTFPConfigs(cattleConfig)
+	rancherConfig, terraformConfig, terratestConfig, _ := config.LoadTFPConfigs(cattleConfig)
 
 	_, keyPath := rancher2.SetKeyPath(moduleKeyPath, terratestConfig.PathToRepo, terraformConfig.Provider)
 	standaloneTerraformOptions := framework.Setup(t, terraformConfig, terratestConfig, keyPath)
@@ -65,7 +65,7 @@ func SetupProxyRancher(t *testing.T, session *session.Session, moduleKeyPath str
 func SetupRancher(t *testing.T, session *session.Session, moduleKeyPath string) (*rancher.Client, string, *terraform.Options,
 	*terraform.Options, map[string]any) {
 	cattleConfig := shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
-	rancherConfig, terraformConfig, terratestConfig := config.LoadTFPConfigs(cattleConfig)
+	rancherConfig, terraformConfig, terratestConfig, _ := config.LoadTFPConfigs(cattleConfig)
 
 	_, keyPath := rancher2.SetKeyPath(moduleKeyPath, terratestConfig.PathToRepo, terraformConfig.Provider)
 	standaloneTerraformOptions := framework.Setup(t, terraformConfig, terratestConfig, keyPath)
@@ -85,7 +85,7 @@ func SetupRancher(t *testing.T, session *session.Session, moduleKeyPath string) 
 // SetupRegistryRancher sets up a registry-enabled Rancher server and returns the client, configuration, and Terraform options.
 func SetupRegistryRancher(t *testing.T, session *session.Session, moduleKeyPath string) (*rancher.Client, string, string, string, *terraform.Options, *terraform.Options, map[string]any) {
 	cattleConfig := shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
-	rancherConfig, terraformConfig, terratestConfig := config.LoadTFPConfigs(cattleConfig)
+	rancherConfig, terraformConfig, terratestConfig, _ := config.LoadTFPConfigs(cattleConfig)
 
 	_, keyPath := rancher2.SetKeyPath(moduleKeyPath, terratestConfig.PathToRepo, terraformConfig.Provider)
 	standaloneTerraformOptions := framework.Setup(t, terraformConfig, terratestConfig, keyPath)

--- a/tests/infrastructure/setup_airgap_rancher_test.go
+++ b/tests/infrastructure/setup_airgap_rancher_test.go
@@ -30,7 +30,7 @@ type AirgapRancherTestSuite struct {
 
 func (i *AirgapRancherTestSuite) TestCreateAirgapRancher() {
 	i.cattleConfig = shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
-	i.rancherConfig, i.terraformConfig, i.terratestConfig = config.LoadTFPConfigs(i.cattleConfig)
+	i.rancherConfig, i.terraformConfig, i.terratestConfig, _ = config.LoadTFPConfigs(i.cattleConfig)
 
 	_, keyPath := rancher2.SetKeyPath(keypath.AirgapKeyPath, i.terratestConfig.PathToRepo, i.terraformConfig.Provider)
 	terraformOptions := framework.Setup(i.T(), i.terraformConfig, i.terratestConfig, keyPath)

--- a/tests/infrastructure/setup_proxy_rancher_test.go
+++ b/tests/infrastructure/setup_proxy_rancher_test.go
@@ -30,7 +30,7 @@ type ProxyRancherTestSuite struct {
 
 func (i *ProxyRancherTestSuite) TestCreateProxyRancher() {
 	i.cattleConfig = shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
-	i.rancherConfig, i.terraformConfig, i.terratestConfig = config.LoadTFPConfigs(i.cattleConfig)
+	i.rancherConfig, i.terraformConfig, i.terratestConfig, _ = config.LoadTFPConfigs(i.cattleConfig)
 
 	_, keyPath := rancher2.SetKeyPath(keypath.ProxyKeyPath, i.terratestConfig.PathToRepo, i.terraformConfig.Provider)
 	terraformOptions := framework.Setup(i.T(), i.terraformConfig, i.terratestConfig, keyPath)

--- a/tests/infrastructure/setup_rancher_ipv6_test.go
+++ b/tests/infrastructure/setup_rancher_ipv6_test.go
@@ -30,7 +30,7 @@ type RancherIPv6TestSuite struct {
 
 func (i *RancherIPv6TestSuite) TestCreateRancherIPv6() {
 	i.cattleConfig = shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
-	i.rancherConfig, i.terraformConfig, i.terratestConfig = config.LoadTFPConfigs(i.cattleConfig)
+	i.rancherConfig, i.terraformConfig, i.terratestConfig, _ = config.LoadTFPConfigs(i.cattleConfig)
 
 	_, keyPath := rancher2.SetKeyPath(keypath.IPv6KeyPath, i.terratestConfig.PathToRepo, i.terraformConfig.Provider)
 	terraformOptions := framework.Setup(i.T(), i.terraformConfig, i.terratestConfig, keyPath)

--- a/tests/infrastructure/setup_rancher_test.go
+++ b/tests/infrastructure/setup_rancher_test.go
@@ -31,7 +31,7 @@ type RancherTestSuite struct {
 
 func (i *RancherTestSuite) TestCreateRancher() {
 	i.cattleConfig = shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
-	i.rancherConfig, i.terraformConfig, i.terratestConfig = config.LoadTFPConfigs(i.cattleConfig)
+	i.rancherConfig, i.terraformConfig, i.terratestConfig, _ = config.LoadTFPConfigs(i.cattleConfig)
 
 	_, keyPath := rancher2.SetKeyPath(keypath.SanityKeyPath, i.terratestConfig.PathToRepo, i.terraformConfig.Provider)
 	terraformOptions := framework.Setup(i.T(), i.terraformConfig, i.terratestConfig, keyPath)

--- a/tests/infrastructure/setup_rke1_test.go
+++ b/tests/infrastructure/setup_rke1_test.go
@@ -25,7 +25,7 @@ type CreateRKE1ClusterTestSuite struct {
 }
 
 func (i *CreateRKE1ClusterTestSuite) TestCreateRKE1Cluster() {
-	i.rancherConfig, i.terraformConfig, i.terratestConfig = config.LoadTFPConfigs(i.cattleConfig)
+	i.rancherConfig, i.terraformConfig, i.terratestConfig, _ = config.LoadTFPConfigs(i.cattleConfig)
 
 	_, keyPath := rancher2.SetKeyPath(keypath.RKEKeyPath, i.terratestConfig.PathToRepo, i.terraformConfig.Provider)
 	terraformOptions := framework.Setup(i.T(), i.terraformConfig, i.terratestConfig, keyPath)

--- a/tests/infrastructure/upgradeRancher.go
+++ b/tests/infrastructure/upgradeRancher.go
@@ -19,7 +19,7 @@ func UpgradeAirgapRancher(t *testing.T, client *rancher.Client, bastion, registr
 	map[string]any, *terraform.Options, *terraform.Options) {
 	var err error
 
-	rancherConfig, terraformConfig, terratestConfig := config.LoadTFPConfigs(cattleConfig)
+	rancherConfig, terraformConfig, terratestConfig, _ := config.LoadTFPConfigs(cattleConfig)
 
 	terraformConfig.Standalone.UpgradeAirgapRancher = true
 
@@ -43,7 +43,7 @@ func UpgradeProxyRancher(t *testing.T, client *rancher.Client, proxyPrivateIP, p
 	map[string]any, *terraform.Options, *terraform.Options) {
 	var err error
 
-	rancherConfig, terraformConfig, terratestConfig := config.LoadTFPConfigs(cattleConfig)
+	rancherConfig, terraformConfig, terratestConfig, _ := config.LoadTFPConfigs(cattleConfig)
 
 	terraformConfig.Standalone.UpgradeProxyRancher = true
 
@@ -67,7 +67,7 @@ func UpgradeRancher(t *testing.T, client *rancher.Client, serverNodeOne string, 
 	map[string]any, *terraform.Options, *terraform.Options) {
 	var err error
 
-	rancherConfig, terraformConfig, terratestConfig := config.LoadTFPConfigs(cattleConfig)
+	rancherConfig, terraformConfig, terratestConfig, _ := config.LoadTFPConfigs(cattleConfig)
 
 	terraformConfig.Standalone.UpgradeRancher = true
 

--- a/tests/proxy/proxy_provisioning_test.go
+++ b/tests/proxy/proxy_provisioning_test.go
@@ -31,6 +31,7 @@ type TfpProxyProvisioningTestSuite struct {
 	rancherConfig              *rancher.Config
 	terraformConfig            *config.TerraformConfig
 	terratestConfig            *config.TerratestConfig
+	standaloneConfig           *config.Standalone
 	standaloneTerraformOptions *terraform.Options
 	terraformOptions           *terraform.Options
 	proxyBastion               string
@@ -46,7 +47,9 @@ func (p *TfpProxyProvisioningTestSuite) SetupSuite() {
 	p.session = testSession
 
 	p.client, p.proxyBastion, _, p.standaloneTerraformOptions, p.terraformOptions, p.cattleConfig = infrastructure.SetupProxyRancher(p.T(), p.session, keypath.ProxyKeyPath)
-	p.rancherConfig, p.terraformConfig, p.terratestConfig = config.LoadTFPConfigs(p.cattleConfig)
+	p.rancherConfig, p.terraformConfig, p.terratestConfig, p.standaloneConfig = config.LoadTFPConfigs(p.cattleConfig)
+
+	provisioning.VerifyRancherVersion(p.T(), p.rancherConfig.Host, p.standaloneConfig.RancherTagVersion)
 }
 
 func (p *TfpProxyProvisioningTestSuite) TestTfpNoProxyProvisioning() {
@@ -87,7 +90,7 @@ func (p *TfpProxyProvisioningTestSuite) TestTfpNoProxyProvisioning() {
 
 		provisioning.GetK8sVersion(p.T(), p.client, p.terratestConfig, p.terraformConfig, configs.DefaultK8sVersion, configMap)
 
-		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, terratest, _ := config.LoadTFPConfigs(configMap[0])
 
 		currentDate := time.Now().Format("2006-01-02 03:04PM")
 		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion + " " + currentDate
@@ -149,7 +152,7 @@ func (p *TfpProxyProvisioningTestSuite) TestTfpProxyProvisioning() {
 
 		provisioning.GetK8sVersion(p.T(), p.client, p.terratestConfig, p.terraformConfig, configs.DefaultK8sVersion, configMap)
 
-		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, terratest, _ := config.LoadTFPConfigs(configMap[0])
 
 		currentDate := time.Now().Format("2006-01-02 03:04PM")
 		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion + " " + currentDate

--- a/tests/rancher2/nodescaling/scale_hosted_test.go
+++ b/tests/rancher2/nodescaling/scale_hosted_test.go
@@ -43,7 +43,7 @@ func (s *ScaleHostedTestSuite) SetupSuite() {
 	s.client = client
 
 	s.cattleConfig = shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
-	s.rancherConfig, s.terraformConfig, s.terratestConfig = config.LoadTFPConfigs(s.cattleConfig)
+	s.rancherConfig, s.terraformConfig, s.terratestConfig, _ = config.LoadTFPConfigs(s.cattleConfig)
 
 	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, s.terratestConfig.PathToRepo, "")
 	terraformOptions := framework.Setup(s.T(), s.terraformConfig, s.terratestConfig, keyPath)

--- a/tests/rancher2/nodescaling/scale_test.go
+++ b/tests/rancher2/nodescaling/scale_test.go
@@ -43,7 +43,7 @@ func (s *ScaleTestSuite) SetupSuite() {
 	s.client = client
 
 	s.cattleConfig = shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
-	s.rancherConfig, s.terraformConfig, s.terratestConfig = config.LoadTFPConfigs(s.cattleConfig)
+	s.rancherConfig, s.terraformConfig, s.terratestConfig, _ = config.LoadTFPConfigs(s.cattleConfig)
 
 	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, s.terratestConfig.PathToRepo, "")
 	terraformOptions := framework.Setup(s.T(), s.terraformConfig, s.terratestConfig, keyPath)
@@ -81,7 +81,7 @@ func (s *ScaleTestSuite) TestTfpScale() {
 
 		provisioning.GetK8sVersion(s.T(), s.client, s.terratestConfig, s.terraformConfig, configs.DefaultK8sVersion, configMap)
 
-		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, terratest, _ := config.LoadTFPConfigs(configMap[0])
 
 		var scaledUpCount, scaledDownCount int64
 
@@ -146,7 +146,7 @@ func (s *ScaleTestSuite) TestTfpScaleDynamicInput() {
 
 		provisioning.GetK8sVersion(s.T(), s.client, s.terratestConfig, s.terraformConfig, configs.DefaultK8sVersion, configMap)
 
-		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, terratest, _ := config.LoadTFPConfigs(configMap[0])
 
 		tt.name = tt.name + " Module: " + s.terraformConfig.Module + " Kubernetes version: " + terratest.KubernetesVersion
 

--- a/tests/rancher2/os/os_test.go
+++ b/tests/rancher2/os/os_test.go
@@ -79,7 +79,7 @@ func (o *OSValidationTestSuite) SetupSuite() {
 	o.permutedConfigs, err = provisioning.UniquifyTerraform(permutedConfigs)
 	require.NoError(o.T(), err)
 
-	_, terraformConfig, terratestConfig := config.LoadTFPConfigs(o.permutedConfigs[0])
+	_, terraformConfig, terratestConfig, _ := config.LoadTFPConfigs(o.permutedConfigs[0])
 
 	o.awsCredentials = cloudcredentials.AmazonEC2CredentialConfig{
 		AccessKey:     terraformConfig.AWSCredentials.AWSAccessKey,
@@ -96,7 +96,7 @@ func (o *OSValidationTestSuite) TestDynamicOSValidation() {
 	//Batch configs so that not all AMIs run in parallel
 	configBatches := map[string][]map[string]any{}
 	for _, cattleConfig := range o.permutedConfigs {
-		_, terraformConfig, _ := config.LoadTFPConfigs(cattleConfig)
+		_, terraformConfig, _, _ := config.LoadTFPConfigs(cattleConfig)
 		configBatches[terraformConfig.AWSConfig.AMI] = append(configBatches[terraformConfig.AWSConfig.AMI], cattleConfig)
 	}
 
@@ -121,7 +121,7 @@ func (o *OSValidationTestSuite) TestDynamicOSValidation() {
 				cattleConfig, err = operations.ReplaceValue([]string{"terraform", "awsConfig", "awsVolumeType"}, *amiInfo.Images[0].BlockDeviceMappings[0].Ebs.VolumeType, cattleConfig)
 				require.NoError(o.T(), err)
 
-				_, terraformConfig, terratestConfig := config.LoadTFPConfigs(cattleConfig)
+				_, terraformConfig, terratestConfig, _ := config.LoadTFPConfigs(cattleConfig)
 
 				logrus.Infof("Provisioning Cluster Type: %s, "+"K8s Version: %s, "+"CNI: %s", terraformConfig.Module, terratestConfig.KubernetesVersion, terraformConfig.CNI)
 			}

--- a/tests/rancher2/provisioning/provision_custom_test.go
+++ b/tests/rancher2/provisioning/provision_custom_test.go
@@ -45,7 +45,7 @@ func (p *ProvisionCustomTestSuite) SetupSuite() {
 	p.client = client
 
 	p.cattleConfig = shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
-	p.rancherConfig, p.terraformConfig, p.terratestConfig = config.LoadTFPConfigs(p.cattleConfig)
+	p.rancherConfig, p.terraformConfig, p.terratestConfig, _ = config.LoadTFPConfigs(p.cattleConfig)
 
 	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, p.terratestConfig.PathToRepo, "")
 	terraformOptions := framework.Setup(p.T(), p.terraformConfig, p.terratestConfig, keyPath)
@@ -78,7 +78,7 @@ func (p *ProvisionCustomTestSuite) TestTfpProvisionCustom() {
 
 		provisioning.GetK8sVersion(p.T(), p.client, p.terratestConfig, p.terraformConfig, configs.DefaultK8sVersion, configMap)
 
-		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, terratest, _ := config.LoadTFPConfigs(configMap[0])
 
 		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion
 
@@ -123,7 +123,7 @@ func (p *ProvisionCustomTestSuite) TestTfpProvisionCustomDynamicInput() {
 
 		provisioning.GetK8sVersion(p.T(), p.client, p.terratestConfig, p.terraformConfig, configs.DefaultK8sVersion, configMap)
 
-		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, terratest, _ := config.LoadTFPConfigs(configMap[0])
 
 		tt.name = tt.name + " Module: " + p.terraformConfig.Module + " Kubernetes version: " + p.terratestConfig.KubernetesVersion
 

--- a/tests/rancher2/provisioning/provision_hosted_test.go
+++ b/tests/rancher2/provisioning/provision_hosted_test.go
@@ -41,7 +41,7 @@ func (p *ProvisionHostedTestSuite) SetupSuite() {
 	p.client = client
 
 	p.cattleConfig = shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
-	p.rancherConfig, p.terraformConfig, p.terratestConfig = config.LoadTFPConfigs(p.cattleConfig)
+	p.rancherConfig, p.terraformConfig, p.terratestConfig, _ = config.LoadTFPConfigs(p.cattleConfig)
 
 	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, p.terratestConfig.PathToRepo, "")
 	terraformOptions := framework.Setup(p.T(), p.terraformConfig, p.terratestConfig, keyPath)

--- a/tests/rancher2/provisioning/provision_import_test.go
+++ b/tests/rancher2/provisioning/provision_import_test.go
@@ -44,7 +44,7 @@ func (p *UpgradeImportedClusterTestSuite) SetupSuite() {
 	p.client = client
 
 	p.cattleConfig = shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
-	p.rancherConfig, p.terraformConfig, p.terratestConfig = config.LoadTFPConfigs(p.cattleConfig)
+	p.rancherConfig, p.terraformConfig, p.terratestConfig, _ = config.LoadTFPConfigs(p.cattleConfig)
 
 	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, p.terratestConfig.PathToRepo, "")
 	terraformOptions := framework.Setup(p.T(), p.terraformConfig, p.terratestConfig, keyPath)
@@ -74,7 +74,7 @@ func (p *UpgradeImportedClusterTestSuite) TestTfpUpgradeImportedCluster() {
 		_, err = operations.ReplaceValue([]string{"terraform", "module"}, tt.module, configMap[0])
 		require.NoError(p.T(), err)
 
-		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, terratest, _ := config.LoadTFPConfigs(configMap[0])
 
 		p.Run((tt.name), func() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, p.terratestConfig.PathToRepo, "")
@@ -114,7 +114,7 @@ func (p *UpgradeImportedClusterTestSuite) TestTfpUpgradeImportedClusterDynamicIn
 
 		provisioning.GetK8sVersion(p.T(), p.client, p.terratestConfig, p.terraformConfig, configs.DefaultK8sVersion, configMap)
 
-		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, terratest, _ := config.LoadTFPConfigs(configMap[0])
 
 		tt.name = tt.name + " Module: " + p.terraformConfig.Module + " Kubernetes version: " + p.terratestConfig.KubernetesVersion
 

--- a/tests/rancher2/provisioning/provision_test.go
+++ b/tests/rancher2/provisioning/provision_test.go
@@ -42,7 +42,7 @@ func (p *ProvisionTestSuite) SetupSuite() {
 	p.client = client
 
 	p.cattleConfig = shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
-	p.rancherConfig, p.terraformConfig, p.terratestConfig = config.LoadTFPConfigs(p.cattleConfig)
+	p.rancherConfig, p.terraformConfig, p.terratestConfig, _ = config.LoadTFPConfigs(p.cattleConfig)
 
 	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, p.terratestConfig.PathToRepo, "")
 	terraformOptions := framework.Setup(p.T(), p.terraformConfig, p.terratestConfig, keyPath)
@@ -73,7 +73,7 @@ func (p *ProvisionTestSuite) TestTfpProvision() {
 
 		provisioning.GetK8sVersion(p.T(), p.client, p.terratestConfig, p.terraformConfig, configs.DefaultK8sVersion, configMap)
 
-		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, terratest, _ := config.LoadTFPConfigs(configMap[0])
 
 		tt.name = tt.name + " Module: " + p.terraformConfig.Module + " Kubernetes version: " + terratest.KubernetesVersion
 
@@ -112,7 +112,7 @@ func (p *ProvisionTestSuite) TestTfpProvisionDynamicInput() {
 
 		provisioning.GetK8sVersion(p.T(), p.client, p.terratestConfig, p.terraformConfig, configs.DefaultK8sVersion, configMap)
 
-		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, terratest, _ := config.LoadTFPConfigs(configMap[0])
 
 		tt.name = tt.name + " Module: " + p.terraformConfig.Module + " Kubernetes version: " + terratest.KubernetesVersion
 

--- a/tests/rancher2/psact/psact_test.go
+++ b/tests/rancher2/psact/psact_test.go
@@ -42,7 +42,7 @@ func (p *PSACTTestSuite) SetupSuite() {
 	p.client = client
 
 	p.cattleConfig = shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
-	p.rancherConfig, p.terraformConfig, p.terratestConfig = config.LoadTFPConfigs(p.cattleConfig)
+	p.rancherConfig, p.terraformConfig, p.terratestConfig, _ = config.LoadTFPConfigs(p.cattleConfig)
 
 	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, p.terratestConfig.PathToRepo, "")
 	terraformOptions := framework.Setup(p.T(), p.terraformConfig, p.terratestConfig, keyPath)
@@ -79,7 +79,7 @@ func (p *PSACTTestSuite) TestTfpPSACT() {
 
 		provisioning.GetK8sVersion(p.T(), p.client, p.terratestConfig, p.terraformConfig, configs.DefaultK8sVersion, configMap)
 
-		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, terratest, _ := config.LoadTFPConfigs(configMap[0])
 
 		tt.name = tt.name + " Module: " + p.terraformConfig.Module + " Kubernetes version: " + terratest.KubernetesVersion
 

--- a/tests/rancher2/rbac/auth_test.go
+++ b/tests/rancher2/rbac/auth_test.go
@@ -44,7 +44,7 @@ func (r *AuthConfigTestSuite) SetupSuite() {
 	r.client = client
 
 	r.cattleConfig = shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
-	r.rancherConfig, r.terraformConfig, r.terratestConfig = config.LoadTFPConfigs(r.cattleConfig)
+	r.rancherConfig, r.terraformConfig, r.terratestConfig, _ = config.LoadTFPConfigs(r.cattleConfig)
 
 	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, r.terratestConfig.PathToRepo, "")
 	terraformOptions := framework.Setup(r.T(), r.terraformConfig, r.terratestConfig, keyPath)
@@ -74,7 +74,7 @@ func (r *AuthConfigTestSuite) TestTfpAuthConfig() {
 		_, err = operations.ReplaceValue([]string{"terraform", "authProvider"}, tt.authProvider, configMap[0])
 		require.NoError(r.T(), err)
 
-		rancher, terraform, _ := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, _, _ := config.LoadTFPConfigs(configMap[0])
 
 		r.Run((tt.name), func() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, r.terratestConfig.PathToRepo, "")
@@ -112,7 +112,7 @@ func (r *AuthConfigTestSuite) TestTfpAuthConfigDynamicInput() {
 		_, err = operations.ReplaceValue([]string{"terraform", "authProvider"}, r.terraformConfig.AuthProvider, configMap[0])
 		require.NoError(r.T(), err)
 
-		rancher, terraform, _ := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, _, _ := config.LoadTFPConfigs(configMap[0])
 
 		r.Run((tt.name), func() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, r.terratestConfig.PathToRepo, "")

--- a/tests/rancher2/rbac/rbac_test.go
+++ b/tests/rancher2/rbac/rbac_test.go
@@ -43,7 +43,7 @@ func (r *RBACTestSuite) SetupSuite() {
 	r.client = client
 
 	r.cattleConfig = shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
-	r.rancherConfig, r.terraformConfig, r.terratestConfig = config.LoadTFPConfigs(r.cattleConfig)
+	r.rancherConfig, r.terraformConfig, r.terratestConfig, _ = config.LoadTFPConfigs(r.cattleConfig)
 
 	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, r.terratestConfig.PathToRepo, "")
 	terraformOptions := framework.Setup(r.T(), r.terraformConfig, r.terratestConfig, keyPath)
@@ -75,7 +75,7 @@ func (r *RBACTestSuite) TestTfpRBAC() {
 
 		provisioning.GetK8sVersion(r.T(), r.client, r.terratestConfig, r.terraformConfig, configs.DefaultK8sVersion, configMap)
 
-		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, terratest, _ := config.LoadTFPConfigs(configMap[0])
 
 		tt.name = tt.name + " Module: " + r.terraformConfig.Module
 

--- a/tests/rancher2/recurring/recurring_test.go
+++ b/tests/rancher2/recurring/recurring_test.go
@@ -33,6 +33,7 @@ type TfpRancher2RecurringRunsTestSuite struct {
 	rancherConfig              *rancher.Config
 	terraformConfig            *config.TerraformConfig
 	terratestConfig            *config.TerratestConfig
+	standaloneConfig           *config.Standalone
 	standaloneTerraformOptions *terraform.Options
 	terraformOptions           *terraform.Options
 }
@@ -47,7 +48,9 @@ func (r *TfpRancher2RecurringRunsTestSuite) SetupSuite() {
 	r.session = testSession
 
 	r.client, _, r.standaloneTerraformOptions, r.terraformOptions, r.cattleConfig = infrastructure.SetupRancher(r.T(), r.session, keypath.SanityKeyPath)
-	r.rancherConfig, r.terraformConfig, r.terratestConfig = config.LoadTFPConfigs(r.cattleConfig)
+	r.rancherConfig, r.terraformConfig, r.terratestConfig, r.standaloneConfig = config.LoadTFPConfigs(r.cattleConfig)
+
+	provisioning.VerifyRancherVersion(r.T(), r.rancherConfig.Host, r.standaloneConfig.RancherTagVersion)
 }
 
 func (r *TfpRancher2RecurringRunsTestSuite) TestTfpRecurringProvisionCustomCluster() {
@@ -79,7 +82,7 @@ func (r *TfpRancher2RecurringRunsTestSuite) TestTfpRecurringProvisionCustomClust
 
 		provisioning.GetK8sVersion(r.T(), r.client, r.terratestConfig, r.terraformConfig, configs.DefaultK8sVersion, configMap)
 
-		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, terratest, _ := config.LoadTFPConfigs(configMap[0])
 
 		currentDate := time.Now().Format("2006-01-02 03:04PM")
 		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion + " " + currentDate
@@ -129,7 +132,7 @@ func (r *TfpRancher2RecurringRunsTestSuite) TestTfpRecurringProvisionImportedClu
 		_, err = operations.ReplaceValue([]string{"terraform", "module"}, tt.module, configMap[0])
 		require.NoError(r.T(), err)
 
-		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, terratest, _ := config.LoadTFPConfigs(configMap[0])
 
 		currentDate := time.Now().Format("2006-01-02 03:04PM")
 		tt.name = tt.name + " " + currentDate
@@ -193,7 +196,7 @@ func (r *TfpRancher2RecurringRunsTestSuite) TestTfpRecurringSnapshotRestore() {
 
 		provisioning.GetK8sVersion(r.T(), r.client, r.terratestConfig, r.terraformConfig, configs.DefaultK8sVersion, configMap)
 
-		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, terratest, _ := config.LoadTFPConfigs(configMap[0])
 
 		currentDate := time.Now().Format("2006-01-02 03:04PM")
 		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion + " " + currentDate

--- a/tests/rancher2/resources/build_module_test.go
+++ b/tests/rancher2/resources/build_module_test.go
@@ -28,7 +28,7 @@ func (r *BuildModuleTestSuite) TestBuildModule() {
 	defer cleanup.TFFilesCleanup(keyPath)
 
 	r.cattleConfig = shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
-	r.rancherConfig, r.terraformConfig, r.terratestConfig = config.LoadTFPConfigs(r.cattleConfig)
+	r.rancherConfig, r.terraformConfig, r.terratestConfig, _ = config.LoadTFPConfigs(r.cattleConfig)
 
 	configMap := []map[string]any{r.cattleConfig}
 

--- a/tests/rancher2/snapshot/snapshot_restore_test.go
+++ b/tests/rancher2/snapshot/snapshot_restore_test.go
@@ -44,7 +44,7 @@ func (s *SnapshotRestoreTestSuite) SetupSuite() {
 	s.client = client
 
 	s.cattleConfig = shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
-	s.rancherConfig, s.terraformConfig, s.terratestConfig = config.LoadTFPConfigs(s.cattleConfig)
+	s.rancherConfig, s.terraformConfig, s.terratestConfig, _ = config.LoadTFPConfigs(s.cattleConfig)
 
 	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, s.terratestConfig.PathToRepo, "")
 	terraformOptions := framework.Setup(s.T(), s.terraformConfig, s.terratestConfig, keyPath)
@@ -85,7 +85,7 @@ func (s *SnapshotRestoreTestSuite) TestTfpSnapshotRestore() {
 
 		provisioning.GetK8sVersion(s.T(), s.client, s.terratestConfig, s.terraformConfig, configs.DefaultK8sVersion, configMap)
 
-		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, terratest, _ := config.LoadTFPConfigs(configMap[0])
 
 		tt.name = tt.name + " Module: " + s.terraformConfig.Module + " Kubernetes version: " + terratest.KubernetesVersion
 

--- a/tests/rancher2/upgrading/kubernetes_hosted_test.go
+++ b/tests/rancher2/upgrading/kubernetes_hosted_test.go
@@ -42,7 +42,7 @@ func (k *KubernetesUpgradeHostedTestSuite) SetupSuite() {
 	k.client = client
 
 	k.cattleConfig = shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
-	k.rancherConfig, k.terraformConfig, k.terratestConfig = config.LoadTFPConfigs(k.cattleConfig)
+	k.rancherConfig, k.terraformConfig, k.terratestConfig, _ = config.LoadTFPConfigs(k.cattleConfig)
 
 	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, k.terratestConfig.PathToRepo, "")
 	terraformOptions := framework.Setup(k.T(), k.terraformConfig, k.terratestConfig, keyPath)

--- a/tests/rancher2/upgrading/kubernetes_upgrade_test.go
+++ b/tests/rancher2/upgrading/kubernetes_upgrade_test.go
@@ -42,7 +42,7 @@ func (k *KubernetesUpgradeTestSuite) SetupSuite() {
 	k.client = client
 
 	k.cattleConfig = shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
-	k.rancherConfig, k.terraformConfig, k.terratestConfig = config.LoadTFPConfigs(k.cattleConfig)
+	k.rancherConfig, k.terraformConfig, k.terratestConfig, _ = config.LoadTFPConfigs(k.cattleConfig)
 
 	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, k.terratestConfig.PathToRepo, "")
 	terraformOptions := framework.Setup(k.T(), k.terraformConfig, k.terratestConfig, keyPath)
@@ -73,7 +73,7 @@ func (k *KubernetesUpgradeTestSuite) TestTfpKubernetesUpgrade() {
 
 		provisioning.GetK8sVersion(k.T(), k.client, k.terratestConfig, k.terraformConfig, configs.SecondHighestVersion, configMap)
 
-		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, terratest, _ := config.LoadTFPConfigs(configMap[0])
 
 		tt.name = tt.name + " Module: " + k.terraformConfig.Module + " Kubernetes version: " + terratest.KubernetesVersion
 
@@ -115,7 +115,7 @@ func (k *KubernetesUpgradeTestSuite) TestTfpKubernetesUpgradeDynamicInput() {
 
 		provisioning.GetK8sVersion(k.T(), k.client, k.terratestConfig, k.terraformConfig, configs.DefaultK8sVersion, configMap)
 
-		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, terratest, _ := config.LoadTFPConfigs(configMap[0])
 
 		tt.name = tt.name + " Module: " + k.terraformConfig.Module + " Kubernetes version: " + terratest.KubernetesVersion
 

--- a/tests/registries/registries_test.go
+++ b/tests/registries/registries_test.go
@@ -29,6 +29,7 @@ type TfpRegistriesTestSuite struct {
 	rancherConfig              *rancher.Config
 	terraformConfig            *config.TerraformConfig
 	terratestConfig            *config.TerratestConfig
+	standaloneConfig           *config.Standalone
 	standaloneTerraformOptions *terraform.Options
 	terraformOptions           *terraform.Options
 	authRegistry               string
@@ -47,8 +48,9 @@ func (r *TfpRegistriesTestSuite) SetupSuite() {
 
 	r.client, r.authRegistry, r.nonAuthRegistry, r.globalRegistry, r.standaloneTerraformOptions, r.terraformOptions,
 		r.cattleConfig = infrastructure.SetupRegistryRancher(r.T(), r.session, keypath.RegistryKeyPath)
+	r.rancherConfig, r.terraformConfig, r.terratestConfig, _ = config.LoadTFPConfigs(r.cattleConfig)
 
-	r.rancherConfig, r.terraformConfig, r.terratestConfig = config.LoadTFPConfigs(r.cattleConfig)
+	provisioning.VerifyRancherVersion(r.T(), r.rancherConfig.Host, r.standaloneConfig.RancherTagVersion)
 }
 
 func (r *TfpRegistriesTestSuite) TestTfpGlobalRegistry() {
@@ -99,7 +101,7 @@ func (r *TfpRegistriesTestSuite) TestTfpGlobalRegistry() {
 
 		provisioning.GetK8sVersion(r.T(), r.client, r.terratestConfig, r.terraformConfig, configs.DefaultK8sVersion, configMap)
 
-		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, terratest, _ := config.LoadTFPConfigs(configMap[0])
 
 		currentDate := time.Now().Format("2006-01-02 03:04PM")
 		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion + " " + currentDate
@@ -161,7 +163,7 @@ func (r *TfpRegistriesTestSuite) TestTfpAuthenticatedRegistry() {
 
 		provisioning.GetK8sVersion(r.T(), r.client, r.terratestConfig, r.terraformConfig, configs.DefaultK8sVersion, configMap)
 
-		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, terratest, _ := config.LoadTFPConfigs(configMap[0])
 
 		currentDate := time.Now().Format("2006-01-02 03:04PM")
 		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion + " " + currentDate
@@ -229,7 +231,7 @@ func (r *TfpRegistriesTestSuite) TestTfpNonAuthenticatedRegistry() {
 
 		provisioning.GetK8sVersion(r.T(), r.client, r.terratestConfig, r.terraformConfig, configs.DefaultK8sVersion, configMap)
 
-		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, terratest, _ := config.LoadTFPConfigs(configMap[0])
 
 		currentDate := time.Now().Format("2006-01-02 03:04PM")
 		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion + " " + currentDate
@@ -298,7 +300,7 @@ func (r *TfpRegistriesTestSuite) TestTfpECRRegistry() {
 
 		provisioning.GetK8sVersion(r.T(), r.client, r.terratestConfig, r.terraformConfig, configs.DefaultK8sVersion, configMap)
 
-		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, terratest, _ := config.LoadTFPConfigs(configMap[0])
 
 		currentDate := time.Now().Format("2006-01-02 03:04PM")
 		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion + " " + currentDate

--- a/tests/rke/rke_provider_test.go
+++ b/tests/rke/rke_provider_test.go
@@ -34,7 +34,7 @@ func (t *RKEProviderTestSuite) TearDownSuite() {
 }
 
 func (t *RKEProviderTestSuite) TestCreateRKECluster() {
-	t.rancherConfig, t.terraformConfig, t.terratestConfig = config.LoadTFPConfigs(t.cattleConfig)
+	t.rancherConfig, t.terraformConfig, t.terratestConfig, _ = config.LoadTFPConfigs(t.cattleConfig)
 
 	_, keyPath := rancher2.SetKeyPath(keypath.RKEKeyPath, t.terratestConfig.PathToRepo, t.terraformConfig.Provider)
 	terraformOptions := framework.Setup(t.T(), t.terraformConfig, t.terratestConfig, keyPath)

--- a/tests/sanity/sanity_provisioning_rke1_test.go
+++ b/tests/sanity/sanity_provisioning_rke1_test.go
@@ -28,6 +28,7 @@ type TfpSanityRKE1ProvisioningTestSuite struct {
 	rancherConfig              *rancher.Config
 	terraformConfig            *config.TerraformConfig
 	terratestConfig            *config.TerratestConfig
+	standaloneConfig           *config.Standalone
 	standaloneTerraformOptions *terraform.Options
 	terraformOptions           *terraform.Options
 }
@@ -42,7 +43,9 @@ func (s *TfpSanityRKE1ProvisioningTestSuite) SetupSuite() {
 	s.session = testSession
 
 	s.client, _, s.standaloneTerraformOptions, s.terraformOptions, s.cattleConfig = infrastructure.SetupRancher(s.T(), s.session, keypath.SanityKeyPath)
-	s.rancherConfig, s.terraformConfig, s.terratestConfig = config.LoadTFPConfigs(s.cattleConfig)
+	s.rancherConfig, s.terraformConfig, s.terratestConfig, s.standaloneConfig = config.LoadTFPConfigs(s.cattleConfig)
+
+	provisioning.VerifyRancherVersion(s.T(), s.rancherConfig.Host, s.standaloneConfig.RancherTagVersion)
 }
 
 func (s *TfpSanityRKE1ProvisioningTestSuite) TestTfpRKE1ProvisioningSanity() {
@@ -77,7 +80,7 @@ func (s *TfpSanityRKE1ProvisioningTestSuite) TestTfpRKE1ProvisioningSanity() {
 
 		provisioning.GetK8sVersion(s.T(), s.client, s.terratestConfig, s.terraformConfig, configs.DefaultK8sVersion, configMap)
 
-		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, terratest, _ := config.LoadTFPConfigs(configMap[0])
 
 		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion
 

--- a/tests/sanity/sanity_provisioning_test.go
+++ b/tests/sanity/sanity_provisioning_test.go
@@ -31,6 +31,7 @@ type TfpSanityProvisioningTestSuite struct {
 	rancherConfig              *rancher.Config
 	terraformConfig            *config.TerraformConfig
 	terratestConfig            *config.TerratestConfig
+	standaloneConfig           *config.Standalone
 	standaloneTerraformOptions *terraform.Options
 	terraformOptions           *terraform.Options
 }
@@ -45,7 +46,9 @@ func (s *TfpSanityProvisioningTestSuite) SetupSuite() {
 	s.session = testSession
 
 	s.client, _, s.standaloneTerraformOptions, s.terraformOptions, s.cattleConfig = infrastructure.SetupRancher(s.T(), s.session, keypath.SanityKeyPath)
-	s.rancherConfig, s.terraformConfig, s.terratestConfig = config.LoadTFPConfigs(s.cattleConfig)
+	s.rancherConfig, s.terraformConfig, s.terratestConfig, s.standaloneConfig = config.LoadTFPConfigs(s.cattleConfig)
+
+	provisioning.VerifyRancherVersion(s.T(), s.rancherConfig.Host, s.standaloneConfig.RancherTagVersion)
 }
 
 func (s *TfpSanityProvisioningTestSuite) TestTfpProvisioningSanity() {
@@ -83,7 +86,7 @@ func (s *TfpSanityProvisioningTestSuite) TestTfpProvisioningSanity() {
 
 		provisioning.GetK8sVersion(s.T(), s.client, s.terratestConfig, s.terraformConfig, configs.DefaultK8sVersion, configMap)
 
-		rancher, terraform, terratest := config.LoadTFPConfigs(configMap[0])
+		rancher, terraform, terratest, _ := config.LoadTFPConfigs(configMap[0])
 
 		currentDate := time.Now().Format("2006-01-02 03:04PM")
 		tt.name = tt.name + " Kubernetes version: " + terratest.KubernetesVersion + " " + currentDate


### PR DESCRIPTION
In recent test runs, there have been times where the requested chart to upgrade rancher to fails to be pulled and ultimately results in no server upgrade occurring.  This PR aims to enhance our checks to verify the expected Rancher server version to prevent "false" positives in the future