### PR TITLE
Revert airgap registry type back to nonauthenticated

### DIFF
--- a/framework/set/resources/airgap/createMainTF.go
+++ b/framework/set/resources/airgap/createMainTF.go
@@ -24,6 +24,8 @@ const (
 	rke2ServerTwo   = "rke2_server2"
 	rke2ServerThree = "rke2_server3"
 
+	nonAuthRegistry = "non_auth_registry"
+
 	registryPublicDNS        = "registry_public_dns"
 	rke2BastionPublicDNS     = "rke2_bastion_public_dns"
 	rke2ServerOnePrivateIP   = "rke2_server1_private_ip"
@@ -69,7 +71,7 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 
 	logrus.Infof("Creating registry...")
 	file = sanity.OpenFile(file, keyPath)
-	file, err = registry.CreateAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, registryPublicDNS)
+	file, err = registry.CreateNonAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, registryPublicDNS, nonAuthRegistry)
 	if err != nil {
 		return "", "", err
 	}


### PR DESCRIPTION
### Description
During release testing of airgap, noted that an authenticated registry is being used instead of the expected nonauthenticated registry. This was done as part of recent changes as a troubleshooting step that was never reverted back. This PR fixes that.