### PR TITLE
Update Qase reporter to display Rancher type

### DIFF
--- a/pipeline/qase/reporter/main.go
+++ b/pipeline/qase/reporter/main.go
@@ -176,12 +176,7 @@ func reportTestQases(qaseService *qase.Service, testRunID int64) error {
 			basePathDirs := strings.Split(basepath, "/")
 			baseTestPathDir := basePathDirs[len(basePathDirs)-1]
 
-			logrus.Infof("base path: %s", basepath)
-			logrus.Infof("base path dirs: %s", basePathDirs)
-			logrus.Infof("baseTestPathDir: %s", baseTestPathDir)
-
 			packagePath := strings.Split(goTestResult.Package, baseTestPathDir)
-			logrus.Infof("packagePath: %v", packagePath)
 			if len(packagePath) > 2 {
 				return errors.New("Error base path directory is not unique")
 			}

--- a/pipeline/qase/schemaParams.go
+++ b/pipeline/qase/schemaParams.go
@@ -13,11 +13,23 @@ import (
 // GetProvisioningSchemaParams gets a set of params from the cattle config and returns a qase params object
 func GetProvisioningSchemaParams(configMap map[string]any) []upstream.Params {
 	var params []upstream.Params
-	var amiParam, windows2019AMIParam, windows2022AMIParam upstream.Params
+	var rancherType, upgradedRancherType, amiParam, windows2019AMIParam, windows2022AMIParam upstream.Params
 
 	_, terraform, terratest, _ := config.LoadTFPConfigs(configMap)
 
 	currentDate := time.Now().Format("2006-01-02 03:04PM")
+
+	if terraform.Standalone.RancherImage == "rancher/rancher" {
+		rancherType = upstream.Params{Title: "Rancher Community", Values: []string{terraform.Standalone.RancherTagVersion}}
+	} else {
+		rancherType = upstream.Params{Title: "Rancher Prime", Values: []string{terraform.Standalone.RancherTagVersion}}
+	}
+
+	if terraform.Standalone.UpgradedRancherImage == "rancher/rancher" {
+		upgradedRancherType = upstream.Params{Title: "Upgraded to Rancher Community", Values: []string{terraform.Standalone.UpgradedRancherTagVersion}}
+	} else {
+		upgradedRancherType = upstream.Params{Title: "Upgraded to Rancher Prime", Values: []string{terraform.Standalone.UpgradedRancherTagVersion}}
+	}
 
 	if strings.Contains(terraform.Module, modules.EC2) {
 		amiParam = upstream.Params{Title: "AMI", Values: []string{terraform.AWSConfig.AMI}}
@@ -36,7 +48,7 @@ func GetProvisioningSchemaParams(configMap map[string]any) []upstream.Params {
 	cniParam := upstream.Params{Title: "CNI", Values: []string{terraform.CNI}}
 	timeParam := upstream.Params{Title: "Time", Values: []string{currentDate}}
 
-	params = append(params, amiParam, windows2019AMIParam, windows2022AMIParam, moduleParam, k8sParam, cniParam, timeParam)
+	params = append(params, rancherType, upgradedRancherType, amiParam, windows2019AMIParam, windows2022AMIParam, moduleParam, k8sParam, cniParam, timeParam)
 
 	return params
 }

--- a/tests/airgap/README.md
+++ b/tests/airgap/README.md
@@ -135,4 +135,4 @@ If you are planning to report to Qase locally, then you will need to have the fo
      - `QASE_AUTOMATION_TOKEN=""`
      - `QASE_TEST_RUN_ID=""`
 3. Append `./reporter` to the end of the `gotestsum` command. See an example below::
-     - `gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/airgap  --junitfile results.xml --jsonfile results.json -- -timeout=9h -v -run TestTfpAirgapProvisioningTestSuite$";/path/to/tfp-automation/reporter`
+     - `gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/airgap  --junitfile results.xml --jsonfile results.json -- -timeout=9h -v -run "TestTfpAirgapProvisioningTestSuite$";/path/to/tfp-automation/reporter`

--- a/tests/proxy/README.md
+++ b/tests/proxy/README.md
@@ -146,4 +146,4 @@ If you are planning to report to Qase locally, then you will need to have the fo
      - `QASE_AUTOMATION_TOKEN=""`
      - `QASE_TEST_RUN_ID=""`
 3. Append `./reporter` to the end of the `gotestsum` command. See an example below::
-     - `gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/proxy  --junitfile results.xml --jsonfile results.json -- -timeout=3h -v -run TestTfpProxyProvisioningTestSuite$";/path/to/tfp-automation/reporter`
+     - `gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/proxy  --junitfile results.xml --jsonfile results.json -- -timeout=3h -v -run "TestTfpProxyProvisioningTestSuite$";/path/to/tfp-automation/reporter`

--- a/tests/registries/README.md
+++ b/tests/registries/README.md
@@ -126,4 +126,4 @@ If you are planning to report to Qase locally, then you will need to have the fo
      - `QASE_AUTOMATION_TOKEN=""`
      - `QASE_TEST_RUN_ID=""`
 3. Append `./reporter` to the end of the `gotestsum` command. See an example below::
-     - `gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/airgap  --junitfile results.xml --jsonfile results.json -- -timeout=8h -v -run TestTfpAirgapProvisioningTestSuite$";/path/to/tfp-automation/reporter`
+     - `gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/airgap  --junitfile results.xml --jsonfile results.json -- -timeout=8h -v -run "TestTfpAirgapProvisioningTestSuite$";/path/to/tfp-automation/reporter`

--- a/tests/sanity/README.md
+++ b/tests/sanity/README.md
@@ -140,4 +140,4 @@ If you are planning to report to Qase locally, then you will need to have the fo
      - `QASE_AUTOMATION_TOKEN=""`
      - `QASE_TEST_RUN_ID=""`
 3. Append `./reporter` to the end of the `gotestsum` command. See an example below::
-     - `gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/sanity  --junitfile results.xml --jsonfile results.json -- -timeout=2h -v -run TestTfpSanityProvisioningTestSuite$";/path/to/tfp-automation/reporter`
+     - `gotestsum --format standard-verbose --packages=github.com/rancher/tfp-automation/tests/sanity  --junitfile results.xml --jsonfile results.json -- -timeout=2h -v -run "TestTfpSanityProvisioningTestSuite$";/path/to/tfp-automation/reporter`


### PR DESCRIPTION
### Description
When reporting to Qase for post release checks, it would be nice to be able to display the Rancher type of Community/Prime. Specifically, when a release has both Community and Prime, this is especially more desirable. This PR updates the Qase schemas to show this information.