### PR TITLE
Update GHA workflows for head commits

### DIFF
--- a/.github/workflows/community-proxy-test.yaml
+++ b/.github/workflows/community-proxy-test.yaml
@@ -10,6 +10,9 @@ on:
         description: "Rancher tag version provided from check-rancher-tag workflow"
       rancher_chart_version:
         description: "Rancher chart version provided from check-rancher-tag workflow"
+      rancher-version-head:
+        description: "Rancher version for head"
+        default: "head"
       rancher-version-2-12:
         description: "Rancher version for v2.12.x"
         default: "v2.12-head"
@@ -102,7 +105,12 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: github.event_name == 'schedule' && vars.RANCHER_VERSION_HEAD
+          value: |
+            ${{ 
+              github.event.inputs.rancher_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher-version-head) || 
+              (github.event_name == 'schedule' && vars.RANCHER_VERSION_HEAD) 
+            }}
 
       - name: Set Rancher chart version
         uses: ./.github/actions/set-env-var

--- a/.github/workflows/community-rancher2-recurring-test.yaml
+++ b/.github/workflows/community-rancher2-recurring-test.yaml
@@ -108,7 +108,7 @@ jobs:
           value: |
             ${{ 
               github.event.inputs.rancher_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher-version-2-12) || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher-version-head) || 
               (github.event_name == 'schedule' && vars.RANCHER_VERSION_HEAD) 
             }}
 

--- a/.github/workflows/community-sanity-test.yaml
+++ b/.github/workflows/community-sanity-test.yaml
@@ -10,6 +10,9 @@ on:
         description: "Rancher tag version provided from check-rancher-tag workflow"
       rancher_chart_version:
         description: "Rancher chart version provided from check-rancher-tag workflow"
+      rancher-version-head:
+        description: "Rancher version for head"
+        default: "head"
       rancher-version-2-12:
         description: "Rancher version for v2.12.x"
         default: "v2.12-head"
@@ -103,7 +106,12 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: github.event_name == 'schedule' && vars.RANCHER_VERSION_HEAD
+          value: |
+            ${{ 
+              github.event.inputs.rancher_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher-version-head) || 
+              (github.event_name == 'schedule' && vars.RANCHER_VERSION_HEAD) 
+            }}
 
       - name: Set Rancher chart version
         uses: ./.github/actions/set-env-var

--- a/.github/workflows/community-sanity-upgrade-test.yaml
+++ b/.github/workflows/community-sanity-upgrade-test.yaml
@@ -108,7 +108,7 @@ jobs:
           value: |
             ${{ 
               github.event.inputs.rancher_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.upgraded-rancher-version-2-12) || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.upgraded-rancher-version-head) || 
               (github.event_name == 'schedule' && vars.RANCHER_VERSION_HEAD) 
             }}
 

--- a/tests/airgap/airgap_upgrade_rancher_test.go
+++ b/tests/airgap/airgap_upgrade_rancher_test.go
@@ -68,7 +68,7 @@ func (a *TfpAirgapUpgradeRancherTestSuite) TestTfpUpgradeAirgapRancher() {
 
 	a.client, a.cattleConfig, a.terraformOptions, a.upgradeTerraformOptions = infrastructure.UpgradeAirgapRancher(a.T(), a.client, a.bastion, a.registry, a.session, a.cattleConfig)
 
-	if a.standaloneConfig.RancherTagVersion != "head" {
+	if a.standaloneConfig.UpgradedRancherTagVersion != "head" {
 		provisioning.VerifyRancherVersion(a.T(), a.rancherConfig.Host, a.standaloneConfig.UpgradedRancherTagVersion)
 	}
 

--- a/tests/proxy/proxy_upgrade_rancher_test.go
+++ b/tests/proxy/proxy_upgrade_rancher_test.go
@@ -68,7 +68,7 @@ func (p *TfpProxyUpgradeRancherTestSuite) TestTfpUpgradeProxyRancher() {
 
 	p.client, p.cattleConfig, p.terraformOptions, p.upgradeTerraformOptions = infrastructure.UpgradeProxyRancher(p.T(), p.client, p.proxyPrivateIP, p.proxyBastion, p.session, p.cattleConfig)
 
-	if p.standaloneConfig.RancherTagVersion != "head" {
+	if p.standaloneConfig.UpgradedRancherTagVersion != "head" {
 		provisioning.VerifyRancherVersion(p.T(), p.rancherConfig.Host, p.standaloneConfig.UpgradedRancherTagVersion)
 	}
 

--- a/tests/sanity/sanity_upgrade_rancher_test.go
+++ b/tests/sanity/sanity_upgrade_rancher_test.go
@@ -67,7 +67,7 @@ func (s *TfpSanityUpgradeRancherTestSuite) TestTfpUpgradeRancher() {
 
 	s.client, s.cattleConfig, s.terraformOptions, s.upgradeTerraformOptions = infrastructure.UpgradeRancher(s.T(), s.client, s.serverNodeOne, s.session, s.cattleConfig)
 
-	if s.standaloneConfig.RancherTagVersion != "head" {
+	if s.standaloneConfig.UpgradedRancherTagVersion != "head" {
 		provisioning.VerifyRancherVersion(s.T(), s.rancherConfig.Host, s.standaloneConfig.UpgradedRancherTagVersion)
 	}
 


### PR DESCRIPTION
### Description
From the last runs, two issues were noted:
- Head commits that are manually kicked off do not have the right version (it needs to be `head)
- The upgrade tests need to use `UpgradeRancherTagVersion` in the conditional check