### PR TITLE
Fixing Jenkins path in import tests + general cleanup

### DIFF
--- a/framework/set/provisioning/imported/importNodes.go
+++ b/framework/set/provisioning/imported/importNodes.go
@@ -20,7 +20,7 @@ import (
 
 // importNodes is a function that will import the nodes to the cluster
 func importNodes(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig, nodeOnePublicDNS, kubeConfig, importCommand string) error {
-	userDir, _ := rancher2.SetKeyPath(keypath.AirgapKeyPath, terratestConfig.PathToRepo, terraformConfig.Provider)
+	userDir, _ := rancher2.SetKeyPath(keypath.RancherKeyPath, terratestConfig.PathToRepo, terraformConfig.Provider)
 
 	scriptPath := filepath.Join(userDir, terratestConfig.PathToRepo, "/framework/set/provisioning/imported/import-nodes.sh")
 
@@ -59,14 +59,14 @@ func importNodes(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfi
 
 	var dependsOnServer string
 
-	if strings.Contains(terraformConfig.Module, defaults.Import) && !strings.Contains(terraformConfig.Module, clustertypes.RKE1) &&
-		!strings.Contains(terraformConfig.Module, clustertypes.WINDOWS) {
+	switch terraformConfig.Module {
+	case modules.ImportEC2RKE2, modules.ImportEC2K3s, modules.ImportVsphereRKE2, modules.ImportVsphereK3s:
 		addServerTwoName := addServer + terraformConfig.ResourcePrefix + `_` + serverTwo
 		addServerThreeName := addServer + terraformConfig.ResourcePrefix + `_` + serverThree
 		dependsOnServer = `[` + defaults.NullResource + `.` + addServerTwoName + `, ` + defaults.NullResource + `.` + addServerThreeName + `]`
-	} else if terraformConfig.Module == modules.ImportEC2RKE2Windows2019 || terraformConfig.Module == modules.ImportEC2RKE2Windows2022 {
+	case modules.ImportEC2RKE2Windows2019, modules.ImportEC2RKE2Windows2022:
 		dependsOnServer = `[` + defaults.TimeSleep + `.` + defaults.TimeSleep + `-` + terraformConfig.ResourcePrefix + `-import_wins` + `]`
-	} else {
+	case modules.ImportEC2RKE1, modules.ImportVsphereRKE1:
 		dependsOnServer = `[` + defaults.RKECluster + `.` + terraformConfig.ResourcePrefix + `]`
 	}
 

--- a/framework/set/provisioning/imported/importedRKE2K3SConfig.go
+++ b/framework/set/provisioning/imported/importedRKE2K3SConfig.go
@@ -124,7 +124,8 @@ func getProviderIPAddresses(terraformConfig *config.TerraformConfig, terratestCo
 	}
 
 	for _, instance := range instances {
-		if terraformConfig.Provider == defaults.Aws {
+		switch terraformConfig.Provider {
+		case defaults.Aws:
 			aws.CreateAWSInstances(rootBody, terraformConfig, terratestConfig, instance)
 			rootBody.AppendNewline()
 
@@ -132,7 +133,7 @@ func getProviderIPAddresses(terraformConfig *config.TerraformConfig, terratestCo
 			nodeOnePublicIP = fmt.Sprintf("${%s.%s.public_ip}", defaults.AwsInstance, serverOneName)
 			nodeTwoPublicIP = fmt.Sprintf("${%s.%s.public_ip}", defaults.AwsInstance, serverTwoName)
 			nodeThreePublicIP = fmt.Sprintf("${%s.%s.public_ip}", defaults.AwsInstance, serverThreeName)
-		} else if terraformConfig.Provider == defaults.Vsphere {
+		case defaults.Vsphere:
 			vsphere.CreateVsphereVirtualMachine(rootBody, terraformConfig, terratestConfig, instance)
 			rootBody.AppendNewline()
 

--- a/framework/set/provisioning/imported/nullresource/importNullResource.go
+++ b/framework/set/provisioning/imported/nullresource/importNullResource.go
@@ -35,9 +35,10 @@ func CreateImportedNullResource(rootBody *hclwrite.Body, terraformConfig *config
 
 	connectionBlockBody.SetAttributeValue(defaults.Type, cty.StringVal(defaults.Ssh))
 
-	if terraformConfig.Provider == defaults.Aws {
+	switch terraformConfig.Provider {
+	case defaults.Aws:
 		connectionBlockBody.SetAttributeValue(defaults.User, cty.StringVal(terraformConfig.AWSConfig.AWSUser))
-	} else if terraformConfig.Provider == defaults.Vsphere {
+	case defaults.Vsphere:
 		connectionBlockBody.SetAttributeValue(defaults.User, cty.StringVal(terraformConfig.VsphereConfig.VsphereUser))
 	}
 
@@ -53,9 +54,10 @@ func CreateImportedNullResource(rootBody *hclwrite.Body, terraformConfig *config
 	serverThreeName := terraformConfig.ResourcePrefix + `_` + serverThree
 
 	var dependsOnServer string
-	if terraformConfig.Provider == defaults.Aws {
+	switch terraformConfig.Provider {
+	case defaults.Aws:
 		dependsOnServer = `[` + defaults.AwsInstance + `.` + serverOneName + `, ` + defaults.AwsInstance + `.` + serverTwoName + `, ` + defaults.AwsInstance + `.` + serverThreeName + `]`
-	} else if terraformConfig.Provider == defaults.Vsphere {
+	case defaults.Vsphere:
 		dependsOnServer = `[` + defaults.VsphereVirtualMachine + `.` + serverOneName + `, ` + defaults.VsphereVirtualMachine + `.` + serverTwoName + `, ` + defaults.VsphereVirtualMachine + `.` + serverThreeName + `]`
 	}
 

--- a/framework/set/resources/imported/addWindowsNode.go
+++ b/framework/set/resources/imported/addWindowsNode.go
@@ -8,18 +8,17 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/keypath"
 	"github.com/rancher/tfp-automation/framework/set/defaults"
 	"github.com/rancher/tfp-automation/framework/set/provisioning/imported/nullresource"
+	"github.com/rancher/tfp-automation/framework/set/resources/rancher2"
 	"github.com/zclconf/go-cty/cty"
 )
 
 // AddWindowsNodeToImportedCluster is a helper function that will add an additional Windows node to the initial server.
 func AddWindowsNodeToImportedCluster(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig,
 	serverOnePrivateIP, windowsNodePublicDNS, token string) error {
-	userDir, err := os.UserHomeDir()
-	if err != nil {
-		return err
-	}
+	userDir, _ := rancher2.SetKeyPath(keypath.RancherKeyPath, terratestConfig.PathToRepo, terraformConfig.Provider)
 
 	scriptPath := filepath.Join(userDir, terratestConfig.PathToRepo, "/framework/set/resources/rke2/add-wins.ps1")
 

--- a/framework/set/resources/imported/createRKE2K3SCluster.go
+++ b/framework/set/resources/imported/createRKE2K3SCluster.go
@@ -9,8 +9,10 @@ import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/defaults/clustertypes"
+	"github.com/rancher/tfp-automation/defaults/keypath"
 	"github.com/rancher/tfp-automation/framework/set/defaults"
 	"github.com/rancher/tfp-automation/framework/set/provisioning/imported/nullresource"
+	"github.com/rancher/tfp-automation/framework/set/resources/rancher2"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -29,12 +31,9 @@ const (
 // CreateRKE2K3SImportedCluster is a helper function that will create the RKE2/K3S cluster to be imported into Rancher.
 func CreateRKE2K3SImportedCluster(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig,
 	serverOnePublicIP, serverOnePrivateIP, serverTwoPublicIP, serverThreePublicIP, token string) error {
-	userDir, err := os.UserHomeDir()
-	if err != nil {
-		return err
-	}
-
 	var serverScriptPath, newServersScriptPath string
+
+	userDir, _ := rancher2.SetKeyPath(keypath.RancherKeyPath, terratestConfig.PathToRepo, terraformConfig.Provider)
 
 	if strings.Contains(terraformConfig.Module, clustertypes.K3S) && strings.Contains(terraformConfig.Module, defaults.Import) {
 		serverScriptPath = filepath.Join(userDir, terratestConfig.PathToRepo, "/framework/set/resources/k3s/init-server.sh")


### PR DESCRIPTION
### Issue: N/A

### Description
The import cluster module-based tests are failing specifically in Jenkins. Looking deeper into it, this is because we were using the outdated method to get the user directory. Locally and GHA are fine with that method, but Jenkins specifically would fail.

Updated to the method in which all of them will work fine. Additionally, did some general cleanup.