### PR TITLE
Consolidate Qase reporting parameters

### DIFF
--- a/.github/actions/get-qase-id/action.yaml
+++ b/.github/actions/get-qase-id/action.yaml
@@ -5,9 +5,6 @@ inputs:
   triggered_tag:
     description: "Rancher server tag version from triggered action"
     required: true
-  qase_release_id:
-    description: "Qase ID for the release test run"
-    required: true
   qase_rc_id:
     description: "Qase ID for the RC test run"
     required: false
@@ -32,7 +29,7 @@ runs:
           if [[ "$TRIGGERED_TAG" == *"-rc"* ]]; then
             QASE_ID="${{ inputs.qase_rc_id }}"
           else
-            QASE_ID="${{ inputs.qase_release_id }}"
+            QASE_ID="${{ inputs.qase_recurring_id }}"
           fi
         else
           QASE_ID="${{ inputs.qase_recurring_id }}"

--- a/.github/workflows/airgap-test.yaml
+++ b/.github/workflows/airgap-test.yaml
@@ -231,7 +231,7 @@ jobs:
       - name: Reporting Results to Qase
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ vars.QASE_RELEASE_TEST_RUN_ID_2_12 }}
+          qase-test-run-id: ${{ vars.QASE_RECURRING_TEST_RUN_ID_2_12 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -434,7 +434,7 @@ jobs:
       - name: Reporting Results to Qase
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ vars.QASE_RELEASE_TEST_RUN_ID_2_11 }}
+          qase-test-run-id: ${{ vars.QASE_RECURRING_TEST_RUN_ID_2_11 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -637,7 +637,7 @@ jobs:
       - name: Reporting Results to Qase
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ vars.QASE_RELEASE_TEST_RUN_ID_2_10 }}
+          qase-test-run-id: ${{ vars.QASE_RECURRING_TEST_RUN_ID_2_10 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack

--- a/.github/workflows/airgap-upgrade-test.yaml
+++ b/.github/workflows/airgap-upgrade-test.yaml
@@ -236,7 +236,7 @@ jobs:
       - name: Reporting Results to Qase
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ vars.QASE_RELEASE_TEST_RUN_ID_2_12 }}
+          qase-test-run-id: ${{ vars.QASE_RECURRING_TEST_RUN_ID_2_12 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -446,7 +446,7 @@ jobs:
       - name: Reporting Results to Qase
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ vars.QASE_RELEASE_TEST_RUN_ID_2_11 }}
+          qase-test-run-id: ${{ vars.QASE_RECURRING_TEST_RUN_ID_2_11 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -656,7 +656,7 @@ jobs:
       - name: Reporting Results to Qase
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ vars.QASE_RELEASE_TEST_RUN_ID_2_10 }}
+          qase-test-run-id: ${{ vars.QASE_RECURRING_TEST_RUN_ID_2_10 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack

--- a/.github/workflows/check-rancher-tag.yaml
+++ b/.github/workflows/check-rancher-tag.yaml
@@ -10,6 +10,7 @@ on:
 permissions:
   id-token: write
   contents: read
+  actions: write
 
 jobs:
   check-latest-rancher-tag:

--- a/.github/workflows/proxy-arm64-test.yaml
+++ b/.github/workflows/proxy-arm64-test.yaml
@@ -221,7 +221,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_12 }}
+          qase-test-run-id: ${{ vars.QASE_RECURRING_TEST_RUN_ID_2_12 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack

--- a/.github/workflows/proxy-test.yaml
+++ b/.github/workflows/proxy-test.yaml
@@ -133,8 +133,7 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_12 }}"
-          qase_recurring_id: "${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_12 }}"
+          qase_recurring_id: "${{ vars.QASE_RECURRING_TEST_RUN_ID_2_12 }}"
 
       - name: Create config.yaml
         run: |
@@ -358,8 +357,7 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_11 }}"
-          qase_recurring_id: "${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_11 }}"
+          qase_recurring_id: "${{ vars.QASE_RECURRING_TEST_RUN_ID_2_11 }}"
 
       - name: Create config.yaml
         run: |
@@ -583,8 +581,7 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_10 }}"
-          qase_recurring_id: "${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_10 }}"
+          qase_recurring_id: "${{ vars.QASE_RECURRING_TEST_RUN_ID_2_10 }}"
 
       - name: Create config.yaml
         run: |

--- a/.github/workflows/proxy-upgrade-arm64-test.yaml
+++ b/.github/workflows/proxy-upgrade-arm64-test.yaml
@@ -227,7 +227,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_12 }}
+          qase-test-run-id: ${{ vars.QASE_RECURRING_TEST_RUN_ID_2_12 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack

--- a/.github/workflows/proxy-upgrade-test.yaml
+++ b/.github/workflows/proxy-upgrade-test.yaml
@@ -134,8 +134,7 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_12 }}"
-          qase_recurring_id: "${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_12 }}"
+          qase_recurring_id: "${{ vars.QASE_RECURRING_TEST_RUN_ID_2_12 }}"
 
       - name: Create config.yaml
         run: |
@@ -365,8 +364,7 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_11 }}"
-          qase_recurring_id: "${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_11 }}"
+          qase_recurring_id: "${{ vars.QASE_RECURRING_TEST_RUN_ID_2_11 }}"
 
       - name: Create config.yaml
         run: |
@@ -596,8 +594,7 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_10 }}"
-          qase_recurring_id: "${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_10 }}"
+          qase_recurring_id: "${{ vars.QASE_RECURRING_TEST_RUN_ID_2_10 }}"
 
       - name: Create config.yaml
         run: |

--- a/.github/workflows/rancher2-recurring-test.yaml
+++ b/.github/workflows/rancher2-recurring-test.yaml
@@ -133,8 +133,7 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_12 }}"
-          qase_recurring_id: "${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_12 }}"
+          qase_recurring_id: "${{ vars.QASE_RECURRING_TEST_RUN_ID_2_12 }}"
 
       - name: Create config.yaml
         run: |
@@ -354,8 +353,7 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_11 }}"
-          qase_recurring_id: "${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_11 }}"
+          qase_recurring_id: "${{ vars.QASE_RECURRING_TEST_RUN_ID_2_11 }}"
 
       - name: Create config.yaml
         run: |
@@ -575,8 +573,7 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_10 }}"
-          qase_recurring_id: "${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_10 }}"
+          qase_recurring_id: "${{ vars.QASE_RECURRING_TEST_RUN_ID_2_10 }}"
 
       - name: Create config.yaml
         run: |

--- a/.github/workflows/registry-test.yaml
+++ b/.github/workflows/registry-test.yaml
@@ -228,7 +228,7 @@ jobs:
       - name: Reporting Results to Qase
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ vars.QASE_RELEASE_TEST_RUN_ID_2_12 }}
+          qase-test-run-id: ${{ vars.QASE_RECURRING_TEST_RUN_ID_2_12 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -428,7 +428,7 @@ jobs:
       - name: Reporting Results to Qase
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ vars.QASE_RELEASE_TEST_RUN_ID_2_11 }}
+          qase-test-run-id: ${{ vars.QASE_RECURRING_TEST_RUN_ID_2_11 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack
@@ -628,7 +628,7 @@ jobs:
       - name: Reporting Results to Qase
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ vars.QASE_RELEASE_TEST_RUN_ID_2_10 }}
+          qase-test-run-id: ${{ vars.QASE_RECURRING_TEST_RUN_ID_2_10 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack

--- a/.github/workflows/sanity-arm64-test.yaml
+++ b/.github/workflows/sanity-arm64-test.yaml
@@ -215,7 +215,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_12}}
+          qase-test-run-id: ${{ vars.QASE_RECURRING_TEST_RUN_ID_2_12}}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack

--- a/.github/workflows/sanity-test.yaml
+++ b/.github/workflows/sanity-test.yaml
@@ -139,9 +139,8 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_release_id: ${{ vars.QASE_RELEASE_TEST_RUN_ID_2_12 }}
           qase_rc_id: ${{ vars.QASE_RC_TEST_RUN_ID_2_12 }}
-          qase_recurring_id: ${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_12 }}
+          qase_recurring_id: ${{ vars.QASE_RECURRING_TEST_RUN_ID_2_12 }}
 
       - name: Create config.yaml
         run: |
@@ -359,9 +358,8 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_11 }}"
           qase_rc_id: ${{ vars.QASE_RC_TEST_RUN_ID_2_11 }}
-          qase_recurring_id: "${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_11 }}"
+          qase_recurring_id: "${{ vars.QASE_RECURRING_TEST_RUN_ID_2_11 }}"
 
       - name: Create config.yaml
         run: |
@@ -579,9 +577,8 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_10 }}"
           qase_rc_id: "${{ vars.QASE_RC_TEST_RUN_ID_2_10 }}"
-          qase_recurring_id: "${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_10 }}"
+          qase_recurring_id: "${{ vars.QASE_RECURRING_TEST_RUN_ID_2_10 }}"
 
       - name: Create config.yaml
         run: |
@@ -799,9 +796,8 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_9 }}"
           qase_rc_id: "${{ vars.QASE_RC_TEST_RUN_ID_2_9 }}"
-          qase_recurring_id: "${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_9 }}"
+          qase_recurring_id: "${{ vars.QASE_RECURRING_TEST_RUN_ID_2_9 }}"
 
       - name: Create config.yaml
         run: |

--- a/.github/workflows/sanity-upgrade-arm64-test.yaml
+++ b/.github/workflows/sanity-upgrade-arm64-test.yaml
@@ -221,7 +221,7 @@ jobs:
         if: always()
         uses: ./.github/actions/report-to-qase
         with:
-          qase-test-run-id: ${{ vars.QASE_DEFAULT_TEST_RUN_ID_2_12 }}
+          qase-test-run-id: ${{ vars.QASE_RECURRING_TEST_RUN_ID_2_12 }}
           qase-automation-token: ${{ secrets.QASE_TOKEN }}
 
       - name: Reporting Results to Slack


### PR DESCRIPTION
### Description
As part of post release cycle, we want to consolidate the Qase reporting for recurring runs and release testing. Moving forward, we will have the following:
- Recurring test run
- RC test run