### PR TITLE
Fix FQDN for PostRancherSetup for airgap installs

### DIFF
--- a/tests/infrastructure/createRancher.go
+++ b/tests/infrastructure/createRancher.go
@@ -31,7 +31,7 @@ func SetupAirgapRancher(t *testing.T, session *session.Session, moduleKeyPath st
 	registry, bastion, err := airgap.CreateMainTF(t, standaloneTerraformOptions, keyPath, rancherConfig, terraformConfig, terratestConfig)
 	require.NoError(t, err)
 
-	client, err := PostRancherSetup(t, standaloneTerraformOptions, rancherConfig, session, terraformConfig.Standalone.RancherHostname, keyPath, true)
+	client, err := PostRancherSetup(t, standaloneTerraformOptions, rancherConfig, session, terraformConfig.Standalone.AirgapInternalFQDN, keyPath, true)
 	require.NoError(t, err)
 
 	_, keyPath = rancher2.SetKeyPath(keypath.RancherKeyPath, terratestConfig.PathToRepo, "")


### PR DESCRIPTION
### Description
Further looking into the last PR, the actual issue of the internal FQDN is part of the recent QOL refactor, the incorrect FQDN is called for `PostRancherSetup`. Past code verified this as well, this needs to be `AirgapInternalFQDN`. The last PR is still a good enhancement to have, but this is the actual issue.