### PR TITLE
Update the rancher version and chart version for airgap/registry

### DIFF
--- a/.github/workflows/community-airgap-test.yaml
+++ b/.github/workflows/community-airgap-test.yaml
@@ -33,7 +33,6 @@ env:
   RKE_PROVIDER_VERSION: "${{ vars.RKE_PROVIDER_VERSION }}"
   SUITE: "^TestTfpAirgapProvisioningTestSuite$"
   SUITE_TIMEOUT: "7h"
-  TIMEOUT: "30m"
 
 permissions:
   id-token: write
@@ -102,13 +101,21 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-12 }}
+          value: | 
+            ${{ 
+              github.event.inputs.rancher_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher-version-2-12)
+            }}
 
       - name: Set Rancher chart version
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_CHART_VERSION
-          value: "${{ inputs.rancher_chart_version || github.event.inputs.rancher-chart-version-2-12 }}"
+          value: |
+            ${{ 
+              github.event.inputs.rancher_chart_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher-chart-version-2-12)
+            }}
 
       - name: Set Rancher repo
         uses: ./.github/actions/set-rancher-repo
@@ -155,7 +162,7 @@ jobs:
               awsVpcID: "${{ secrets.AWS_VPC_ID }}"
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
-              registryRootSize: ${{ vars.AWS_ROOT_SIZE_REGISTRY}}
+              registryRootSize: ${{ vars.AWS_ROOT_SIZE_REGISTRY }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
               awsUser: "${{ secrets.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 

--- a/.github/workflows/community-airgap-upgrade-test.yaml
+++ b/.github/workflows/community-airgap-upgrade-test.yaml
@@ -31,7 +31,6 @@ env:
   RKE_PROVIDER_VERSION: "${{ vars.RKE_PROVIDER_VERSION }}"
   SUITE: "^TestTfpAirgapUpgradeRancherTestSuite$"
   SUITE_TIMEOUT: "7h"
-  TIMEOUT: "30m"
 
 permissions:
   id-token: write
@@ -100,13 +99,21 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: UPGRADED_RANCHER_VERSION
-          value: ${{ inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-12 }}
+          value: | 
+            ${{ 
+              github.event.inputs.rancher_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.upgradedrancher-version-2-12)
+            }}
 
       - name: Set upgraded Rancher chart version
         uses: ./.github/actions/set-env-var
         with:
           key: UPGRADED_RANCHER_CHART_VERSION
-          value: "${{ inputs.rancher_chart_version || github.event.inputs.upgraded-rancher-chart-version-2-12 }}"
+          value: |
+            ${{ 
+              github.event.inputs.rancher_chart_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.upgraded-rancher-chart-version-2-12)
+            }}
 
       - name: Set upgraded Rancher repo
         uses: ./.github/actions/set-rancher-repo
@@ -153,7 +160,7 @@ jobs:
               awsVpcID: "${{ secrets.AWS_VPC_ID }}"
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
-              registryRootSize: ${{ vars.AWS_ROOT_SIZE_REGISTRY}}
+              registryRootSize: ${{ vars.AWS_ROOT_SIZE_REGISTRY }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
               awsUser: "${{ secrets.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 

--- a/.github/workflows/community-registry-test.yaml
+++ b/.github/workflows/community-registry-test.yaml
@@ -33,7 +33,6 @@ env:
   RKE_PROVIDER_VERSION: "${{ vars.RKE_PROVIDER_VERSION }}"
   SUITE: ^TestTfpRegistriesTestSuite$
   SUITE_TIMEOUT: 7h
-  TIMEOUT: 30m
 
 permissions:
   id-token: write
@@ -102,13 +101,21 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-12 }}
+          value: | 
+            ${{ 
+              github.event.inputs.rancher_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher-version-2-12)
+            }}
 
       - name: Set Rancher chart version
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_CHART_VERSION
-          value: ${{ inputs.rancher_chart_version || github.event.inputs.rancher-chart-version-2-12 }}
+          value: |
+            ${{ 
+              github.event.inputs.rancher_chart_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher-chart-version-2-12)
+            }}
 
       - name: Set Rancher repo
         uses: ./.github/actions/set-rancher-repo

--- a/.github/workflows/prime-airgap-test.yaml
+++ b/.github/workflows/prime-airgap-test.yaml
@@ -39,7 +39,6 @@ env:
   RKE_PROVIDER_VERSION: "${{ vars.RKE_PROVIDER_VERSION }}"
   SUITE: "^TestTfpAirgapProvisioningTestSuite$"
   SUITE_TIMEOUT: "7h"
-  TIMEOUT: "30m"
 
 permissions:
   id-token: write
@@ -108,13 +107,21 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-11 }}
+          value: | 
+            ${{ 
+              github.event.inputs.rancher_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher-version-2-11)
+            }}
 
       - name: Set Rancher chart version
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_CHART_VERSION
-          value: "${{ inputs.rancher_chart_version || github.event.inputs.rancher-chart-version-2-11 }}"
+          value: |
+            ${{ 
+              github.event.inputs.rancher_chart_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher-chart-version-2-11)
+            }}
 
       - name: Set Rancher repo
         uses: ./.github/actions/set-rancher-repo
@@ -168,7 +175,7 @@ jobs:
               awsVpcID: "${{ secrets.AWS_VPC_ID }}"
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
-              registryRootSize: ${{ vars.AWS_ROOT_SIZE_REGISTRY}}
+              registryRootSize: ${{ vars.AWS_ROOT_SIZE_REGISTRY }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
               awsUser: "${{ secrets.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
@@ -330,13 +337,21 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-10 }}
+          value: | 
+            ${{ 
+              github.event.inputs.rancher_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher-version-2-10)
+            }}
 
       - name: Set Rancher chart version
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_CHART_VERSION
-          value: "${{ inputs.rancher_chart_version || github.event.inputs.rancher-chart-version-2-10 }}"
+          value: |
+            ${{ 
+              github.event.inputs.rancher_chart_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher-chart-version-2-10)
+            }}
 
       - name: Set Rancher repo
         uses: ./.github/actions/set-rancher-repo
@@ -390,7 +405,7 @@ jobs:
               awsVpcID: "${{ secrets.AWS_VPC_ID }}"
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
-              registryRootSize: ${{ vars.AWS_ROOT_SIZE_REGISTRY}}
+              registryRootSize: ${{ vars.AWS_ROOT_SIZE_REGISTRY }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
               awsUser: "${{ secrets.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 

--- a/.github/workflows/prime-airgap-upgrade-test.yaml
+++ b/.github/workflows/prime-airgap-upgrade-test.yaml
@@ -37,7 +37,6 @@ env:
   RKE_PROVIDER_VERSION: "${{ vars.RKE_PROVIDER_VERSION }}"
   SUITE: "^TestTfpAirgapUpgradeRancherTestSuite$"
   SUITE_TIMEOUT: "7h"
-  TIMEOUT: "30m"
 
 permissions:
   id-token: write
@@ -106,13 +105,21 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: UPGRADED_RANCHER_VERSION
-          value: ${{ inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-11 }}
+          value: | 
+            ${{ 
+              github.event.inputs.rancher_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.upgraded-rancher-version-2-11)
+            }}
 
       - name: Set upgraded Rancher chart version
         uses: ./.github/actions/set-env-var
         with:
           key: UPGRADED_RANCHER_CHART_VERSION
-          value: "${{ inputs.rancher_chart_version || github.event.inputs.upgraded-rancher-chart-version-2-11 }}"
+          value: |
+            ${{ 
+              github.event.inputs.rancher_chart_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.upgraded-rancher-chart-version-2-11)
+            }}
 
       - name: Set upgraded Rancher repo
         uses: ./.github/actions/set-rancher-repo
@@ -168,7 +175,7 @@ jobs:
               awsVpcID: "${{ secrets.AWS_VPC_ID }}"
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
-              registryRootSize: ${{ vars.AWS_ROOT_SIZE_REGISTRY}}
+              registryRootSize: ${{ vars.AWS_ROOT_SIZE_REGISTRY }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
               awsUser: "${{ secrets.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
@@ -337,13 +344,21 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: UPGRADED_RANCHER_VERSION
-          value: ${{ inputs.rancher_version || github.event.inputs.upgraded-rancher-version-2-10 }}
+          value: | 
+            ${{ 
+              github.event.inputs.rancher_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.upgraded-rancher-version-2-10)
+            }}
 
       - name: Set upgraded Rancher chart version
         uses: ./.github/actions/set-env-var
         with:
           key: UPGRADED_RANCHER_CHART_VERSION
-          value: "${{ inputs.rancher_chart_version || github.event.inputs.upgraded-rancher-chart-version-2-10 }}"
+          value: |
+            ${{ 
+              github.event.inputs.rancher_chart_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.upgraded-rancher-chart-version-2-10)
+            }}
 
       - name: Set upgraded Rancher repo
         uses: ./.github/actions/set-rancher-repo
@@ -399,7 +414,7 @@ jobs:
               awsVpcID: "${{ secrets.AWS_VPC_ID }}"
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
-              registryRootSize: ${{ vars.AWS_ROOT_SIZE_REGISTRY}}
+              registryRootSize: ${{ vars.AWS_ROOT_SIZE_REGISTRY }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
               awsUser: "${{ secrets.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 

--- a/.github/workflows/prime-registry-test.yaml
+++ b/.github/workflows/prime-registry-test.yaml
@@ -39,7 +39,6 @@ env:
   RKE_PROVIDER_VERSION: "${{ vars.RKE_PROVIDER_VERSION }}"
   SUITE: ^TestTfpRegistriesTestSuite$
   SUITE_TIMEOUT: 7h
-  TIMEOUT: 30m
 
 permissions:
   id-token: write
@@ -108,13 +107,21 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-11 }}
+          value: | 
+            ${{ 
+              github.event.inputs.rancher_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher-version-2-11)
+            }}
 
       - name: Set Rancher chart version
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_CHART_VERSION
-          value: ${{ inputs.rancher_chart_version || github.event.inputs.rancher-chart-version-2-11 }}
+          value: |
+            ${{ 
+              github.event.inputs.rancher_chart_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher-chart-version-2-11)
+            }}
 
       - name: Set Rancher repo
         uses: ./.github/actions/set-rancher-repo
@@ -169,7 +176,7 @@ jobs:
               awsVpcID: "${{ secrets.AWS_VPC_ID }}"
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
-              registryRootSize: ${{ vars.AWS_ROOT_SIZE_REGISTRY}}
+              registryRootSize: ${{ vars.AWS_ROOT_SIZE_REGISTRY }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
               awsUser: "${{ secrets.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
@@ -327,13 +334,21 @@ jobs:
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_VERSION
-          value: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-10 }}
+          value: | 
+            ${{ 
+              github.event.inputs.rancher_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher-version-2-10)
+            }}
 
       - name: Set Rancher chart version
         uses: ./.github/actions/set-env-var
         with:
           key: RANCHER_CHART_VERSION
-          value: ${{ inputs.rancher_chart_version || github.event.inputs.rancher-chart-version-2-10 }}
+          value: |
+            ${{ 
+              github.event.inputs.rancher_chart_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher-chart-version-2-10)
+            }}
 
       - name: Set Rancher repo
         uses: ./.github/actions/set-rancher-repo
@@ -388,7 +403,7 @@ jobs:
               awsVpcID: "${{ secrets.AWS_VPC_ID }}"
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
-              registryRootSize: ${{ vars.AWS_ROOT_SIZE_REGISTRY}}
+              registryRootSize: ${{ vars.AWS_ROOT_SIZE_REGISTRY }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
               awsUser: "${{ secrets.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 


### PR DESCRIPTION
### Description
The check rancher tag is having issues when running the airgap and private registry workflows. Through some deep diving, it is speculated that the issue pertains to `workflow_dispatch`. Specifically, there are secrets that may not be properly getting set. This is further backed by the point that when manually ran, it is working fine.