### PR TITLE
Fix configs in registries and airgap workflows

### DIFF
--- a/.github/workflows/airgap-upgrade-test.yaml
+++ b/.github/workflows/airgap-upgrade-test.yaml
@@ -194,6 +194,7 @@ jobs:
             standaloneRegistry:
               assetsPath: "${{ secrets.ASSETS_PATH }}"
               registryName: "${{ secrets.REGISTRY_NAME }}"
+              upgradedAssetsPath: "${{ secrets.UPGRADED_ASSETS_PATH }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
           EOF
@@ -403,6 +404,7 @@ jobs:
             standaloneRegistry:
               assetsPath: "${{ secrets.ASSETS_PATH }}"
               registryName: "${{ secrets.REGISTRY_NAME }}"
+              upgradedAssetsPath: "${{ secrets.UPGRADED_ASSETS_PATH }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
           EOF
@@ -612,6 +614,7 @@ jobs:
             standaloneRegistry:
               assetsPath: "${{ secrets.ASSETS_PATH }}"
               registryName: "${{ secrets.REGISTRY_NAME }}"
+              upgradedAssetsPath: "${{ secrets.UPGRADED_ASSETS_PATH }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
           EOF

--- a/.github/workflows/registry-test.yaml
+++ b/.github/workflows/registry-test.yaml
@@ -178,7 +178,7 @@ jobs:
               registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
               registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
               repo: "${{ env.RANCHER_REPO }}"
-              rke2Version: "${{ vars.RKE2_VERSION_2_11 }}${{ vars.RKE2_VERSION_SUFFIX }}"
+              rke2Version: "${{ vars.RKE2_VERSION_2_12 }}"
             standaloneRegistry:
               assetsPath: "${{ secrets.ASSETS_PATH }}"
               registryName: "${{ secrets.REGISTRY_NAME }}"
@@ -378,7 +378,7 @@ jobs:
               registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
               registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
               repo: "${{ env.RANCHER_REPO }}"
-              rke2Version: "${{ vars.RKE2_VERSION_2_11 }}${{ vars.RKE2_VERSION_SUFFIX }}"
+              rke2Version: "${{ vars.RKE2_VERSION_2_11 }}"
             standaloneRegistry:
               assetsPath: "${{ secrets.ASSETS_PATH }}"
               registryName: "${{ secrets.REGISTRY_NAME }}"
@@ -578,7 +578,7 @@ jobs:
               registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
               registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
               repo: "${{ env.RANCHER_REPO }}"
-              rke2Version: "${{ vars.RKE2_VERSION_2_10 }}${{ vars.RKE2_VERSION_SUFFIX }}"
+              rke2Version: "${{ vars.RKE2_VERSION_2_10 }}"
             standaloneRegistry:
               assetsPath: "${{ secrets.ASSETS_PATH }}"
               registryName: "${{ secrets.REGISTRY_NAME }}"

--- a/tests/airgap/README.md
+++ b/tests/airgap/README.md
@@ -106,6 +106,7 @@ terraform:
   standaloneRegistry:
     assetsPath: ""                                # REQUIRED - ensure that you end with a trailing `/`
     registryName: ""                              # REQUIRED - fill with desired value
+    upgradedAssetsPath: ""                        # REQUIRED - ensure that you end with a trailing `/`
 terratest:
   pathToRepo: "go/src/github.com/rancher/tfp-automation"
 ```

--- a/tests/registries/README.md
+++ b/tests/registries/README.md
@@ -86,7 +86,7 @@ terraform:
     rancherImage: ""                              # REQUIRED - fill with desired value
     rancherTagVersion: ""                         # REQUIRED - fill with desired value
     repo: ""                                      # REQUIRED - fill with desired value
-    rke2Version: ""                               # REQUIRED - fill with desired RKE2 k8s value (i.e. v1.30.6+rke2r1)
+    rke2Version: ""                               # REQUIRED - fill with desired RKE2 k8s value (i.e. v1.xx.x)
   ####################################
   # STANDALONE CONFIG - REGISTRY SETUP
   ####################################


### PR DESCRIPTION
### Description
The `airgap-upgrade-test.yaml` was missing `upgradedAssetsPath`, causing airgap upgrades to not properly continue as expected. The `registry-test.yaml` had the RKE2 suffix still defined, causing RKE2 cluster creation to not properly work.