### PR TITLE
Fix SSH connectivity with IPv6 RKE2 cluster

### DIFF
--- a/framework/set/resources/ipv6/rke2/add-servers.sh
+++ b/framework/set/resources/ipv6/rke2/add-servers.sh
@@ -68,7 +68,7 @@ configFunction=$(declare -f setupConfig)
 runSSH "${RKE2_NEW_SERVER_PRIVATE_IP}" "${configFunction}; setupConfig"
 
 registryFunction=$(declare -f setupRegistry)
-runSSH "${RKE2_SERVER_ONE_IP}" "${registryFunction}; setupRegistry"
+runSSH "${RKE2_NEW_SERVER_PRIVATE_IP}" "${registryFunction}; setupRegistry"
 
 runSSH "${RKE2_NEW_SERVER_PRIVATE_IP}" "sudo INSTALL_RKE2_ARTIFACT_PATH=/home/${USER} sh install.sh"
 runSSH "${RKE2_NEW_SERVER_PRIVATE_IP}" "sudo systemctl enable rke2-server"

--- a/framework/set/resources/ipv6/rke2/init-server.sh
+++ b/framework/set/resources/ipv6/rke2/init-server.sh
@@ -68,7 +68,7 @@ configFunction=$(declare -f setupConfig)
 runSSH "${RKE2_SERVER_ONE_PRIVATE_IP}" "${configFunction}; setupConfig"
 
 registryFunction=$(declare -f setupRegistry)
-runSSH "${RKE2_SERVER_ONE_IP}" "${registryFunction}; setupRegistry"
+runSSH "${RKE2_SERVER_ONE_PRIVATE_IP}" "${registryFunction}; setupRegistry"
 
 runSSH "${RKE2_SERVER_ONE_PRIVATE_IP}" "sudo INSTALL_RKE2_ARTIFACT_PATH=/home/${USER} sh install.sh"
 runSSH "${RKE2_SERVER_ONE_PRIVATE_IP}" "sudo systemctl enable rke2-server"


### PR DESCRIPTION
### Description
When testing IPv6, there was a small issue I noted with connecting to the airgapped nodes. The registry YAML is not creating and it is because it is trying to connect to the public IP and not the private IP. This small PR fixes that.