### PR TITLE
Update chart version for manually ran head workflows

### DIFF
--- a/.github/workflows/community-proxy-test.yaml
+++ b/.github/workflows/community-proxy-test.yaml
@@ -116,7 +116,12 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_CHART_VERSION
-          value: github.event_name == 'schedule' && vars.RELEASED_RANCHER_CHART_VERSION_2_12
+          value: |
+            ${{ 
+              github.event.inputs.rancher_chart_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher-chart-version-2-12) || 
+              (github.event_name == 'schedule' && vars.RELEASED_RANCHER_CHART_VERSION_2_12) 
+            }}
 
       - name: Set Rancher repo
         uses: ./.github/actions/set-rancher-repo

--- a/.github/workflows/community-sanity-test.yaml
+++ b/.github/workflows/community-sanity-test.yaml
@@ -117,7 +117,12 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_CHART_VERSION
-          value: github.event_name == 'schedule' && vars.RELEASED_RANCHER_CHART_VERSION_2_12
+          value: |
+            ${{ 
+              github.event.inputs.rancher_chart_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher-chart-version-2-12) || 
+              (github.event_name == 'schedule' && vars.RELEASED_RANCHER_CHART_VERSION_2_12) 
+            }}
 
       - name: Set Rancher repo
         uses: ./.github/actions/set-rancher-repo


### PR DESCRIPTION
### Description
Non upgrade proxy and sanity are still failing and it's because we need the chart version to be set like the Rancher version in the prior PR.