### PR TITLE
Update Qase 2.13 reporting + fix chart versions

### DIFF
--- a/.github/workflows/community-proxy-test.yaml
+++ b/.github/workflows/community-proxy-test.yaml
@@ -18,7 +18,7 @@ on:
         default: "v2.12-head"
       rancher-chart-version-2-12:
         description: "Rancher chart version for v2.12.x"
-        default: "v2.12.1"
+        default: "2.12.1"
   workflow_call:
     inputs:
       rancher_version:
@@ -134,7 +134,7 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_recurring_id: "${{ vars.QASE_RECURRING_TEST_RUN_ID_2_12 }}"
+          qase_recurring_id: "${{ vars.QASE_RECURRING_TEST_RUN_ID_2_13 }}"
 
       - name: Create config.yaml
         run: |

--- a/.github/workflows/community-proxy-upgrade-test.yaml
+++ b/.github/workflows/community-proxy-upgrade-test.yaml
@@ -18,7 +18,7 @@ on:
         default: "v2.12-head"
       upgraded-rancher-chart-version-2-12:
         description: "Upgraded Rancher chart version for v2.12.x"
-        default: "v2.12.1"
+        default: "2.12.1"
   workflow_call:
     inputs:
       rancher_version:
@@ -135,7 +135,7 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_recurring_id: "${{ vars.QASE_RECURRING_TEST_RUN_ID_2_12 }}"
+          qase_recurring_id: "${{ vars.QASE_RECURRING_TEST_RUN_ID_2_13 }}"
 
       - name: Create config.yaml
         run: |

--- a/.github/workflows/community-rancher2-recurring-test.yaml
+++ b/.github/workflows/community-rancher2-recurring-test.yaml
@@ -134,7 +134,7 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_recurring_id: "${{ vars.QASE_RECURRING_TEST_RUN_ID_2_12 }}"
+          qase_recurring_id: "${{ vars.QASE_RECURRING_TEST_RUN_ID_2_13 }}"
 
       - name: Create config.yaml
         run: |

--- a/.github/workflows/community-sanity-test.yaml
+++ b/.github/workflows/community-sanity-test.yaml
@@ -18,7 +18,7 @@ on:
         default: "v2.12-head"
       rancher-chart-version-2-12:
         description: Rancher chart version for v2.12.x
-        default: "v2.12.1"
+        default: "2.12.1"
   workflow_call:
     inputs:
       rancher_version:
@@ -135,8 +135,8 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_rc_id: ${{ vars.QASE_RC_TEST_RUN_ID_2_12 }}
-          qase_recurring_id: ${{ vars.QASE_RECURRING_TEST_RUN_ID_2_12 }}
+          qase_rc_id: ${{ vars.QASE_RC_TEST_RUN_ID_2_13 }}
+          qase_recurring_id: ${{ vars.QASE_RECURRING_TEST_RUN_ID_2_13 }}
 
       - name: Create config.yaml
         run: |

--- a/.github/workflows/community-sanity-upgrade-test.yaml
+++ b/.github/workflows/community-sanity-upgrade-test.yaml
@@ -18,7 +18,7 @@ on:
         default: "v2.12-head"
       upgraded-rancher-chart-version-2-12:
         description: "Upgraded Rancher chart version for v2.12.x"
-        default: "v2.12.1"
+        default: "2.12.1"
   workflow_call:
     inputs:
       rancher_version:
@@ -135,8 +135,8 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_rc_id: "${{ vars.QASE_RC_TEST_RUN_ID_2_12 }}"
-          qase_recurring_id: "${{ vars.QASE_RECURRING_TEST_RUN_ID_2_12 }}"
+          qase_rc_id: "${{ vars.QASE_RC_TEST_RUN_ID_2_13 }}"
+          qase_recurring_id: "${{ vars.QASE_RECURRING_TEST_RUN_ID_2_13 }}"
 
       - name: Create config.yaml
         run: |

--- a/.github/workflows/prime-proxy-test.yaml
+++ b/.github/workflows/prime-proxy-test.yaml
@@ -15,13 +15,13 @@ on:
         default: "v2.11-head"
       rancher-chart-version-2-11:
         description: "Rancher chart version for v2.11.x"
-        default: "v2.11.5"
+        default: "2.11.5"
       rancher-version-2-10:
         description: "Rancher version for v2.10.x"
         default: "v2.10-head"
       rancher-chart-version-2-10:
         description: "Rancher chart version for v2.10.x"
-        default: "v2.10.9"
+        default: "2.10.9"
   workflow_call:
     inputs:
       rancher_version:

--- a/.github/workflows/prime-proxy-upgrade-test.yaml
+++ b/.github/workflows/prime-proxy-upgrade-test.yaml
@@ -15,13 +15,13 @@ on:
         default: "v2.11-head"
       upgraded-rancher-chart-version-2-11:
         description: "Upgraded Rancher chart version for v2.11.x"
-        default: "v2.11.5"
+        default: "2.11.5"
       upgraded-rancher-version-2-10:
         description: "Upgraded Rancher version for v2.10.x"
         default: "v2.10-head"
       upgraded-rancher-chart-version-2-10:
         description: "Upgraded Rancher chart version for v2.10.x"
-        default: "v2.10.9"
+        default: "2.10.9"
   workflow_call:
     inputs:
       rancher_version:

--- a/.github/workflows/prime-rancher2-recurring-test.yaml
+++ b/.github/workflows/prime-rancher2-recurring-test.yaml
@@ -15,13 +15,13 @@ on:
         default: "v2.11-head"
       rancher-chart-version-2-11:
         description: "Rancher chart version for v2.11-head"
-        default: "v2.11.5"
+        default: "2.11.5"
       rancher-version-2-10:
         description: "Rancher version for v2.10-head"
         default: "v2.10-head"
       rancher-chart-version-2-10:
         description: "Rancher chart version for v2.10-head"
-        default: "v2.10.9"
+        default: "2.10.9"
   workflow_call:
     inputs:
       rancher_version:

--- a/.github/workflows/prime-sanity-test.yaml
+++ b/.github/workflows/prime-sanity-test.yaml
@@ -15,19 +15,19 @@ on:
         default: "v2.11-head"
       rancher-chart-version-2-11:
         description: Rancher chart version for v2.11.x
-        default: "v2.11.5"
+        default: "2.11.5"
       rancher-version-2-10:
         description: "Rancher version for v2.10.x"
         default: "v2.10-head"
       rancher-chart-version-2-10:
         description: Rancher chart version for v2.10.x
-        default: "v2.10.9"
+        default: "2.10.9"
       rancher-version-2-9:
         description: "Rancher version for v2.9.x"
         default: "v2.9-head"
       rancher-chart-version-2-9:
         description: Rancher chart version for v2.9.x
-        default: "v2.9.11"
+        default: "2.9.11"
   workflow_call:
     inputs:
       rancher_version:

--- a/.github/workflows/prime-sanity-upgrade-test.yaml
+++ b/.github/workflows/prime-sanity-upgrade-test.yaml
@@ -15,19 +15,19 @@ on:
         default: "v2.11-head"
       upgraded-rancher-chart-version-2-11:
         description: "Upgraded Rancher chart version for v2.11.x"
-        default: "v2.11.5"
+        default: "2.11.5"
       upgraded-rancher-version-2-10:
         description: "Upgraded Rancher version for v2.10.x"
         default: "v2.10-head"
       upgraded-rancher-chart-version-2-10:
         description: "Upgraded Rancher chart version for v2.10.x"
-        default: "v2.10.9"
+        default: "2.10.9"
       upgraded-rancher-version-2-9:
         description: "Upgraded Rancher version for v2.9.x"
         default: "v2.9-head"
       upgraded-rancher-chart-version-2-9:
         description: "Upgraded Rancher chart version for v2.9.x"
-        default: "v2.9.11"
+        default: "2.9.11"
   workflow_call:
     inputs:
       rancher_version:

--- a/.github/workflows/proxy-arm64-test.yaml
+++ b/.github/workflows/proxy-arm64-test.yaml
@@ -15,7 +15,7 @@ on:
         default: "v2.12-head"
       rancher-chart-version-2-12:
         description: "Rancher chart version for v2.12.x"
-        default: "v2.12-head"
+        default: "2.12.1"
 
 permissions:
   id-token: write

--- a/.github/workflows/proxy-upgrade-arm64-test.yaml
+++ b/.github/workflows/proxy-upgrade-arm64-test.yaml
@@ -15,7 +15,7 @@ on:
         default: "v2.12-head"
       upgraded-rancher-chart-version-2-12:
         description: "Upgraded Rancher chart version for v2.12.x"
-        default: "v2.12.1"
+        default: "2.12.1"
 
 permissions:
   id-token: write

--- a/.github/workflows/sanity-arm64-test.yaml
+++ b/.github/workflows/sanity-arm64-test.yaml
@@ -15,7 +15,7 @@ on:
         default: "v2.12-head"
       rancher-chart-version-2-12:
         description: "Rancher chart version for v2.12.x"
-        default: "v2.12-head"
+        default: "2.12.1"
 
 permissions:
   id-token: write

--- a/.github/workflows/sanity-upgrade-arm64-test.yaml
+++ b/.github/workflows/sanity-upgrade-arm64-test.yaml
@@ -15,7 +15,7 @@ on:
         default: "v2.12-head"
       upgraded-rancher-chart-version-2-12:
         description: "Upgraded Rancher chart version for v2.12.x"
-        default: "v2.12.1"
+        default: "2.12.1"
 
 permissions:
   id-token: write


### PR DESCRIPTION
### Description
Small PR to update the `head` commits to have a Qase reporting of 2.13. Additionally, some chart versions are using a leading `v`. This was discovered from recent upgrade tests not running and it most likely is due to that.