### PR TITLE
Fix duplicate registry secret issue for upgrading tests

### DIFF
--- a/.github/workflows/proxy-test.yaml
+++ b/.github/workflows/proxy-test.yaml
@@ -56,7 +56,7 @@ jobs:
   v2-12:
     if: |
       github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.12.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.12')) ||
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.12.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-12 }}
     runs-on: ubuntu-latest
@@ -280,7 +280,7 @@ jobs:
   v2-11:
     if: |
       github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11')) ||
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-11 }}
     runs-on: ubuntu-latest
@@ -504,7 +504,7 @@ jobs:
   v2-10:
     if: |
       github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.10.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.10')) ||
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.10.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-12 }}
     runs-on: ubuntu-latest

--- a/.github/workflows/proxy-upgrade-test.yaml
+++ b/.github/workflows/proxy-upgrade-test.yaml
@@ -56,7 +56,7 @@ jobs:
   v2-12:
     if: |
       github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.12.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.12')) ||
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.12.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ vars.RELEASED_RANCHER_VERSION_2_12 }} -> ${{ inputs.rancher_version || github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
@@ -286,7 +286,7 @@ jobs:
   v2-11:
     if: |
       github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11')) ||
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ vars.RELEASED_RANCHER_VERSION_2_11 }} -> ${{ inputs.rancher_version || github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
@@ -516,7 +516,7 @@ jobs:
   v2-10:
     if: |
       github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.10.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.10')) ||
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.10.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ vars.RELEASED_RANCHER_VERSION_2_10 }} -> ${{ inputs.rancher_version || github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest

--- a/.github/workflows/rancher2-recurring-test.yaml
+++ b/.github/workflows/rancher2-recurring-test.yaml
@@ -56,7 +56,7 @@ jobs:
   v2-12:
     if: |
       github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.12.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.12')) ||
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.12.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-12 }}
     runs-on: ubuntu-latest
@@ -276,7 +276,7 @@ jobs:
   v2-11:
     if: |
       github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11')) ||
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-11 }}
     runs-on: ubuntu-latest
@@ -496,7 +496,7 @@ jobs:
   v2-10:
     if: |
       github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.10.')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.10')) ||
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.10.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ github.event.inputs.rancher_version || github.event.inputs.rancher-version-2-10 }}
     runs-on: ubuntu-latest

--- a/.github/workflows/sanity-test.yaml
+++ b/.github/workflows/sanity-test.yaml
@@ -62,8 +62,8 @@ jobs:
   v2-12:
     if: |
       github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.12.')) ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.12.'))
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.12')) ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.12'))
     name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-12 }}
     runs-on: ubuntu-latest
     environment: latest
@@ -281,8 +281,8 @@ jobs:
   v2-11:
     if: |
       github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11.')) ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11.'))
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11')) ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11'))
     name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-11 }}
     runs-on: ubuntu-latest
     environment: staging-latest
@@ -500,8 +500,8 @@ jobs:
   v2-10:
     if: |
       github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.10.')) ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.10.'))
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.10')) ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.10'))
     name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-10 }}
     runs-on: ubuntu-latest
     environment: staging-latest
@@ -719,8 +719,8 @@ jobs:
 
   v2-9:
     if: |
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.9.')) ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.9.'))
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.9')) ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.9'))
     name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-9 }}
     runs-on: ubuntu-latest
     environment: staging-latest

--- a/.github/workflows/sanity-upgrade-test.yaml
+++ b/.github/workflows/sanity-upgrade-test.yaml
@@ -62,8 +62,8 @@ jobs:
   v2-12:
     if: |
       github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.12.')) ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.12.'))
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.12')) ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.12'))
     name: ${{ vars.RELEASED_RANCHER_VERSION_2_12 }} -> ${{ inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-12 }}
     runs-on: ubuntu-latest
     environment: latest
@@ -287,8 +287,8 @@ jobs:
   v2-11:
     if: |
       github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11.')) ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11.'))
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11')) ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11'))
     name: ${{ vars.RELEASED_RANCHER_VERSION_2_11 }} -> ${{ inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-11 }}
     runs-on: ubuntu-latest
     environment: upgrade-prime-staging
@@ -512,8 +512,8 @@ jobs:
   v2-10:
     if: |
       github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.10.')) ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.10.'))
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.10')) ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.10'))
     name: ${{ vars.RELEASED_RANCHER_VERSION_2_10 }} -> ${{ inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-10 }}
     runs-on: ubuntu-latest
     environment: upgrade-prime-staging
@@ -738,8 +738,8 @@ jobs:
 
   v2-9:
     if: |
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.9.')) ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.9.'))
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.9')) ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.9'))
     name: ${{ vars.RELEASED_RANCHER_VERSION_2_9 }} -> ${{ inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-9 }}
     runs-on: ubuntu-latest
     environment: upgrade-prime-staging

--- a/framework/set/provisioning/nodedriver/rke2k3s/createRegistrySecret.go
+++ b/framework/set/provisioning/nodedriver/rke2k3s/createRegistrySecret.go
@@ -22,7 +22,10 @@ func CreateRegistrySecret(terraformConfig *config.TerraformConfig, rootBody *hcl
 	secretBlockBody := secretBlock.Body()
 
 	secretBlockBody.SetAttributeValue(clusterID, cty.StringVal(localCluster))
-	secretBlockBody.SetAttributeValue(defaults.ResourceName, cty.StringVal(terraformConfig.PrivateRegistries.AuthConfigSecretName))
+
+	registrySecretName := terraformConfig.PrivateRegistries.AuthConfigSecretName + "-" + terraformConfig.ResourcePrefix
+
+	secretBlockBody.SetAttributeValue(defaults.ResourceName, cty.StringVal(registrySecretName))
 	secretBlockBody.SetAttributeValue(defaults.Namespace, cty.StringVal(namespace))
 	secretBlockBody.SetAttributeValue(defaults.Type, cty.StringVal(secretType))
 

--- a/framework/set/provisioning/nodedriver/rke2k3s/setPrivateRegistry.go
+++ b/framework/set/provisioning/nodedriver/rke2k3s/setPrivateRegistry.go
@@ -30,7 +30,8 @@ func SetPrivateRegistryConfig(registryBlockBody *hclwrite.Body, terraformConfig 
 	configBlockBody.SetAttributeValue(hostname, cty.StringVal(terraformConfig.PrivateRegistries.URL))
 
 	if terraformConfig.PrivateRegistries.Username != "" {
-		configBlockBody.SetAttributeValue(authConfigSecretName, cty.StringVal(terraformConfig.PrivateRegistries.AuthConfigSecretName))
+		registrySecretName := terraformConfig.PrivateRegistries.AuthConfigSecretName + "-" + terraformConfig.ResourcePrefix
+		configBlockBody.SetAttributeValue(authConfigSecretName, cty.StringVal(registrySecretName))
 	}
 
 	configBlockBody.SetAttributeValue(tlsSecretName, cty.StringVal(terraformConfig.PrivateRegistries.TLSSecretName))


### PR DESCRIPTION
### Issue: N/A

### Description
Now that we have more stability with the QA private registry, when running a sanity upgrade, it was revealed that duplicate secret names are being made. To get around this, we will just make the name unique to the cluster name.