### PR TITLE
Fix airgap internal FQDN patching

### DIFF
--- a/.github/workflows/airgap-upgrade-test.yaml
+++ b/.github/workflows/airgap-upgrade-test.yaml
@@ -56,7 +56,7 @@ jobs:
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.12.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ vars.RELEASED_RANCHER_VERSION_2_12 }} -> ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-12 }}
     runs-on: ubuntu-latest
-    environment: alpha
+    environment: latest
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_12 }}"
 

--- a/framework/set/resources/airgap/rancher/setup.sh
+++ b/framework/set/resources/airgap/rancher/setup.sh
@@ -172,3 +172,8 @@ kubectl patch setting server-url --type=json -p="[{
   \"path\": \"/value\", 
   \"value\": \"https://${INTERNAL_FQDN}\"
 }]"
+
+echo "Restarting Rancher"
+kubectl -n cattle-system rollout restart deploy/rancher
+kubectl -n cattle-system rollout status deploy/rancher
+kubectl -n cattle-system get deploy rancher

--- a/framework/set/resources/airgap/rancher/upgrade.sh
+++ b/framework/set/resources/airgap/rancher/upgrade.sh
@@ -85,9 +85,6 @@ echo "Waiting for Rancher to be rolled out"
 kubectl -n cattle-system rollout status deploy/rancher
 kubectl -n cattle-system get deploy rancher
 
-echo "Waiting 15 seconds to be able to login to Rancher"
-sleep 15
-
 kubectl patch ingress rancher -n cattle-system --type=json -p="[{
   \"op\": \"add\", 
   \"path\": \"/spec/rules/-\", 
@@ -120,3 +117,11 @@ kubectl patch setting server-url --type=json -p="[{
   \"path\": \"/value\", 
   \"value\": \"https://${INTERNAL_FQDN}\"
 }]"
+
+echo "Restarting Rancher"
+kubectl -n cattle-system rollout restart deploy/rancher
+kubectl -n cattle-system rollout status deploy/rancher
+kubectl -n cattle-system get deploy rancher
+
+echo "Waiting 15 seconds to be able to login to Rancher"
+sleep 15


### PR DESCRIPTION
### Description
When running airgap upgrade GHA, few issues were spotted:
- v2.12 is using `alpha` as the repo instead of `latest`. This causes issues as it needs to be `latest` initially when setting up the released version. The other jobs are correctly using `upgrade-prime-staging`
- The internal FQDN is getting patched, but Rancher needs to be restarted for the change to take impact