### PR TITLE
Update staging registry UI to be Prime-like

### DIFF
--- a/framework/set/resources/airgap/rancher/setup.sh
+++ b/framework/set/resources/airgap/rancher/setup.sh
@@ -46,6 +46,10 @@ if [ "$CERT_TYPE" == "self-signed" ]; then
                                                                                   --set systemDefaultRegistry=${REGISTRY} \
                                                                                   --set 'extraEnv[0].name=CATTLE_AGENT_IMAGE' \
                                                                                   --set "extraEnv[0].value=${REGISTRY}/${RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}" \
+                                                                                  --set 'extraEnv[1].name=RANCHER_VERSION_TYPE' \
+                                                                                  --set 'extraEnv[1].value=prime' \
+                                                                                  --set 'extraEnv[2].name=CATTLE_BASE_UI_BRAND' \
+                                                                                  --set 'extraEnv[2].value=suse' \
                                                                                   --set agentTLSMode=system-store \
                                                                                   --set bootstrapPassword=${BOOTSTRAP_PASSWORD} \
                                                                                   --devel
@@ -74,6 +78,10 @@ elif [ "$CERT_TYPE" == "lets-encrypt" ]; then
                                                                                      --set letsEncrypt.email=${LETS_ENCRYPT_EMAIL} \
                                                                                      --set 'extraEnv[0].name=CATTLE_AGENT_IMAGE' \
                                                                                      --set "extraEnv[0].value=${REGISTRY}/${RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}" \
+                                                                                     --set 'extraEnv[1].name=RANCHER_VERSION_TYPE' \
+                                                                                     --set 'extraEnv[1].value=prime' \
+                                                                                     --set 'extraEnv[2].name=CATTLE_BASE_UI_BRAND' \
+                                                                                     --set 'extraEnv[2].value=suse' \
                                                                                      --set agentTLSMode=system-store \
                                                                                      --set bootstrapPassword=${BOOTSTRAP_PASSWORD} \
                                                                                      --devel

--- a/framework/set/resources/airgap/rancher/upgrade.sh
+++ b/framework/set/resources/airgap/rancher/upgrade.sh
@@ -27,6 +27,10 @@ if [ "$CERT_TYPE" == "self-signed" ]; then
                                                                                   --set systemDefaultRegistry=${REGISTRY} \
                                                                                   --set 'extraEnv[0].name=CATTLE_AGENT_IMAGE' \
                                                                                   --set "extraEnv[0].value=${REGISTRY}/${RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}" \
+                                                                                  --set 'extraEnv[1].name=RANCHER_VERSION_TYPE' \
+                                                                                  --set 'extraEnv[1].value=prime' \
+                                                                                  --set 'extraEnv[2].name=CATTLE_BASE_UI_BRAND' \
+                                                                                  --set 'extraEnv[2].value=suse' \
                                                                                   --set agentTLSMode=system-store \
                                                                                   --devel
 
@@ -53,6 +57,10 @@ elif [ "$CERT_TYPE" == "lets-encrypt" ]; then
                                                                                      --set letsEncrypt.ingress.class=nginx \
                                                                                      --set 'extraEnv[0].name=CATTLE_AGENT_IMAGE' \
                                                                                      --set "extraEnv[0].value=${REGISTRY}/${RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}" \
+                                                                                     --set 'extraEnv[1].name=RANCHER_VERSION_TYPE' \
+                                                                                     --set 'extraEnv[1].value=prime' \
+                                                                                     --set 'extraEnv[2].name=CATTLE_BASE_UI_BRAND' \
+                                                                                     --set 'extraEnv[2].value=suse' \
                                                                                      --set agentTLSMode=system-store \
                                                                                      --devel
     else

--- a/framework/set/resources/proxy/rancher/setup.sh
+++ b/framework/set/resources/proxy/rancher/setup.sh
@@ -64,6 +64,10 @@ if [ "$CERT_TYPE" == "self-signed" ]; then
                                                                                     --set rancherImage=${RANCHER_IMAGE} \
                                                                                     --set 'extraEnv[0].name=CATTLE_AGENT_IMAGE' \
                                                                                     --set "extraEnv[0].value=${RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}" \
+                                                                                    --set 'extraEnv[1].name=RANCHER_VERSION_TYPE' \
+                                                                                    --set 'extraEnv[1].value=prime' \
+                                                                                    --set 'extraEnv[2].name=CATTLE_BASE_UI_BRAND' \
+                                                                                    --set 'extraEnv[2].value=suse' \
                                                                                     --set proxy="http://${BASTION}:${PROXY_PORT}" \
                                                                                     --set noProxy="${NO_PROXY}" \
                                                                                     --set agentTLSMode=system-store \
@@ -94,6 +98,10 @@ elif [ "$CERT_TYPE" == "lets-encrypt" ]; then
                                                                                      --set letsEncrypt.ingress.class=nginx \
                                                                                      --set 'extraEnv[0].name=CATTLE_AGENT_IMAGE' \
                                                                                      --set "extraEnv[0].value=${RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}" \
+                                                                                     --set 'extraEnv[1].name=RANCHER_VERSION_TYPE' \
+                                                                                     --set 'extraEnv[1].value=prime' \
+                                                                                     --set 'extraEnv[2].name=CATTLE_BASE_UI_BRAND' \
+                                                                                     --set 'extraEnv[2].value=suse' \
                                                                                      --set proxy="http://${BASTION}:${PROXY_PORT}" \
                                                                                      --set noProxy="${NO_PROXY}" \
                                                                                      --set agentTLSMode=system-store \

--- a/framework/set/resources/proxy/rancher/upgrade.sh
+++ b/framework/set/resources/proxy/rancher/upgrade.sh
@@ -27,6 +27,10 @@ if [ "$CERT_TYPE" == "self-signed" ]; then
                                                                                     --set rancherImage=${RANCHER_IMAGE} \
                                                                                     --set 'extraEnv[0].name=CATTLE_AGENT_IMAGE' \
                                                                                     --set "extraEnv[0].value=${RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}" \
+                                                                                    --set 'extraEnv[1].name=RANCHER_VERSION_TYPE' \
+                                                                                    --set 'extraEnv[1].value=prime' \
+                                                                                    --set 'extraEnv[2].name=CATTLE_BASE_UI_BRAND' \
+                                                                                    --set 'extraEnv[2].value=suse' \
                                                                                     --set proxy="http://${BASTION}:${PROXY_PORT}" \
                                                                                     --set noProxy="${NO_PROXY}" \
                                                                                     --set agentTLSMode=system-store \
@@ -55,6 +59,10 @@ elif [ "$CERT_TYPE" == "lets-encrypt" ]; then
                                                                                      --set letsEncrypt.ingress.class=nginx \
                                                                                      --set 'extraEnv[0].name=CATTLE_AGENT_IMAGE' \
                                                                                      --set "extraEnv[0].value=${RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}" \
+                                                                                     --set 'extraEnv[1].name=RANCHER_VERSION_TYPE' \
+                                                                                     --set 'extraEnv[1].value=prime' \
+                                                                                     --set 'extraEnv[2].name=CATTLE_BASE_UI_BRAND' \
+                                                                                     --set 'extraEnv[2].value=suse' \
                                                                                      --set proxy="http://${BASTION}:${PROXY_PORT}" \
                                                                                      --set noProxy="${NO_PROXY}" \
                                                                                      --set agentTLSMode=system-store \

--- a/framework/set/resources/registries/rancher/setup.sh
+++ b/framework/set/resources/registries/rancher/setup.sh
@@ -57,6 +57,10 @@ if [ "$CERT_TYPE" == "self-signed" ]; then
                                                                                     --set rancherImage=${REGISTRY}/${RANCHER_IMAGE} \
                                                                                     --set 'extraEnv[0].name=CATTLE_AGENT_IMAGE' \
                                                                                     --set "extraEnv[0].value=${RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}" \
+                                                                                    --set 'extraEnv[1].name=RANCHER_VERSION_TYPE' \
+                                                                                    --set 'extraEnv[1].value=prime' \
+                                                                                    --set 'extraEnv[2].name=CATTLE_BASE_UI_BRAND' \
+                                                                                    --set 'extraEnv[2].value=suse' \
                                                                                     --set systemDefaultRegistry=${REGISTRY} \
                                                                                     --set agentTLSMode=system-store \
                                                                                     --set bootstrapPassword=${BOOTSTRAP_PASSWORD} \
@@ -85,6 +89,10 @@ elif [ "$CERT_TYPE" == "lets-encrypt" ]; then
                                                                                      --set letsEncrypt.ingress.class=nginx \
                                                                                      --set 'extraEnv[0].name=CATTLE_AGENT_IMAGE' \
                                                                                      --set "extraEnv[0].value=${RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}" \
+                                                                                     --set 'extraEnv[1].name=RANCHER_VERSION_TYPE' \
+                                                                                     --set 'extraEnv[1].value=prime' \
+                                                                                     --set 'extraEnv[2].name=CATTLE_BASE_UI_BRAND' \
+                                                                                     --set 'extraEnv[2].value=suse' \
                                                                                      --set systemDefaultRegistry=${REGISTRY} \
                                                                                      --set agentTLSMode=system-store \
                                                                                      --set bootstrapPassword=${BOOTSTRAP_PASSWORD} \

--- a/framework/set/resources/sanity/rancher/setup.sh
+++ b/framework/set/resources/sanity/rancher/setup.sh
@@ -56,6 +56,10 @@ if [ "$CERT_TYPE" == "self-signed" ]; then
                                                                                      --set rancherImage=${RANCHER_IMAGE} \
                                                                                      --set 'extraEnv[0].name=CATTLE_AGENT_IMAGE' \
                                                                                      --set "extraEnv[0].value=${RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}" \
+                                                                                     --set 'extraEnv[1].name=RANCHER_VERSION_TYPE' \
+                                                                                     --set 'extraEnv[1].value=prime' \
+                                                                                     --set 'extraEnv[2].name=CATTLE_BASE_UI_BRAND' \
+                                                                                     --set 'extraEnv[2].value=suse' \
                                                                                      --set agentTLSMode=system-store \
                                                                                      --set bootstrapPassword=${BOOTSTRAP_PASSWORD} \
                                                                                      --devel
@@ -81,6 +85,10 @@ elif [ "$CERT_TYPE" == "lets-encrypt" ]; then
                                                                                      --set letsEncrypt.ingress.class=nginx \
                                                                                      --set 'extraEnv[0].name=CATTLE_AGENT_IMAGE' \
                                                                                      --set "extraEnv[0].value=${RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}" \
+                                                                                     --set 'extraEnv[1].name=RANCHER_VERSION_TYPE' \
+                                                                                     --set 'extraEnv[1].value=prime' \
+                                                                                     --set 'extraEnv[2].name=CATTLE_BASE_UI_BRAND' \
+                                                                                     --set 'extraEnv[2].value=suse' \
                                                                                      --set agentTLSMode=system-store \
                                                                                      --set bootstrapPassword=${BOOTSTRAP_PASSWORD} \
                                                                                      --devel

--- a/framework/set/resources/sanity/rancher/upgrade.sh
+++ b/framework/set/resources/sanity/rancher/upgrade.sh
@@ -24,6 +24,10 @@ if [ "$CERT_TYPE" == "self-signed" ]; then
                                                                                     --set rancherImage=${RANCHER_IMAGE} \
                                                                                     --set 'extraEnv[0].name=CATTLE_AGENT_IMAGE' \
                                                                                     --set "extraEnv[0].value=${RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}" \
+                                                                                    --set 'extraEnv[1].name=RANCHER_VERSION_TYPE' \
+                                                                                    --set 'extraEnv[1].value=prime' \
+                                                                                    --set 'extraEnv[2].name=CATTLE_BASE_UI_BRAND' \
+                                                                                    --set 'extraEnv[2].value=suse' \
                                                                                     --set agentTLSMode=system-store \
                                                                                     --devel
 
@@ -48,6 +52,10 @@ elif [ "$CERT_TYPE" == "lets-encrypt" ]; then
                                                                                      --set letsEncrypt.ingress.class=nginx \
                                                                                      --set 'extraEnv[0].name=CATTLE_AGENT_IMAGE' \
                                                                                      --set "extraEnv[0].value=${RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}" \
+                                                                                     --set 'extraEnv[1].name=RANCHER_VERSION_TYPE' \
+                                                                                     --set 'extraEnv[1].value=prime' \
+                                                                                     --set 'extraEnv[2].name=CATTLE_BASE_UI_BRAND' \
+                                                                                     --set 'extraEnv[2].value=suse' \
                                                                                      --set agentTLSMode=system-store \
                                                                                      --devel
     else


### PR DESCRIPTION
### Issue: N/A

### Description
Testing the staging registry has a community Rancher UI by default. While not ideal, this PR tries to mimic Prime UI by modifying the environment variables to mirror what Prime does. As we cannot control what images are pushed into a staging registry, this is the next best thing.