### PR TITLE
Update tests to optionally use QA private registry

### DIFF
--- a/.github/workflows/pr-sanity-test.yaml
+++ b/.github/workflows/pr-sanity-test.yaml
@@ -91,6 +91,15 @@ jobs:
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
             windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
+            privateRegistries:
+              url: "${{ secrets.PRIVATE_REGISTRY_URL }}"
+              username: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
+              password: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
+              insecure: true
+              authConfigSecretName: "${{ secrets.AUTH_CONFIG_SECRET_NAME }}"
+              mirrorHostname: "${{ secrets.PRIVATE_REGISTRY_MIRROR_HOSTNAME }}"
+              mirrorEndpoint: "${{ secrets.PRIVATE_REGISTRY_MIRROR_ENDPOINT }}"
+              mirrorRewrite: "${{ secrets.PRIVATE_REGISTRY_MIRROR_REWRITE }}"
             awsCredentials:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"

--- a/.github/workflows/proxy-arm64-test.yaml
+++ b/.github/workflows/proxy-arm64-test.yaml
@@ -121,6 +121,15 @@ jobs:
             windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
             proxy:
               proxyBastion: ""
+            privateRegistries:
+              url: "${{ secrets.PRIVATE_REGISTRY_URL }}"
+              username: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
+              password: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
+              insecure: true
+              authConfigSecretName: "${{ secrets.AUTH_CONFIG_SECRET_NAME }}"
+              mirrorHostname: "${{ secrets.PRIVATE_REGISTRY_MIRROR_HOSTNAME }}"
+              mirrorEndpoint: "${{ secrets.PRIVATE_REGISTRY_MIRROR_ENDPOINT }}"
+              mirrorRewrite: "${{ secrets.PRIVATE_REGISTRY_MIRROR_REWRITE }}"
             awsCredentials:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"

--- a/.github/workflows/proxy-test.yaml
+++ b/.github/workflows/proxy-test.yaml
@@ -154,6 +154,15 @@ jobs:
             windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
             proxy:
               proxyBastion: ""
+            privateRegistries:
+              url: "${{ secrets.PRIVATE_REGISTRY_URL }}"
+              username: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
+              password: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
+              insecure: true
+              authConfigSecretName: "${{ secrets.AUTH_CONFIG_SECRET_NAME }}"
+              mirrorHostname: "${{ secrets.PRIVATE_REGISTRY_MIRROR_HOSTNAME }}"
+              mirrorEndpoint: "${{ secrets.PRIVATE_REGISTRY_MIRROR_ENDPOINT }}"
+              mirrorRewrite: "${{ secrets.PRIVATE_REGISTRY_MIRROR_REWRITE }}"
             awsCredentials:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"
@@ -369,6 +378,15 @@ jobs:
             windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
             proxy:
               proxyBastion: ""
+            privateRegistries:
+              url: "${{ secrets.PRIVATE_REGISTRY_URL }}"
+              username: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
+              password: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
+              insecure: true
+              authConfigSecretName: "${{ secrets.AUTH_CONFIG_SECRET_NAME }}"
+              mirrorHostname: "${{ secrets.PRIVATE_REGISTRY_MIRROR_HOSTNAME }}"
+              mirrorEndpoint: "${{ secrets.PRIVATE_REGISTRY_MIRROR_ENDPOINT }}"
+              mirrorRewrite: "${{ secrets.PRIVATE_REGISTRY_MIRROR_REWRITE }}"
             awsCredentials:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"
@@ -584,6 +602,15 @@ jobs:
             windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
             proxy:
               proxyBastion: ""
+            privateRegistries:
+              url: "${{ secrets.PRIVATE_REGISTRY_URL }}"
+              username: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
+              password: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
+              insecure: true
+              authConfigSecretName: "${{ secrets.AUTH_CONFIG_SECRET_NAME }}"
+              mirrorHostname: "${{ secrets.PRIVATE_REGISTRY_MIRROR_HOSTNAME }}"
+              mirrorEndpoint: "${{ secrets.PRIVATE_REGISTRY_MIRROR_ENDPOINT }}"
+              mirrorRewrite: "${{ secrets.PRIVATE_REGISTRY_MIRROR_REWRITE }}"
             awsCredentials:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"

--- a/.github/workflows/proxy-upgrade-arm64-test.yaml
+++ b/.github/workflows/proxy-upgrade-arm64-test.yaml
@@ -122,6 +122,15 @@ jobs:
             windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
             proxy:
               proxyBastion: ""
+            privateRegistries:
+              url: "${{ secrets.PRIVATE_REGISTRY_URL }}"
+              username: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
+              password: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
+              insecure: true
+              authConfigSecretName: "${{ secrets.AUTH_CONFIG_SECRET_NAME }}"
+              mirrorHostname: "${{ secrets.PRIVATE_REGISTRY_MIRROR_HOSTNAME }}"
+              mirrorEndpoint: "${{ secrets.PRIVATE_REGISTRY_MIRROR_ENDPOINT }}"
+              mirrorRewrite: "${{ secrets.PRIVATE_REGISTRY_MIRROR_REWRITE }}"
             awsCredentials:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"

--- a/.github/workflows/proxy-upgrade-test.yaml
+++ b/.github/workflows/proxy-upgrade-test.yaml
@@ -155,6 +155,15 @@ jobs:
             windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
             proxy:
               proxyBastion: ""
+            privateRegistries:
+              url: "${{ secrets.PRIVATE_REGISTRY_URL }}"
+              username: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
+              password: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
+              insecure: true
+              authConfigSecretName: "${{ secrets.AUTH_CONFIG_SECRET_NAME }}"
+              mirrorHostname: "${{ secrets.PRIVATE_REGISTRY_MIRROR_HOSTNAME }}"
+              mirrorEndpoint: "${{ secrets.PRIVATE_REGISTRY_MIRROR_ENDPOINT }}"
+              mirrorRewrite: "${{ secrets.PRIVATE_REGISTRY_MIRROR_REWRITE }}"
             awsCredentials:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"
@@ -376,6 +385,15 @@ jobs:
             windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
             proxy:
               proxyBastion: ""
+            privateRegistries:
+              url: "${{ secrets.PRIVATE_REGISTRY_URL }}"
+              username: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
+              password: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
+              insecure: true
+              authConfigSecretName: "${{ secrets.AUTH_CONFIG_SECRET_NAME }}"
+              mirrorHostname: "${{ secrets.PRIVATE_REGISTRY_MIRROR_HOSTNAME }}"
+              mirrorEndpoint: "${{ secrets.PRIVATE_REGISTRY_MIRROR_ENDPOINT }}"
+              mirrorRewrite: "${{ secrets.PRIVATE_REGISTRY_MIRROR_REWRITE }}"
             awsCredentials:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"
@@ -597,6 +615,15 @@ jobs:
             windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
             proxy:
               proxyBastion: ""
+            privateRegistries:
+              url: "${{ secrets.PRIVATE_REGISTRY_URL }}"
+              username: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
+              password: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
+              insecure: true
+              authConfigSecretName: "${{ secrets.AUTH_CONFIG_SECRET_NAME }}"
+              mirrorHostname: "${{ secrets.PRIVATE_REGISTRY_MIRROR_HOSTNAME }}"
+              mirrorEndpoint: "${{ secrets.PRIVATE_REGISTRY_MIRROR_ENDPOINT }}"
+              mirrorRewrite: "${{ secrets.PRIVATE_REGISTRY_MIRROR_REWRITE }}"
             awsCredentials:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"

--- a/.github/workflows/rancher2-recurring-test.yaml
+++ b/.github/workflows/rancher2-recurring-test.yaml
@@ -152,6 +152,15 @@ jobs:
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
             windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
+            privateRegistries:
+              url: "${{ secrets.PRIVATE_REGISTRY_URL }}"
+              username: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
+              password: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
+              insecure: true
+              authConfigSecretName: "${{ secrets.AUTH_CONFIG_SECRET_NAME }}"
+              mirrorHostname: "${{ secrets.PRIVATE_REGISTRY_MIRROR_HOSTNAME }}"
+              mirrorEndpoint: "${{ secrets.PRIVATE_REGISTRY_MIRROR_ENDPOINT }}"
+              mirrorRewrite: "${{ secrets.PRIVATE_REGISTRY_MIRROR_REWRITE }}"
             awsCredentials:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"
@@ -363,6 +372,15 @@ jobs:
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
             windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
+            privateRegistries:
+              url: "${{ secrets.PRIVATE_REGISTRY_URL }}"
+              username: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
+              password: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
+              insecure: true
+              authConfigSecretName: "${{ secrets.AUTH_CONFIG_SECRET_NAME }}"
+              mirrorHostname: "${{ secrets.PRIVATE_REGISTRY_MIRROR_HOSTNAME }}"
+              mirrorEndpoint: "${{ secrets.PRIVATE_REGISTRY_MIRROR_ENDPOINT }}"
+              mirrorRewrite: "${{ secrets.PRIVATE_REGISTRY_MIRROR_REWRITE }}"
             awsCredentials:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"
@@ -574,6 +592,15 @@ jobs:
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
             windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
+            privateRegistries:
+              url: "${{ secrets.PRIVATE_REGISTRY_URL }}"
+              username: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
+              password: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
+              insecure: true
+              authConfigSecretName: "${{ secrets.AUTH_CONFIG_SECRET_NAME }}"
+              mirrorHostname: "${{ secrets.PRIVATE_REGISTRY_MIRROR_HOSTNAME }}"
+              mirrorEndpoint: "${{ secrets.PRIVATE_REGISTRY_MIRROR_ENDPOINT }}"
+              mirrorRewrite: "${{ secrets.PRIVATE_REGISTRY_MIRROR_REWRITE }}"
             awsCredentials:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"

--- a/.github/workflows/sanity-arm64-test.yaml
+++ b/.github/workflows/sanity-arm64-test.yaml
@@ -119,6 +119,15 @@ jobs:
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
             windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
+            privateRegistries:
+              url: "${{ secrets.PRIVATE_REGISTRY_URL }}"
+              username: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
+              password: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
+              insecure: true
+              authConfigSecretName: "${{ secrets.AUTH_CONFIG_SECRET_NAME }}"
+              mirrorHostname: "${{ secrets.PRIVATE_REGISTRY_MIRROR_HOSTNAME }}"
+              mirrorEndpoint: "${{ secrets.PRIVATE_REGISTRY_MIRROR_ENDPOINT }}"
+              mirrorRewrite: "${{ secrets.PRIVATE_REGISTRY_MIRROR_REWRITE }}"
             awsCredentials:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"

--- a/.github/workflows/sanity-test.yaml
+++ b/.github/workflows/sanity-test.yaml
@@ -159,6 +159,15 @@ jobs:
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
             windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
+            privateRegistries:
+              url: "${{ secrets.PRIVATE_REGISTRY_URL }}"
+              username: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
+              password: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
+              insecure: true
+              authConfigSecretName: "${{ secrets.AUTH_CONFIG_SECRET_NAME }}"
+              mirrorHostname: "${{ secrets.PRIVATE_REGISTRY_MIRROR_HOSTNAME }}"
+              mirrorEndpoint: "${{ secrets.PRIVATE_REGISTRY_MIRROR_ENDPOINT }}"
+              mirrorRewrite: "${{ secrets.PRIVATE_REGISTRY_MIRROR_REWRITE }}"
             awsCredentials:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"
@@ -369,6 +378,15 @@ jobs:
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
             windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
+            privateRegistries:
+              url: "${{ secrets.PRIVATE_REGISTRY_URL }}"
+              username: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
+              password: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
+              insecure: true
+              authConfigSecretName: "${{ secrets.AUTH_CONFIG_SECRET_NAME }}"
+              mirrorHostname: "${{ secrets.PRIVATE_REGISTRY_MIRROR_HOSTNAME }}"
+              mirrorEndpoint: "${{ secrets.PRIVATE_REGISTRY_MIRROR_ENDPOINT }}"
+              mirrorRewrite: "${{ secrets.PRIVATE_REGISTRY_MIRROR_REWRITE }}"
             awsCredentials:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"
@@ -579,6 +597,15 @@ jobs:
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
             windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
+            privateRegistries:
+              url: "${{ secrets.PRIVATE_REGISTRY_URL }}"
+              username: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
+              password: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
+              insecure: true
+              authConfigSecretName: "${{ secrets.AUTH_CONFIG_SECRET_NAME }}"
+              mirrorHostname: "${{ secrets.PRIVATE_REGISTRY_MIRROR_HOSTNAME }}"
+              mirrorEndpoint: "${{ secrets.PRIVATE_REGISTRY_MIRROR_ENDPOINT }}"
+              mirrorRewrite: "${{ secrets.PRIVATE_REGISTRY_MIRROR_REWRITE }}"
             awsCredentials:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"
@@ -789,6 +816,15 @@ jobs:
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
             windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
+            privateRegistries:
+              url: "${{ secrets.PRIVATE_REGISTRY_URL }}"
+              username: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
+              password: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
+              insecure: true
+              authConfigSecretName: "${{ secrets.AUTH_CONFIG_SECRET_NAME }}"
+              mirrorHostname: "${{ secrets.PRIVATE_REGISTRY_MIRROR_HOSTNAME }}"
+              mirrorEndpoint: "${{ secrets.PRIVATE_REGISTRY_MIRROR_ENDPOINT }}"
+              mirrorRewrite: "${{ secrets.PRIVATE_REGISTRY_MIRROR_REWRITE }}"
             awsCredentials:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"

--- a/.github/workflows/sanity-upgrade-arm64-test.yaml
+++ b/.github/workflows/sanity-upgrade-arm64-test.yaml
@@ -120,6 +120,15 @@ jobs:
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
             windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
+            privateRegistries:
+              url: "${{ secrets.PRIVATE_REGISTRY_URL }}"
+              username: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
+              password: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
+              insecure: true
+              authConfigSecretName: "${{ secrets.AUTH_CONFIG_SECRET_NAME }}"
+              mirrorHostname: "${{ secrets.PRIVATE_REGISTRY_MIRROR_HOSTNAME }}"
+              mirrorEndpoint: "${{ secrets.PRIVATE_REGISTRY_MIRROR_ENDPOINT }}"
+              mirrorRewrite: "${{ secrets.PRIVATE_REGISTRY_MIRROR_REWRITE }}"
             awsCredentials:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"

--- a/.github/workflows/sanity-upgrade-test.yaml
+++ b/.github/workflows/sanity-upgrade-test.yaml
@@ -160,6 +160,15 @@ jobs:
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
             windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
+            privateRegistries:
+              url: "${{ secrets.PRIVATE_REGISTRY_URL }}"
+              username: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
+              password: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
+              insecure: true
+              authConfigSecretName: "${{ secrets.AUTH_CONFIG_SECRET_NAME }}"
+              mirrorHostname: "${{ secrets.PRIVATE_REGISTRY_MIRROR_HOSTNAME }}"
+              mirrorEndpoint: "${{ secrets.PRIVATE_REGISTRY_MIRROR_ENDPOINT }}"
+              mirrorRewrite: "${{ secrets.PRIVATE_REGISTRY_MIRROR_REWRITE }}"
             awsCredentials:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"
@@ -376,6 +385,15 @@ jobs:
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
             windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
+            privateRegistries:
+              url: "${{ secrets.PRIVATE_REGISTRY_URL }}"
+              username: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
+              password: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
+              insecure: true
+              authConfigSecretName: "${{ secrets.AUTH_CONFIG_SECRET_NAME }}"
+              mirrorHostname: "${{ secrets.PRIVATE_REGISTRY_MIRROR_HOSTNAME }}"
+              mirrorEndpoint: "${{ secrets.PRIVATE_REGISTRY_MIRROR_ENDPOINT }}"
+              mirrorRewrite: "${{ secrets.PRIVATE_REGISTRY_MIRROR_REWRITE }}"
             awsCredentials:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"
@@ -592,6 +610,15 @@ jobs:
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
             windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
+            privateRegistries:
+              url: "${{ secrets.PRIVATE_REGISTRY_URL }}"
+              username: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
+              password: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
+              insecure: true
+              authConfigSecretName: "${{ secrets.AUTH_CONFIG_SECRET_NAME }}"
+              mirrorHostname: "${{ secrets.PRIVATE_REGISTRY_MIRROR_HOSTNAME }}"
+              mirrorEndpoint: "${{ secrets.PRIVATE_REGISTRY_MIRROR_ENDPOINT }}"
+              mirrorRewrite: "${{ secrets.PRIVATE_REGISTRY_MIRROR_REWRITE }}"
             awsCredentials:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"
@@ -809,6 +836,15 @@ jobs:
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
             windowsPrivateKeyPath: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_PATH }}"
+            privateRegistries:
+              url: "${{ secrets.PRIVATE_REGISTRY_URL }}"
+              username: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
+              password: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
+              insecure: true
+              authConfigSecretName: "${{ secrets.AUTH_CONFIG_SECRET_NAME }}"
+              mirrorHostname: "${{ secrets.PRIVATE_REGISTRY_MIRROR_HOSTNAME }}"
+              mirrorEndpoint: "${{ secrets.PRIVATE_REGISTRY_MIRROR_ENDPOINT }}"
+              mirrorRewrite: "${{ secrets.PRIVATE_REGISTRY_MIRROR_REWRITE }}"
             awsCredentials:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"

--- a/README.md
+++ b/README.md
@@ -243,11 +243,14 @@ terraform:
   privateRegistries:                          # This is an optional block. You must already have a private registry stood up
     engineInsecureRegistry: ""                # RKE1 specific
     url: ""
-    systemDefaultRegistry: ""                 # RKE2/K3S specific
+    systemDefaultRegistry: ""                 # RKE2/K3S specific, can be left blank
     username: ""                              # RKE1 specific
     password: ""                              # RKE1 specific
     insecure: true
-    authConfigSecretName: ""                  # RKE2/K3S specific. Secret must be created in the fleet-default namespace already
+    authConfigSecretName: ""                  # RKE2/K3S specific
+    mirrorHostname: ""
+    mirrorEndpoint: ""
+    mirrorRewrite: ""
   chartValues: |-			      # Provided as a multiline string
     rke2-cilium:                              # RKE2/Cilium specific example of how to do a Kube-proxy Replacement deployment
       k8sServiceHost: 127.0.0.1               

--- a/config/config.go
+++ b/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"errors"
 	"fmt"
 	"path"
 	"runtime"
@@ -119,6 +118,9 @@ type PrivateRegistries struct {
 	CABundle               string `json:"caBundle,omitempty" yaml:"caBundle,omitempty"`
 	EngineInsecureRegistry string `json:"engineInsecureRegistry,omitempty" yaml:"engineInsecureRegistry,omitempty"`
 	Insecure               bool   `json:"insecure,omitempty" yaml:"insecure,omitempty"`
+	MirrorEndpoint         string `json:"mirrorEndpoint,omitempty" yaml:"mirrorEndpoint,omitempty"`
+	MirrorHostname         string `json:"mirrorHostname,omitempty" yaml:"mirrorHostname,omitempty"`
+	MirrorRewrite          string `json:"mirrorRewrite,omitempty" yaml:"mirrorRewrite,omitempty"`
 	Password               string `json:"password,omitempty" yaml:"password,omitempty"`
 	SystemDefaultRegistry  string `json:"systemDefaultRegistry,omitempty" yaml:"systemDefaultRegistry,omitempty"`
 	TLSSecretName          string `json:"tlsSecretName,omitempty" yaml:"tlsSecretName,omitempty"`
@@ -276,7 +278,7 @@ func LoadProvisioningDefaults(cattleConfig map[string]any, filename string) (map
 
 	_, filePath, _, ok := runtime.Caller(0)
 	if !ok {
-		err := errors.New(fmt.Sprintf("Unable to locate directory of %s", filename))
+		err := fmt.Errorf("Unable to locate directory of %s", filename)
 		return nil, err
 	}
 

--- a/framework/set/provisioning/nodedriver/rke2k3s/setConfig.go
+++ b/framework/set/provisioning/nodedriver/rke2k3s/setConfig.go
@@ -50,6 +50,7 @@ const (
 	systemDefaultRegistry = "system-default-registry"
 	project               = "project"
 	endpoints             = "endpoints"
+	rewrites              = "rewrites"
 
 	httpProxy    = "HTTP_PROXY"
 	httpsProxy   = "HTTPS_PROXY"
@@ -158,7 +159,9 @@ func SetRKE2K3s(terraformConfig *config.TerraformConfig, k8sVersion, psact strin
 			CreateRegistrySecret(terraformConfig, rootBody)
 		}
 
-		SetMachineSelectorConfig(rkeConfigBlockBody, terraformConfig)
+		if terraformConfig.PrivateRegistries.SystemDefaultRegistry != "" {
+			SetMachineSelectorConfig(rkeConfigBlockBody, terraformConfig)
+		}
 
 		registryBlock := rkeConfigBlockBody.AppendNewBlock(defaults.PrivateRegistries, nil)
 		registryBlockBody := registryBlock.Body()

--- a/framework/set/provisioning/nodedriver/rke2k3s/setPrivateRegistry.go
+++ b/framework/set/provisioning/nodedriver/rke2k3s/setPrivateRegistry.go
@@ -40,7 +40,11 @@ func SetPrivateRegistryConfig(registryBlockBody *hclwrite.Body, terraformConfig 
 	mirrorsBlock := registryBlockBody.AppendNewBlock(defaults.Mirrors, nil)
 	mirrorsBlockBody := mirrorsBlock.Body()
 
-	mirrorsBlockBody.SetAttributeValue(hostname, cty.StringVal(terraformConfig.PrivateRegistries.URL))
+	mirrorsBlockBody.SetAttributeValue(hostname, cty.StringVal(terraformConfig.PrivateRegistries.MirrorHostname))
+	mirrorsBlockBody.SetAttributeValue(endpoints, cty.ListVal([]cty.Value{cty.StringVal(terraformConfig.PrivateRegistries.MirrorEndpoint)}))
+	mirrorsBlockBody.SetAttributeValue(rewrites, cty.MapVal(map[string]cty.Value{
+		"^(.*)": cty.StringVal(terraformConfig.PrivateRegistries.MirrorRewrite),
+	}))
 
 	return nil
 }

--- a/tests/proxy/README.md
+++ b/tests/proxy/README.md
@@ -44,6 +44,17 @@ terraform:
     proxyBastion: ""                              # REQUIRED - this will be set/unset during testing
   resourcePrefix: ""                              # REQUIRED - fill with desired value
   windowsPrivateKeyPath: ""                       # REQUIRED - specify Windows private key that will be used to access created instances
+  privateRegistries:                              # This is an optional block. You must already have a private registry stood up
+    engineInsecureRegistry: ""                    # RKE1 specific
+    url: ""
+    systemDefaultRegistry: ""                     # RKE2/K3S specific, can be left blank
+    username: ""                                  # RKE1 specific
+    password: ""                                  # RKE1 specific
+    insecure: true
+    authConfigSecretName: ""                      # RKE2/K3S specific
+    mirrorHostname: ""
+    mirrorEndpoint: ""
+    mirrorRewrite: ""
   ########################
   # INFRASTRUCTURE SETUP
   ########################

--- a/tests/rancher2/provisioning/README.md
+++ b/tests/rancher2/provisioning/README.md
@@ -171,6 +171,22 @@ terratest:
   pathToRepo: "go/src/github.com/rancher/tfp-automation"
 ```
 
+If you would like a private registry associated to your downstream cluster, enter in the optional parameters underneath the `terraform` block:
+
+```yaml
+privateRegistries:                          # This is an optional block. You must already have a private registry stood up
+  engineInsecureRegistry: ""                # RKE1 specific
+  url: ""
+  systemDefaultRegistry: ""                 # RKE2/K3S specific, can be left blank
+  username: ""                              # RKE1 specific
+  password: ""                              # RKE1 specific
+  insecure: true
+  authConfigSecretName: ""                  # RKE2/K3S specific
+  mirrorHostname: ""
+  mirrorEndpoint: ""
+  mirrorRewrite: ""
+```
+
 In addition, when running locally, you will need to ensure that you have `export RKE_PROVIDER_VERSION=x.x.x` defined for the RKE1 portion of the test. You also must ensure that you are not using the highest available K8s version as this test will perform an upgrade of the imported cluster.
 
 See the below examples on how to run the tests:

--- a/tests/rancher2/recurring/README.md
+++ b/tests/rancher2/recurring/README.md
@@ -27,7 +27,17 @@ terraform:
   privateKeyPath: ""                              # REQUIRED - specify private key that will be used to access created instances
   windowsPrivateKeyPath: ""
   resourcePrefix: ""
-
+  privateRegistries:                              # This is an optional block. You must already have a private registry stood up
+    engineInsecureRegistry: ""                    # RKE1 specific
+    url: ""
+    systemDefaultRegistry: ""                     # RKE2/K3S specific, can be left blank
+    username: ""                                  # RKE1 specific
+    password: ""                                  # RKE1 specific
+    insecure: true
+    authConfigSecretName: ""                      # RKE2/K3S specific
+    mirrorHostname: ""
+    mirrorEndpoint: ""
+    mirrorRewrite: ""
   awsCredentials:
     awsAccessKey: ""
     awsSecretKey: ""

--- a/tests/sanity/README.md
+++ b/tests/sanity/README.md
@@ -40,6 +40,17 @@ terraform:
   privateKeyPath: ""                              # REQUIRED - specify private key that will be used to access created instances
   resourcePrefix: ""                              # REQUIRED - fill with desired value
   windowsPrivateKeyPath: ""                       # REQUIRED - specify Windows private key that will be used to access created instances
+  privateRegistries:                              # This is an optional block. You must already have a private registry stood up
+    engineInsecureRegistry: ""                    # RKE1 specific
+    url: ""
+    systemDefaultRegistry: ""                     # RKE2/K3S specific, can be left blank
+    username: ""                                  # RKE1 specific
+    password: ""                                  # RKE1 specific
+    insecure: true
+    authConfigSecretName: ""                      # RKE2/K3S specific
+    mirrorHostname: ""
+    mirrorEndpoint: ""
+    mirrorRewrite: ""
   ##########################################
   # STANDALONE / RANCHER CLUSTER CONFIG
   ##########################################


### PR DESCRIPTION
### Issue: N/A

### Description
As per the ongoing issue with the new Docker rate limit, we need a way to consistently provision downstream clusters in a reliable manner. With the recent addition of the new QA private registry, this PR allows support for that. By default, our GHA will now use the QA private registry as well.