### PR TITLE
Add local cluster checks before setting up Rancher

### DIFF
--- a/framework/set/resources/airgap/rancher/setup.sh
+++ b/framework/set/resources/airgap/rancher/setup.sh
@@ -15,6 +15,35 @@ RANCHER_AGENT_IMAGE=${12}
 
 set -ex
 
+checkClusterStatus() {
+    EXPECTED_NODES=3
+    TIMEOUT=300
+    INTERVAL=10
+    ELAPSED=0
+
+    while true; do
+        TOTAL_NODES=$(kubectl get nodes --no-headers | wc -l)
+        READY_NODES=$(kubectl get nodes --no-headers | awk '$2 == "Ready"' | wc -l)
+
+        if [ "$READY_NODES" -ne "$EXPECTED_NODES" ]; then
+            echo "Waiting for all $EXPECTED_NODES nodes to be Ready...$READY_NODES/$TOTAL_NODES Ready"
+            sleep $INTERVAL
+
+            ELAPSED=$((ELAPSED + INTERVAL))
+
+            if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+                echo "Timeout reached: Not all nodes are Ready after $TIMEOUT seconds."
+                exit 1
+            fi
+        else
+            echo "All nodes are in status Ready!"
+            break
+        fi
+    done
+}
+
+checkClusterStatus
+
 echo "Installing Helm"
 curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
 chmod +x get_helm.sh

--- a/framework/set/resources/airgap/rancher/setupAirgapRancher.go
+++ b/framework/set/resources/airgap/rancher/setupAirgapRancher.go
@@ -32,7 +32,7 @@ func CreateAirgapRancher(file *os.File, newFile *hclwrite.File, rootBody *hclwri
 
 	_, provisionerBlockBody := rke2.SSHNullResource(rootBody, terraformConfig, rke2BastionPublicDNS, installRancher)
 
-	command := "bash -c '/tmp/setup.sh " + terraformConfig.Standalone.RancherChartRepository + " " +
+	command := "/tmp/setup.sh " + terraformConfig.Standalone.RancherChartRepository + " " +
 		terraformConfig.Standalone.Repo + " " + terraformConfig.Standalone.CertManagerVersion + " " +
 		terraformConfig.Standalone.CertType + " " + terraformConfig.Standalone.RancherHostname + " " +
 		terraformConfig.Standalone.AirgapInternalFQDN + " " + terraformConfig.Standalone.RancherTagVersion + " " +
@@ -43,10 +43,10 @@ func CreateAirgapRancher(file *os.File, newFile *hclwrite.File, rootBody *hclwri
 		command += " " + terraformConfig.Standalone.RancherAgentImage
 	}
 
-	command += " || true'"
+	command += " || true"
 
 	provisionerBlockBody.SetAttributeValue(defaults.Inline, cty.ListVal([]cty.Value{
-		cty.StringVal("printf '" + string(scriptContent) + "' > /tmp/setup.sh"),
+		cty.StringVal("cat <<'EOF' > /tmp/setup.sh\n" + string(scriptContent) + "\nEOF"),
 		cty.StringVal("chmod +x /tmp/setup.sh"),
 		cty.StringVal(command),
 	}))

--- a/framework/set/resources/proxy/rancher/createRancher.go
+++ b/framework/set/resources/proxy/rancher/createRancher.go
@@ -37,7 +37,7 @@ func CreateProxiedRancher(file *os.File, newFile *hclwrite.File, rootBody *hclwr
 		terraformConfig.Standalone.RancherHostname = linodeNodeBalancerHostname
 	}
 
-	command := "bash -c '/tmp/setup.sh " + terraformConfig.Standalone.RancherChartRepository + " " +
+	command := "/tmp/setup.sh " + terraformConfig.Standalone.RancherChartRepository + " " +
 		terraformConfig.Standalone.Repo + " " + terraformConfig.Standalone.CertManagerVersion + " " +
 		terraformConfig.Standalone.CertType + " " + terraformConfig.Standalone.RancherHostname + " " +
 		terraformConfig.Standalone.RancherTagVersion + " " + terraformConfig.Standalone.ChartVersion + " " +
@@ -47,10 +47,10 @@ func CreateProxiedRancher(file *os.File, newFile *hclwrite.File, rootBody *hclwr
 		command += " " + terraformConfig.Standalone.RancherAgentImage
 	}
 
-	command += " || true'"
+	command += " || true"
 
 	provisionerBlockBody.SetAttributeValue(defaults.Inline, cty.ListVal([]cty.Value{
-		cty.StringVal("printf '" + string(scriptContent) + "' > /tmp/setup.sh"),
+		cty.StringVal("cat <<'EOF' > /tmp/setup.sh\n" + string(scriptContent) + "\nEOF"),
 		cty.StringVal("chmod +x /tmp/setup.sh"),
 		cty.StringVal(command),
 	}))

--- a/framework/set/resources/registries/rancher/createRancher.go
+++ b/framework/set/resources/registries/rancher/createRancher.go
@@ -32,7 +32,7 @@ func CreateRancher(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Bod
 
 	_, provisionerBlockBody := rke2.SSHNullResource(rootBody, terraformConfig, rke2ServerOnePublicDNS, installRancher)
 
-	command := "bash -c '/tmp/setup.sh " + terraformConfig.Standalone.RancherChartRepository + " " +
+	command := "/tmp/setup.sh " + terraformConfig.Standalone.RancherChartRepository + " " +
 		terraformConfig.Standalone.Repo + " " + terraformConfig.Standalone.CertManagerVersion + " " +
 		terraformConfig.Standalone.CertType + " " + terraformConfig.Standalone.RancherHostname + " " +
 		terraformConfig.Standalone.RancherTagVersion + " " + terraformConfig.Standalone.ChartVersion + " " +
@@ -42,10 +42,10 @@ func CreateRancher(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Bod
 		command += " " + terraformConfig.Standalone.RancherAgentImage
 	}
 
-	command += " || true'"
+	command += " || true"
 
 	provisionerBlockBody.SetAttributeValue(defaults.Inline, cty.ListVal([]cty.Value{
-		cty.StringVal("printf '" + string(scriptContent) + "' > /tmp/setup.sh"),
+		cty.StringVal("cat <<'EOF' > /tmp/setup.sh\n" + string(scriptContent) + "\nEOF"),
 		cty.StringVal("chmod +x /tmp/setup.sh"),
 		cty.StringVal(command),
 	}))

--- a/framework/set/resources/registries/rancher/setup.sh
+++ b/framework/set/resources/registries/rancher/setup.sh
@@ -14,6 +14,33 @@ RANCHER_AGENT_IMAGE=${11}
 
 set -ex
 
+checkClusterStatus() {
+    EXPECTED_NODES=3
+    TIMEOUT=300
+    INTERVAL=10
+    ELAPSED=0
+
+    while true; do
+        TOTAL_NODES=$(kubectl get nodes --no-headers | wc -l)
+        READY_NODES=$(kubectl get nodes --no-headers | awk '$2 == "Ready"' | wc -l)
+
+        if [ "$READY_NODES" -ne "$EXPECTED_NODES" ]; then
+            echo "Waiting for all $EXPECTED_NODES nodes to be Ready...$READY_NODES/$TOTAL_NODES Ready"
+            sleep $INTERVAL
+
+            ELAPSED=$((ELAPSED + INTERVAL))
+
+            if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+                echo "Timeout reached: Not all nodes are Ready after $TIMEOUT seconds."
+                exit 1
+            fi
+        else
+            echo "All nodes are in status Ready!"
+            break
+        fi
+    done
+}
+
 ARCH=$(uname -m)
 if [[ $ARCH == "x86_64" ]]; then
     ARCH="amd64"
@@ -26,6 +53,8 @@ curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stabl
 sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 mkdir -p ~/.kube
 rm kubectl
+
+checkClusterStatus
 
 echo "Installing Helm"
 curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3

--- a/framework/set/resources/sanity/rancher/createRancher.go
+++ b/framework/set/resources/sanity/rancher/createRancher.go
@@ -36,7 +36,7 @@ func CreateRancher(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Bod
 		terraformConfig.Standalone.RancherHostname = nodeBalancerHostname
 	}
 
-	command := "bash -c '/tmp/setup.sh " + terraformConfig.Standalone.RancherChartRepository + " " +
+	command := "/tmp/setup.sh " + terraformConfig.Standalone.RancherChartRepository + " " +
 		terraformConfig.Standalone.Repo + " " + terraformConfig.Standalone.CertManagerVersion + " " +
 		terraformConfig.Standalone.CertType + " " + terraformConfig.Standalone.RancherHostname + " " +
 		terraformConfig.Standalone.RancherTagVersion + " " + terraformConfig.Standalone.ChartVersion + " " +
@@ -46,10 +46,10 @@ func CreateRancher(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Bod
 		command += " " + terraformConfig.Standalone.RancherAgentImage
 	}
 
-	command += " || true'"
+	command += " || true"
 
 	provisionerBlockBody.SetAttributeValue(defaults.Inline, cty.ListVal([]cty.Value{
-		cty.StringVal("printf '" + string(scriptContent) + "' > /tmp/setup.sh"),
+		cty.StringVal("cat <<'EOF' > /tmp/setup.sh\n" + string(scriptContent) + "\nEOF"),
 		cty.StringVal("chmod +x /tmp/setup.sh"),
 		cty.StringVal(command),
 	}))

--- a/framework/set/resources/sanity/rancher/setup.sh
+++ b/framework/set/resources/sanity/rancher/setup.sh
@@ -13,6 +13,33 @@ RANCHER_AGENT_IMAGE=${10}
 
 set -ex
 
+checkClusterStatus() {
+    EXPECTED_NODES=3
+    TIMEOUT=300
+    INTERVAL=10
+    ELAPSED=0
+
+    while true; do
+        TOTAL_NODES=$(kubectl get nodes --no-headers | wc -l)
+        READY_NODES=$(kubectl get nodes --no-headers | awk '$2 == "Ready"' | wc -l)
+
+        if [ "$READY_NODES" -ne "$EXPECTED_NODES" ]; then
+            echo "Waiting for all $EXPECTED_NODES nodes to be Ready...$READY_NODES/$TOTAL_NODES Ready"
+            sleep $INTERVAL
+
+            ELAPSED=$((ELAPSED + INTERVAL))
+
+            if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+                echo "Timeout reached: Not all nodes are Ready after $TIMEOUT seconds."
+                exit 1
+            fi
+        else
+            echo "All nodes are in status Ready!"
+            break
+        fi
+    done
+}
+
 ARCH=$(uname -m)
 if [[ $ARCH == "x86_64" ]]; then
     ARCH="amd64"
@@ -25,6 +52,8 @@ curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stabl
 sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 mkdir -p ~/.kube
 rm kubectl
+
+checkClusterStatus
 
 echo "Installing Helm"
 curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3


### PR DESCRIPTION
### Issue: N/A

### Description
In light of the docker rate limit, further investigation into that revealed a side issue. Specifically, all of the nodes in the RKE2 local cluster may or may not be in a state of `Ready`. That is an issue because when you try to install cert manager pods, this may fail. And if those don't fail, installing Rancher will because all of the RKE2 specific pods will not be up due to all of the nodes not being Ready.

To fix this, I am checking the status to make sure the cluster is ready.