### PR TITLE
Update airgap/registries local cluster to properly handle Docker Teams

### DIFF
--- a/framework/set/resources/airgap/rke2/add-servers.sh
+++ b/framework/set/resources/airgap/rke2/add-servers.sh
@@ -45,16 +45,19 @@ setupRegistry() {
 mirrors:
   docker.io:
     endpoint:
-      - "https://${HOST}"
+      - "https://registry-1.docker.io"
+  "${REGISTRY}":
+    endpoint:
+      - "https://${REGISTRY}"
+
 configs:
-  "${HOST}":
-    auth:
-      username: "${REGISTRY_USERNAME}"
-      password: "${REGISTRY_PASSWORD}"
   "docker.io":
     auth:
       username: "${REGISTRY_USERNAME}"
       password: "${REGISTRY_PASSWORD}"
+  "${REGISTRY}":
+    tls:
+      insecure_skip_verify: true
 EOF
 }
 

--- a/framework/set/resources/airgap/rke2/init-server.sh
+++ b/framework/set/resources/airgap/rke2/init-server.sh
@@ -43,16 +43,19 @@ setupRegistry() {
 mirrors:
   docker.io:
     endpoint:
-      - "https://${HOST}"
+      - "https://registry-1.docker.io"
+  "${REGISTRY}":
+    endpoint:
+      - "https://${REGISTRY}"
+
 configs:
-  "${HOST}":
-    auth:
-      username: "${REGISTRY_USERNAME}"
-      password: "${REGISTRY_PASSWORD}"
   "docker.io":
     auth:
       username: "${REGISTRY_USERNAME}"
       password: "${REGISTRY_PASSWORD}"
+  "${REGISTRY}":
+    tls:
+      insecure_skip_verify: true
 EOF
 }
 

--- a/framework/set/resources/registries/rke2/add-servers.sh
+++ b/framework/set/resources/registries/rke2/add-servers.sh
@@ -26,16 +26,19 @@ sudo tee -a /etc/rancher/rke2/registries.yaml > /dev/null << EOF
 mirrors:
   docker.io:
     endpoint:
-    - "https://registry-1.docker.io"
+      - "https://registry-1.docker.io"
+  "${REGISTRY}":
+    endpoint:
+      - "https://${REGISTRY}"
+
 configs:
-  "registry-1.docker.io":
-    auth:
-      username: "${REGISTRY_USERNAME}"
-      password: "${REGISTRY_PASSWORD}"
   "docker.io":
     auth:
       username: "${REGISTRY_USERNAME}"
       password: "${REGISTRY_PASSWORD}"
+  "${REGISTRY}":
+    tls:
+      insecure_skip_verify: true
 EOF
 
 ARCH=$(uname -m)

--- a/framework/set/resources/registries/rke2/init-server.sh
+++ b/framework/set/resources/registries/rke2/init-server.sh
@@ -25,16 +25,19 @@ sudo tee -a /etc/rancher/rke2/registries.yaml > /dev/null << EOF
 mirrors:
   docker.io:
     endpoint:
-    - "https://registry-1.docker.io"
+      - "https://registry-1.docker.io"
+  "${REGISTRY}":
+    endpoint:
+      - "https://${REGISTRY}"
+
 configs:
-  "registry-1.docker.io":
-    auth:
-      username: "${REGISTRY_USERNAME}"
-      password: "${REGISTRY_PASSWORD}"
   "docker.io":
     auth:
       username: "${REGISTRY_USERNAME}"
       password: "${REGISTRY_PASSWORD}"
+  "${REGISTRY}":
+    tls:
+      insecure_skip_verify: true
 EOF
 
 ARCH=$(uname -m)


### PR DESCRIPTION
### Description
The airgap and private registries have local clusters that are failing. Digger deeper, it was noted that the actual `registries.yaml` was the root of the problem. This PR fixes that.