### PR TITLE
Update tfp-automation to use v3IDs and reuse rancher/tests validations

### DIFF
--- a/tests/airgap/airgap_provisioning_test.go
+++ b/tests/airgap/airgap_provisioning_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/rancher/shepherd/extensions/defaults/namespaces"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
+	clusterActions "github.com/rancher/tests/actions/clusters"
+	provisioningActions "github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -123,9 +125,11 @@ func (a *TfpAirgapProvisioningTestSuite) TestTfpAirgapProvisioning() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, a.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(a.T(), perTestTerraformOptions, keyPath)
 
-			clusterIDs, customClusterNames := provisioning.Provision(a.T(), a.client, a.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
-			provisioning.VerifyClustersState(a.T(), a.client, clusterIDs)
-			provisioning.VerifyServiceAccountTokenSecret(a.T(), a.client, clusterIDs)
+			clusters, customClusterNames := provisioning.Provision(a.T(), a.client, a.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+			err = provisioningActions.VerifyClusterReady(a.client, clusters[0])
+			require.NoError(a.T(), err)
+			err = clusterActions.VerifyServiceAccountTokenSecret(a.client, clusters[0].Name)
+			require.NoError(a.T(), err)
 
 			cluster, err := a.client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetDefault + "/" + terraform.ResourcePrefix)
 			require.NoError(a.T(), err)
@@ -134,9 +138,11 @@ func (a *TfpAirgapProvisioningTestSuite) TestTfpAirgapProvisioning() {
 			require.NoError(a.T(), err)
 
 			if strings.Contains(terraform.Module, clustertypes.WINDOWS) {
-				clusterIDs, _ = provisioning.Provision(a.T(), a.client, a.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, true, true, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
-				provisioning.VerifyClustersState(a.T(), a.client, clusterIDs)
-				provisioning.VerifyServiceAccountTokenSecret(a.T(), a.client, clusterIDs)
+				clusters, _ = provisioning.Provision(a.T(), a.client, a.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, true, true, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+				err = provisioningActions.VerifyClusterReady(a.client, clusters[0])
+				require.NoError(a.T(), err)
+				err = clusterActions.VerifyServiceAccountTokenSecret(a.client, clusters[0].Name)
+				require.NoError(a.T(), err)
 
 				err = pods.VerifyClusterPods(a.client, cluster)
 				require.NoError(a.T(), err)

--- a/tests/airgap/airgap_upgrade_rancher_test.go
+++ b/tests/airgap/airgap_upgrade_rancher_test.go
@@ -7,9 +7,12 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/rancher/shepherd/clients/rancher"
+	steveV1 "github.com/rancher/shepherd/clients/rancher/v1"
 	"github.com/rancher/shepherd/extensions/defaults/namespaces"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
+	clusterActions "github.com/rancher/tests/actions/clusters"
+	provisioningActions "github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tfp-automation/config"
@@ -96,6 +99,7 @@ func (a *TfpAirgapUpgradeRancherTestSuite) provisionAndVerifyCluster(name string
 	testUser, testPassword string) string {
 	var clusterIDs []string
 	var nestedRancherModuleDir string
+	var clusters []*steveV1.SteveAPIObject
 
 	customClusterNames := []string{}
 
@@ -139,10 +143,12 @@ func (a *TfpAirgapUpgradeRancherTestSuite) provisionAndVerifyCluster(name string
 
 				rancher, terraform, terratest, _ := config.LoadTFPConfigs(cattleConfig)
 
-				clusterIDs, customClusterNames = provisioning.Provision(t, a.client, standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, true, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
-				provisioning.VerifyClustersState(t, a.client, clusterIDs)
-				provisioning.VerifyServiceAccountTokenSecret(t, a.client, clusterIDs)
+				clusters, customClusterNames = provisioning.Provision(t, a.client, standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, true, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+				err = provisioningActions.VerifyClusterReady(a.client, clusters[0])
+				require.NoError(t, err)
 
+				err = clusterActions.VerifyServiceAccountTokenSecret(a.client, clusters[0].Name)
+				require.NoError(t, err)
 				cluster, err := a.client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetDefault + "/" + terraform.ResourcePrefix)
 				require.NoError(t, err)
 
@@ -150,10 +156,12 @@ func (a *TfpAirgapUpgradeRancherTestSuite) provisionAndVerifyCluster(name string
 				require.NoError(t, err)
 
 				if strings.Contains(terraform.Module, clustertypes.WINDOWS) {
-					clusterIDs, customClusterNames = provisioning.Provision(t, a.client, standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, true, true, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
-					provisioning.VerifyClustersState(t, a.client, clusterIDs)
-					provisioning.VerifyServiceAccountTokenSecret(t, a.client, clusterIDs)
+					clusters, customClusterNames = provisioning.Provision(t, a.client, standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, true, true, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+					err = provisioningActions.VerifyClusterReady(a.client, clusters[0])
+					require.NoError(t, err)
 
+					err = clusterActions.VerifyServiceAccountTokenSecret(a.client, clusters[0].Name)
+					require.NoError(t, err)
 					err = pods.VerifyClusterPods(a.client, cluster)
 					require.NoError(t, err)
 				}

--- a/tests/extensions/provisioning/provision.go
+++ b/tests/extensions/provisioning/provision.go
@@ -1,25 +1,33 @@
 package provisioning
 
 import (
+	"context"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/rancher/shepherd/clients/rancher"
-	clusterExtensions "github.com/rancher/shepherd/extensions/clusters"
+	steveV1 "github.com/rancher/shepherd/clients/rancher/v1"
+	extClusters "github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/defaults"
+	"github.com/rancher/shepherd/extensions/defaults/namespaces"
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/defaults/providers"
+	"github.com/rancher/tfp-automation/defaults/stevetypes"
 	framework "github.com/rancher/tfp-automation/framework/set"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
 )
 
 // Provision is a function that will run terraform init and apply Terraform resources to provision a cluster.
 func Provision(t *testing.T, client, standardUserClient *rancher.Client, rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig,
 	terratestConfig *config.TerratestConfig, testUser, testPassword string, terraformOptions *terraform.Options,
 	configMap []map[string]any, newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File, isWindows, persistClusters,
-	containsCustomModule bool, clusterIDs, customClusterNames []string, nestedRancherModuleDir string) ([]string, []string) {
+	containsCustomModule bool, clusterIDs, customClusterNames []string, nestedRancherModuleDir string) ([]*steveV1.SteveAPIObject, []string) {
 	var err error
 	var clusterNames []string
 
@@ -38,12 +46,35 @@ func Provision(t *testing.T, client, standardUserClient *rancher.Client, rancher
 
 	terraform.InitAndApply(t, terraformOptions)
 
+	var clusterObjects []*steveV1.SteveAPIObject
 	for _, clusterName := range clusterNames {
-		clusterID, err := clusterExtensions.GetClusterIDByName(client, clusterName)
+		var createdCluster *steveV1.SteveAPIObject
+		err = kwait.PollUntilContextTimeout(context.TODO(), 10*time.Second, defaults.FiveMinuteTimeout, false, func(ctx context.Context) (done bool, err error) {
+			adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+			if err != nil {
+				logrus.Warningf("Unable to get admin cluster client (%s) retrying", clusterName)
+				return false, nil
+			}
+
+			if IsImportedModule(terraformConfig.Module) || IsHostedModule(terraformConfig.Module) {
+				clusterName, err = extClusters.GetClusterIDByName(adminClient, terraformConfig.ResourcePrefix)
+				if err != nil {
+					return false, nil
+				}
+			}
+
+			createdCluster, err = adminClient.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetDefault + "/" + clusterName)
+			if err != nil {
+				logrus.Warningf("Unable to get cluster (%s) retrying", clusterName)
+				return false, nil
+			}
+
+			return true, nil
+		})
 		require.NoError(t, err)
 
-		clusterIDs = append(clusterIDs, clusterID)
+		clusterObjects = append(clusterObjects, createdCluster)
 	}
 
-	return clusterIDs, customClusterNames
+	return clusterObjects, customClusterNames
 }

--- a/tests/extensions/provisioning/supportedModules.go
+++ b/tests/extensions/provisioning/supportedModules.go
@@ -2,6 +2,7 @@ package provisioning
 
 import (
 	"slices"
+	"strings"
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/rancher/shepherd/pkg/config/operations"
@@ -63,6 +64,22 @@ func ImportedClusterModules(terraformConfig *config.TerraformConfig) (string, st
 	}
 
 	return rke2Module, rke2Windows2019, rke2Windows2022, k3sModule
+}
+
+func IsImportedModule(module string) bool {
+	if strings.Contains(module, "import") {
+		return true
+	}
+
+	return false
+}
+
+func IsHostedModule(module string) bool {
+	if strings.Contains(module, "gke") || strings.Contains(module, "eks") || strings.Contains(module, "aks") {
+		return true
+	}
+
+	return false
 }
 
 // SupportedModules is a function that will check if the user-inputted module is supported.

--- a/tests/extensions/provisioning/verify.go
+++ b/tests/extensions/provisioning/verify.go
@@ -9,71 +9,16 @@ import (
 	provv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	"github.com/rancher/shepherd/clients/rancher"
 	steveV1 "github.com/rancher/shepherd/clients/rancher/v1"
-	clusterExtensions "github.com/rancher/shepherd/extensions/clusters"
 	"github.com/rancher/shepherd/extensions/kubeconfig"
-	"github.com/rancher/shepherd/extensions/workloads/pods"
-	clusterActions "github.com/rancher/tests/actions/clusters"
-	"github.com/rancher/tests/actions/psact"
 	"github.com/rancher/tests/actions/registries"
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/framework/cleanup"
-	"github.com/rancher/tfp-automation/tests/extensions/postProvisioning"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 )
-
-// VerifyClustersState validates that all clusters are active and have no pod errors.
-func VerifyClustersState(t *testing.T, client *rancher.Client, clusterIDs []string) {
-	for _, clusterID := range clusterIDs {
-		cluster, err := client.Management.Cluster.ByID(clusterID)
-		require.NoError(t, err)
-
-		logrus.Infof("Waiting for cluster %v to be in an active state...", cluster.Name)
-		err = postProvisioning.IsClusterActive(client, clusterID)
-		require.NoError(t, err)
-
-		logrus.Infof("Waiting for all nodes to be active on cluster: %s", cluster.Name)
-		err = postProvisioning.AreNodesActive(client, clusterID)
-		require.NoError(t, err)
-	}
-}
-
-// VerifyV3ClustersPods validates that all pods in the v3 clusters are running without errors.
-func VerifyV3ClustersPods(t *testing.T, client *rancher.Client, clusterIDs []string) {
-	for _, clusterID := range clusterIDs {
-		podErrors := pods.StatusPods(client, clusterID)
-		require.Empty(t, podErrors)
-	}
-}
-
-// VerifyServiceAccountTokenSecret validates that the service account token secret exists for each cluster
-func VerifyServiceAccountTokenSecret(t *testing.T, client *rancher.Client, clusterIDs []string) {
-	for _, clusterID := range clusterIDs {
-		clusterName, err := clusterExtensions.GetClusterNameByID(client, clusterID)
-		require.NoError(t, err)
-
-		clusterToken, err := clusterActions.CheckServiceAccountTokenSecret(client, clusterName)
-		require.NoError(t, err)
-		require.NotEmpty(t, clusterToken)
-	}
-}
-
-// VerifyClusterPSACT validates that psact clusters can provision an nginx deployment
-func VerifyClusterPSACT(t *testing.T, client *rancher.Client, clusterIDs []string) {
-	for _, clusterID := range clusterIDs {
-		cluster, err := client.Management.Cluster.ByID(clusterID)
-		require.NoError(t, err)
-
-		psactName := cluster.DefaultPodSecurityAdmissionConfigurationTemplateName
-		if psactName == string(config.RancherPrivileged) || psactName == string(config.RancherRestricted) {
-			err := psact.CreateNginxDeployment(client, clusterID, psactName)
-			require.NoError(t, err)
-		}
-	}
-}
 
 // VerifyRegistry validates that the expected registry is set.
 func VerifyRegistry(t *testing.T, client *rancher.Client, clusterID string, terraformConfig *config.TerraformConfig) {

--- a/tests/infrastructure/ranchers/upgrade_rancher_resources.go
+++ b/tests/infrastructure/ranchers/upgrade_rancher_resources.go
@@ -7,7 +7,7 @@ import (
 	"github.com/rancher/shepherd/clients/rancher"
 	extClusters "github.com/rancher/shepherd/extensions/clusters"
 	"github.com/rancher/shepherd/extensions/defaults/namespaces"
-	"github.com/rancher/tests/actions/provisioning"
+	provisioningActions "github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/defaults/stevetypes"
@@ -44,7 +44,7 @@ func CleanupDownstreamClusters(t *testing.T, client *rancher.Client, terraformCo
 			continue
 		}
 
-		err = provisioning.VerifyClusterReady(client, &cluster)
+		err = provisioningActions.VerifyClusterReady(client, &cluster)
 		require.NoError(t, err)
 
 		dsCluster, err := client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetDefault + "/" + cluster.Name)
@@ -54,7 +54,7 @@ func CleanupDownstreamClusters(t *testing.T, client *rancher.Client, terraformCo
 		err = extClusters.DeleteK3SRKE2Cluster(client, dsCluster.ID)
 		require.NoError(t, err)
 
-		provisioning.VerifyDeleteRKE2K3SCluster(t, client, dsCluster.ID)
+		provisioningActions.VerifyDeleteRKE2K3SCluster(t, client, dsCluster.ID)
 	}
 }
 

--- a/tests/kdm/kdm_test.go
+++ b/tests/kdm/kdm_test.go
@@ -12,6 +12,9 @@ import (
 	"github.com/rancher/shepherd/extensions/defaults/namespaces"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
+	clusterActions "github.com/rancher/tests/actions/clusters"
+	provisioningActions "github.com/rancher/tests/actions/provisioning"
+
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -139,10 +142,12 @@ func (k *KDMTestSuite) TestKDM() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, k.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(k.T(), perTestTerraformOptions, keyPath)
 
-			clusterIDs, _ := provisioning.Provision(k.T(), k.client, k.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
-			provisioning.VerifyClustersState(k.T(), k.client, clusterIDs)
-			provisioning.VerifyServiceAccountTokenSecret(k.T(), k.client, clusterIDs)
+			clusters, _ := provisioning.Provision(k.T(), k.client, k.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+			err = provisioningActions.VerifyClusterReady(k.client, clusters[0])
+			require.NoError(k.T(), err)
 
+			err = clusterActions.VerifyServiceAccountTokenSecret(k.client, clusters[0].Name)
+			require.NoError(k.T(), err)
 			cluster, err := k.client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetDefault + "/" + terraform.ResourcePrefix)
 			require.NoError(k.T(), err)
 

--- a/tests/postrelease/post_release_test.go
+++ b/tests/postrelease/post_release_test.go
@@ -52,10 +52,10 @@ func (s *TfpPostReleaseTestSuite) TestTfpPostRelease() {
 			err = pods.VerifyClusterPods(s.client, cluster)
 			require.NoError(s.T(), err)
 
-			configMap, err := provisioning.UniquifyTerraform([]map[string]any{s.cattleConfig})
+			cattleConfig, err := provisioning.UniquifyTerraform(s.cattleConfig)
 			require.NoError(t, err)
 
-			params := tfpQase.GetProvisioningSchemaParams(configMap[0])
+			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
 			err = qase.UpdateSchemaParameters(tt.name, params)
 			if err != nil {
 				logrus.Warningf("Failed to upload schema parameters %s", err)

--- a/tests/postrelease/post_release_upgrade_test.go
+++ b/tests/postrelease/post_release_upgrade_test.go
@@ -54,10 +54,10 @@ func (s *TfpPostReleaseUpgradeTestSuite) TestTfpPostReleaseUpgrade() {
 			err = pods.VerifyClusterPods(s.client, cluster)
 			require.NoError(s.T(), err)
 
-			configMap, err := provisioning.UniquifyTerraform([]map[string]any{s.cattleConfig})
+			cattleConfig, err := provisioning.UniquifyTerraform(s.cattleConfig)
 			require.NoError(t, err)
 
-			params := tfpQase.GetProvisioningSchemaParams(configMap[0])
+			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
 			err = qase.UpdateSchemaParameters(tt.name, params)
 			if err != nil {
 				logrus.Warningf("Failed to upload schema parameters %s", err)

--- a/tests/proxy/proxy_provisioning_test.go
+++ b/tests/proxy/proxy_provisioning_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/rancher/shepherd/extensions/defaults/namespaces"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
+	clusterActions "github.com/rancher/tests/actions/clusters"
+	provisioningActions "github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -120,10 +122,11 @@ func (p *TfpProxyProvisioningTestSuite) TestTfpNoProxyProvisioning() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, p.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(p.T(), perTestTerraformOptions, keyPath)
 
-			clusterIDs, customClusterNames := provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
-			provisioning.VerifyClustersState(p.T(), p.client, clusterIDs)
-			provisioning.VerifyServiceAccountTokenSecret(p.T(), p.client, clusterIDs)
-
+			clusters, customClusterNames := provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+			err = provisioningActions.VerifyClusterReady(p.client, clusters[0])
+			require.NoError(p.T(), err)
+			err = clusterActions.VerifyServiceAccountTokenSecret(p.client, clusters[0].Name)
+			require.NoError(p.T(), err)
 			cluster, err := p.client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetDefault + "/" + terraform.ResourcePrefix)
 			require.NoError(p.T(), err)
 
@@ -131,10 +134,11 @@ func (p *TfpProxyProvisioningTestSuite) TestTfpNoProxyProvisioning() {
 			require.NoError(p.T(), err)
 
 			if strings.Contains(terraform.Module, clustertypes.WINDOWS) {
-				clusterIDs, _ = provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, true, true, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
-				provisioning.VerifyClustersState(p.T(), p.client, clusterIDs)
-				provisioning.VerifyServiceAccountTokenSecret(p.T(), p.client, clusterIDs)
-
+				clusters, _ = provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, true, true, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+				err = provisioningActions.VerifyClusterReady(p.client, clusters[0])
+				require.NoError(p.T(), err)
+				err = clusterActions.VerifyServiceAccountTokenSecret(p.client, clusters[0].Name)
+				require.NoError(p.T(), err)
 				err = pods.VerifyClusterPods(p.client, cluster)
 				require.NoError(p.T(), err)
 			}
@@ -213,10 +217,11 @@ func (p *TfpProxyProvisioningTestSuite) TestTfpProxyProvisioning() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, p.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(p.T(), perTestTerraformOptions, keyPath)
 
-			clusterIDs, _ := provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
-			provisioning.VerifyClustersState(p.T(), p.client, clusterIDs)
-			provisioning.VerifyServiceAccountTokenSecret(p.T(), p.client, clusterIDs)
-
+			clusters, _ := provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+			err = provisioningActions.VerifyClusterReady(p.client, clusters[0])
+			require.NoError(p.T(), err)
+			err = clusterActions.VerifyServiceAccountTokenSecret(p.client, clusters[0].Name)
+			require.NoError(p.T(), err)
 			cluster, err := p.client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetDefault + "/" + terraform.ResourcePrefix)
 			require.NoError(p.T(), err)
 
@@ -224,9 +229,11 @@ func (p *TfpProxyProvisioningTestSuite) TestTfpProxyProvisioning() {
 			require.NoError(p.T(), err)
 
 			if strings.Contains(terraform.Module, clustertypes.WINDOWS) {
-				clusterIDs, _ = provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, true, true, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
-				provisioning.VerifyClustersState(p.T(), p.client, clusterIDs)
-				provisioning.VerifyServiceAccountTokenSecret(p.T(), p.client, clusterIDs)
+				clusters, _ = provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, true, true, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+				err = provisioningActions.VerifyClusterReady(p.client, clusters[0])
+				require.NoError(p.T(), err)
+				err = clusterActions.VerifyServiceAccountTokenSecret(p.client, clusters[0].Name)
+				require.NoError(p.T(), err)
 				err = pods.VerifyClusterPods(p.client, cluster)
 				require.NoError(p.T(), err)
 			}

--- a/tests/proxy/proxy_upgrade_rancher_test.go
+++ b/tests/proxy/proxy_upgrade_rancher_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/rancher/shepherd/extensions/defaults/namespaces"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
+	clusterActions "github.com/rancher/tests/actions/clusters"
+	provisioningActions "github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tfp-automation/config"
@@ -137,10 +139,11 @@ func (p *TfpProxyUpgradeRancherTestSuite) provisionAndVerifyCluster(name string,
 
 				tt.name = name + tt.name
 
-				clusterIDs, customClusterNames := provisioning.Provision(p.T(), p.client, standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, true, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
-				provisioning.VerifyClustersState(p.T(), p.client, clusterIDs)
-				provisioning.VerifyServiceAccountTokenSecret(p.T(), p.client, clusterIDs)
-
+				clusters, customClusterNames := provisioning.Provision(p.T(), p.client, standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, true, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+				err = provisioningActions.VerifyClusterReady(p.client, clusters[0])
+				require.NoError(p.T(), err)
+				err = clusterActions.VerifyServiceAccountTokenSecret(p.client, clusters[0].Name)
+				require.NoError(p.T(), err)
 				cluster, err := p.client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetDefault + "/" + terraform.ResourcePrefix)
 				require.NoError(p.T(), err)
 
@@ -148,10 +151,11 @@ func (p *TfpProxyUpgradeRancherTestSuite) provisionAndVerifyCluster(name string,
 				require.NoError(p.T(), err)
 
 				if strings.Contains(terraform.Module, clustertypes.WINDOWS) {
-					clusterIDs, customClusterNames = provisioning.Provision(p.T(), p.client, standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, true, true, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
-					provisioning.VerifyClustersState(p.T(), p.client, clusterIDs)
-					provisioning.VerifyServiceAccountTokenSecret(p.T(), p.client, clusterIDs)
-
+					clusters, customClusterNames = provisioning.Provision(p.T(), p.client, standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, true, true, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+					err = provisioningActions.VerifyClusterReady(p.client, clusters[0])
+					require.NoError(p.T(), err)
+					err = clusterActions.VerifyServiceAccountTokenSecret(p.client, clusters[0].Name)
+					require.NoError(p.T(), err)
 					err = pods.VerifyClusterPods(p.client, cluster)
 					require.NoError(p.T(), err)
 				}

--- a/tests/rancher2/airgap/airgap_ace_test.go
+++ b/tests/rancher2/airgap/airgap_ace_test.go
@@ -12,6 +12,8 @@ import (
 	shepherdConfig "github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
+	clusterActions "github.com/rancher/tests/actions/clusters"
+	provisioningActions "github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -142,10 +144,11 @@ func (a *AirgapACETestSuite) TestTfpAirgapACE() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, a.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(a.T(), perTestTerraformOptions, keyPath)
 
-			clusterIDs, _ := provisioning.Provision(a.T(), a.client, a.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
-			provisioning.VerifyClustersState(a.T(), a.client, clusterIDs)
-			provisioning.VerifyServiceAccountTokenSecret(a.T(), a.client, clusterIDs)
-
+			clusters, _ := provisioning.Provision(a.T(), a.client, a.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+			err = provisioningActions.VerifyClusterReady(a.client, clusters[0])
+			require.NoError(a.T(), err)
+			err = clusterActions.VerifyServiceAccountTokenSecret(a.client, clusters[0].Name)
+			require.NoError(a.T(), err)
 			cluster, err := a.client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetDefault + "/" + terraform.ResourcePrefix)
 			require.NoError(a.T(), err)
 

--- a/tests/rancher2/os/os_test.go
+++ b/tests/rancher2/os/os_test.go
@@ -13,7 +13,9 @@ import (
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/config/operations/permutations"
 	"github.com/rancher/shepherd/pkg/session"
+	clusterActions "github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/nodes/ec2"
+	provisioningActions "github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads"
 	"github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -136,10 +138,12 @@ func (o *OSValidationTestSuite) TestDynamicOSValidation() {
 				logrus.Infof("Provisioning Cluster Type: %s, "+"K8s Version: %s, "+"CNI: %s", terraformConfig.Module, terratestConfig.KubernetesVersion, terraformConfig.CNI)
 			}
 
-			clusterIDs, _ = provisioning.Provision(o.T(), o.client, o.standardUserClient, o.rancherConfig, o.terraformConfig, o.terratestConfig, testUser, testPassword, o.terraformOptions, batch, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, "")
+			clusters, _ := provisioning.Provision(o.T(), o.client, o.standardUserClient, o.rancherConfig, o.terraformConfig, o.terratestConfig, testUser, testPassword, o.terraformOptions, batch, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, "")
 			time.Sleep(2 * time.Minute)
-			provisioning.VerifyClustersState(o.T(), o.client, clusterIDs)
-			provisioning.VerifyServiceAccountTokenSecret(o.T(), o.client, clusterIDs)
+			err = provisioningActions.VerifyClusterReady(o.client, clusters[0])
+			require.NoError(o.T(), err)
+			err = clusterActions.VerifyServiceAccountTokenSecret(o.client, clusters[0].Name)
+			require.NoError(o.T(), err)
 		})
 
 		for _, clusterID := range clusterIDs {

--- a/tests/rancher2/provisioning/dynamic_provision_custom_test.go
+++ b/tests/rancher2/provisioning/dynamic_provision_custom_test.go
@@ -13,6 +13,8 @@ import (
 	shepherdConfig "github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
+	clusterActions "github.com/rancher/tests/actions/clusters"
+	provisioningActions "github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -109,19 +111,22 @@ func (p *DynamicProvisionCustomTestSuite) TestTfpProvisionCustomDynamicInput() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, p.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(p.T(), perTestTerraformOptions, keyPath)
 
-			clusterIDs, customClusterNames := provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
-			provisioning.VerifyClustersState(p.T(), p.client, clusterIDs)
-			provisioning.VerifyServiceAccountTokenSecret(p.T(), p.client, clusterIDs)
-
+			clusters, customClusterNames := provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+			err = provisioningActions.VerifyClusterReady(p.client, clusters[0])
+			require.NoError(p.T(), err)
+			err = clusterActions.VerifyServiceAccountTokenSecret(p.client, clusters[0].Name)
+			require.NoError(p.T(), err)
 			cluster, err := p.client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetDefault + "/" + terraform.ResourcePrefix)
 			require.NoError(p.T(), err)
 
 			pods.VerifyClusterPods(p.client, cluster)
 
 			if strings.Contains(p.terraformConfig.Module, clustertypes.WINDOWS) {
-				clusterIDs, _ = provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, true, true, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
-				provisioning.VerifyClustersState(p.T(), p.client, clusterIDs)
-				provisioning.VerifyServiceAccountTokenSecret(p.T(), p.client, clusterIDs)
+				clusters, _ = provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, true, true, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+				err = provisioningActions.VerifyClusterReady(p.client, clusters[0])
+				require.NoError(p.T(), err)
+				err = clusterActions.VerifyServiceAccountTokenSecret(p.client, clusters[0].Name)
+				require.NoError(p.T(), err)
 				pods.VerifyClusterPods(p.client, cluster)
 			}
 

--- a/tests/rancher2/provisioning/dynamic_provision_import_test.go
+++ b/tests/rancher2/provisioning/dynamic_provision_import_test.go
@@ -12,6 +12,8 @@ import (
 	shepherdConfig "github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
+	clusterActions "github.com/rancher/tests/actions/clusters"
+	provisioningActions "github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -106,10 +108,11 @@ func (p *DynamicUpgradeImportedClusterTestSuite) TestTfpUpgradeImportedClusterDy
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, p.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(p.T(), perTestTerraformOptions, keyPath)
 
-			clusterIDs, _ := provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, nil, nestedRancherModuleDir)
-			provisioning.VerifyClustersState(p.T(), p.client, clusterIDs)
-			provisioning.VerifyServiceAccountTokenSecret(p.T(), p.client, clusterIDs)
-
+			clusters, _ := provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, nil, nestedRancherModuleDir)
+			err = provisioningActions.VerifyClusterReady(p.client, clusters[0])
+			require.NoError(p.T(), err)
+			err = clusterActions.VerifyServiceAccountTokenSecret(p.client, clusters[0].Name)
+			require.NoError(p.T(), err)
 			cluster, err := p.client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetDefault + "/" + terraform.ResourcePrefix)
 			require.NoError(p.T(), err)
 

--- a/tests/rancher2/provisioning/dynamic_provision_test.go
+++ b/tests/rancher2/provisioning/dynamic_provision_test.go
@@ -12,6 +12,8 @@ import (
 	shepherdConfig "github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
+	clusterActions "github.com/rancher/tests/actions/clusters"
+	provisioningActions "github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -107,10 +109,11 @@ func (p *DynamicTfpProvisionTestSuite) TestTfpProvisionDynamicInput() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, p.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(p.T(), perTestTerraformOptions, keyPath)
 
-			clusterIDs, _ := provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, false, clusterIDs, nil, nestedRancherModuleDir)
-			provisioning.VerifyClustersState(p.T(), p.client, clusterIDs)
-			provisioning.VerifyServiceAccountTokenSecret(p.T(), p.client, clusterIDs)
-
+			clusters, _ := provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, false, clusterIDs, nil, nestedRancherModuleDir)
+			err = provisioningActions.VerifyClusterReady(p.client, clusters[0])
+			require.NoError(p.T(), err)
+			err = clusterActions.VerifyServiceAccountTokenSecret(p.client, clusters[0].Name)
+			require.NoError(p.T(), err)
 			cluster, err := p.client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetDefault + "/" + terraform.ResourcePrefix)
 			require.NoError(p.T(), err)
 

--- a/tests/rancher2/provisioning/provision_ace_test.go
+++ b/tests/rancher2/provisioning/provision_ace_test.go
@@ -12,7 +12,8 @@ import (
 	shepherdConfig "github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
-	verify "github.com/rancher/tests/actions/provisioning"
+	clusterActions "github.com/rancher/tests/actions/clusters"
+	provisioningActions "github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -126,17 +127,18 @@ func (p *ProvisionACETestSuite) TestTfpProvisionACE() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, p.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(p.T(), perTestTerraformOptions, keyPath)
 
-			clusterIDs, _ := provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, nil, nestedRancherModuleDir)
-			provisioning.VerifyClustersState(p.T(), p.client, clusterIDs)
-			provisioning.VerifyServiceAccountTokenSecret(p.T(), p.client, clusterIDs)
-
+			clusters, _ := provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, nil, nestedRancherModuleDir)
+			err = provisioningActions.VerifyClusterReady(p.client, clusters[0])
+			require.NoError(p.T(), err)
+			err = clusterActions.VerifyServiceAccountTokenSecret(p.client, clusters[0].Name)
+			require.NoError(p.T(), err)
 			cluster, err := p.client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetDefault + "/" + terraform.ResourcePrefix)
 			require.NoError(p.T(), err)
 
 			err = pods.VerifyClusterPods(p.client, cluster)
 			require.NoError(p.T(), err)
 
-			verify.VerifyACE(p.T(), p.client, cluster)
+			provisioningActions.VerifyACE(p.T(), p.client, cluster)
 
 			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
 			err = qase.UpdateSchemaParameters(tt.name, params)

--- a/tests/rancher2/provisioning/provision_custom_test.go
+++ b/tests/rancher2/provisioning/provision_custom_test.go
@@ -13,6 +13,8 @@ import (
 	shepherdConfig "github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
+	clusterActions "github.com/rancher/tests/actions/clusters"
+	provisioningActions "github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -117,10 +119,11 @@ func (p *ProvisionCustomTestSuite) TestTfpProvisionCustom() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, p.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(p.T(), perTestTerraformOptions, keyPath)
 
-			clusterIDs, customClusterNames := provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
-			provisioning.VerifyClustersState(p.T(), p.client, clusterIDs)
-			provisioning.VerifyServiceAccountTokenSecret(p.T(), p.client, clusterIDs)
-
+			clusters, customClusterNames := provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+			err = provisioningActions.VerifyClusterReady(p.client, clusters[0])
+			require.NoError(p.T(), err)
+			err = clusterActions.VerifyServiceAccountTokenSecret(p.client, clusters[0].Name)
+			require.NoError(p.T(), err)
 			cluster, err := p.client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetDefault + "/" + terraform.ResourcePrefix)
 			require.NoError(p.T(), err)
 
@@ -128,10 +131,11 @@ func (p *ProvisionCustomTestSuite) TestTfpProvisionCustom() {
 			require.NoError(p.T(), err)
 
 			if strings.Contains(terraform.Module, clustertypes.WINDOWS) {
-				clusterIDs, _ = provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, true, true, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
-				provisioning.VerifyClustersState(p.T(), p.client, clusterIDs)
-				provisioning.VerifyServiceAccountTokenSecret(p.T(), p.client, clusterIDs)
-
+				clusters, _ = provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, true, true, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+				err = provisioningActions.VerifyClusterReady(p.client, clusters[0])
+				require.NoError(p.T(), err)
+				err = clusterActions.VerifyServiceAccountTokenSecret(p.client, clusters[0].Name)
+				require.NoError(p.T(), err)
 				err = pods.VerifyClusterPods(p.client, cluster)
 				require.NoError(p.T(), err)
 			}

--- a/tests/rancher2/provisioning/provision_data_directory_test.go
+++ b/tests/rancher2/provisioning/provision_data_directory_test.go
@@ -12,6 +12,8 @@ import (
 	shepherdConfig "github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
+	clusterActions "github.com/rancher/tests/actions/clusters"
+	provisioningActions "github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -129,10 +131,11 @@ func (p *ProvisionDataDirectoryTestSuite) TestTfpProvisionDataDirectory() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, p.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(p.T(), perTestTerraformOptions, keyPath)
 
-			clusterIDs, _ := provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, false, clusterIDs, nil, nestedRancherModuleDir)
-			provisioning.VerifyClustersState(p.T(), p.client, clusterIDs)
-			provisioning.VerifyServiceAccountTokenSecret(p.T(), p.client, clusterIDs)
-
+			clusters, _ := provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, false, clusterIDs, nil, nestedRancherModuleDir)
+			err = provisioningActions.VerifyClusterReady(p.client, clusters[0])
+			require.NoError(p.T(), err)
+			err = clusterActions.VerifyServiceAccountTokenSecret(p.client, clusters[0].Name)
+			require.NoError(p.T(), err)
 			cluster, err := p.client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetDefault + "/" + terraform.ResourcePrefix)
 			require.NoError(p.T(), err)
 

--- a/tests/rancher2/provisioning/provision_import_test.go
+++ b/tests/rancher2/provisioning/provision_import_test.go
@@ -13,6 +13,8 @@ import (
 	shepherdConfig "github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
+	clusterActions "github.com/rancher/tests/actions/clusters"
+	provisioningActions "github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -119,11 +121,12 @@ func (p *UpgradeImportedClusterTestSuite) TestTfpUpgradeImportedCluster() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, p.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(p.T(), perTestTerraformOptions, keyPath)
 
-			clusterIDs, _ := provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, nil, nestedRancherModuleDir)
-			provisioning.VerifyClustersState(p.T(), p.client, clusterIDs)
-			provisioning.VerifyServiceAccountTokenSecret(p.T(), p.client, clusterIDs)
-
-			clusterResp, err := p.client.Management.Cluster.ByID(clusterIDs[0])
+			clusters, _ := provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, nil, nestedRancherModuleDir)
+			err = provisioningActions.VerifyClusterReady(p.client, clusters[0])
+			require.NoError(p.T(), err)
+			err = clusterActions.VerifyServiceAccountTokenSecret(p.client, clusters[0].Name)
+			require.NoError(p.T(), err)
+			clusterResp, err := p.client.Management.Cluster.ByID(clusters[0].ID)
 			require.NoError(p.T(), err)
 
 			cluster, err := p.client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetDefault + "/" + clusterResp.ID)

--- a/tests/rancher2/provisioning/provision_test.go
+++ b/tests/rancher2/provisioning/provision_test.go
@@ -12,6 +12,8 @@ import (
 	shepherdConfig "github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
+	clusterActions "github.com/rancher/tests/actions/clusters"
+	provisioningActions "github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -111,10 +113,11 @@ func (p *ProvisionTestSuite) TestTfpProvision() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, p.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(p.T(), perTestTerraformOptions, keyPath)
 
-			clusterIDs, _ := provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, false, clusterIDs, nil, nestedRancherModuleDir)
-			provisioning.VerifyClustersState(p.T(), p.client, clusterIDs)
-			provisioning.VerifyServiceAccountTokenSecret(p.T(), p.client, clusterIDs)
-
+			clusters, _ := provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, false, clusterIDs, nil, nestedRancherModuleDir)
+			err = provisioningActions.VerifyClusterReady(p.client, clusters[0])
+			require.NoError(p.T(), err)
+			err = clusterActions.VerifyServiceAccountTokenSecret(p.client, clusters[0].Name)
+			require.NoError(p.T(), err)
 			cluster, err := p.client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetDefault + "/" + terraform.ResourcePrefix)
 			require.NoError(p.T(), err)
 

--- a/tests/rancher2/psact/psact_test.go
+++ b/tests/rancher2/psact/psact_test.go
@@ -12,6 +12,8 @@ import (
 	shepherdConfig "github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
+	clusterActions "github.com/rancher/tests/actions/clusters"
+	provisioningActions "github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -125,17 +127,19 @@ func (p *PSACTTestSuite) TestTfpPSACT() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, p.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(p.T(), perTestTerraformOptions, keyPath)
 
-			clusterIDs, _ := provisioning.Provision(t, p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, false, clusterIDs, nil, nestedRancherModuleDir)
-			provisioning.VerifyClustersState(t, p.client, clusterIDs)
-			provisioning.VerifyServiceAccountTokenSecret(t, p.client, clusterIDs)
+			clusters, _ := provisioning.Provision(t, p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, false, clusterIDs, nil, nestedRancherModuleDir)
+			err = provisioningActions.VerifyClusterReady(p.client, clusters[0])
+			require.NoError(t, err)
 
+			err = clusterActions.VerifyServiceAccountTokenSecret(p.client, clusters[0].Name)
+			require.NoError(t, err)
 			cluster, err := p.client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetDefault + "/" + terraform.ResourcePrefix)
 			require.NoError(t, err)
 
 			err = pods.VerifyClusterPods(p.client, cluster)
 			require.NoError(t, err)
 
-			provisioning.VerifyClusterPSACT(t, p.client, clusterIDs)
+			provisioningActions.VerifyPSACT(t, p.client, cluster)
 
 			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
 			err = qase.UpdateSchemaParameters(tt.name, params)

--- a/tests/rancher2/rbac/rbac_test.go
+++ b/tests/rancher2/rbac/rbac_test.go
@@ -12,6 +12,8 @@ import (
 	shepherdConfig "github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
+	clusterActions "github.com/rancher/tests/actions/clusters"
+	provisioningActions "github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -119,10 +121,11 @@ func (r *RBACTestSuite) TestTfpRBAC() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, r.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(r.T(), perTestTerraformOptions, keyPath)
 
-			clusterIDs, _ := provisioning.Provision(r.T(), r.client, r.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, false, clusterIDs, nil, nestedRancherModuleDir)
-			provisioning.VerifyClustersState(r.T(), r.client, clusterIDs)
-			provisioning.VerifyServiceAccountTokenSecret(r.T(), r.client, clusterIDs)
-
+			clusters, _ := provisioning.Provision(r.T(), r.client, r.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, false, clusterIDs, nil, nestedRancherModuleDir)
+			err = provisioningActions.VerifyClusterReady(r.client, clusters[0])
+			require.NoError(r.T(), err)
+			err = clusterActions.VerifyServiceAccountTokenSecret(r.client, clusters[0].Name)
+			require.NoError(r.T(), err)
 			cluster, err := r.client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetDefault + "/" + terraform.ResourcePrefix)
 			require.NoError(r.T(), err)
 

--- a/tests/rancher2/snapshot/snapshot.go
+++ b/tests/rancher2/snapshot/snapshot.go
@@ -18,7 +18,7 @@ import (
 	"github.com/rancher/shepherd/extensions/workloads/pods"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	namegen "github.com/rancher/shepherd/pkg/namegenerator"
-	"github.com/rancher/tests/actions/provisioning"
+	provisioningActions "github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/services"
 	deploy "github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tfp-automation/config"
@@ -58,7 +58,7 @@ const (
 // RestoreSnapshot creates workloads, takes a snapshot of the cluster, restores the cluster and verifies the workloads created after
 // a snapshot no longer are present in the cluster
 func RestoreSnapshot(t *testing.T, client *rancher.Client, rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig,
-	terratestConfig *config.TerratestConfig, testUser, testPassword string, terraformOptions *terraform.Options, configMap []map[string]any,
+	terratestConfig *config.TerratestConfig, testUser, testPassword string, terraformOptions *terraform.Options, cattleConfig map[string]any,
 	newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File, nestedRancherModuleDir string) {
 	initialWorkloadName := namegen.AppendRandomString(initialWorkload)
 
@@ -73,10 +73,10 @@ func RestoreSnapshot(t *testing.T, client *rancher.Client, rancherConfig *ranche
 
 	deploymentResp, serviceResp := createWorkloads(t, client, clusterID, podTemplate, initialWorkloadName, isCattleLabeled, DeploymentSteveType)
 
-	snapshotName, postDeploymentResp, postServiceResp, err := snapshotV2Prov(t, client, rancherConfig, terraformConfig, terratestConfig, podTemplate, testUser, testPassword, clusterID, terraformOptions, configMap, newFile, rootBody, file, nestedRancherModuleDir)
+	snapshotName, postDeploymentResp, postServiceResp, err := snapshotV2Prov(t, client, rancherConfig, terraformConfig, terratestConfig, podTemplate, testUser, testPassword, clusterID, terraformOptions, cattleConfig, newFile, rootBody, file, nestedRancherModuleDir)
 	require.NoError(t, err)
 
-	restoreV2Prov(t, client, rancherConfig, terraformConfig, terratestConfig, snapshotName, testUser, testPassword, clusterID, terraformOptions, configMap, newFile, rootBody, file, nestedRancherModuleDir)
+	restoreV2Prov(t, client, rancherConfig, terraformConfig, terratestConfig, snapshotName, testUser, testPassword, clusterID, terraformOptions, cattleConfig, newFile, rootBody, file, nestedRancherModuleDir)
 
 	_, err = steveclient.SteveType(DeploymentSteveType).ByID(postDeploymentResp.ID)
 	require.Error(t, err)
@@ -95,12 +95,12 @@ func RestoreSnapshot(t *testing.T, client *rancher.Client, rancherConfig *ranche
 // snapshotV2Prov takes a snapshot of the cluster and creates a deployment and service in the cluster.
 func snapshotV2Prov(t *testing.T, client *rancher.Client, rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig,
 	terratestConfig *config.TerratestConfig, podTemplate corev1.PodTemplateSpec, testUser, testPassword, clusterID string,
-	terraformOptions *terraform.Options, configMap []map[string]any, newFile *hclwrite.File, rootBody *hclwrite.Body,
+	terraformOptions *terraform.Options, cattleConfig map[string]any, newFile *hclwrite.File, rootBody *hclwrite.Body,
 	file *os.File, nestedRancherModuleDir string) (string, *steveV1.SteveAPIObject, *steveV1.SteveAPIObject, error) {
-	_, err := operations.ReplaceValue([]string{"terratest", "snapshotInput", "createSnapshot"}, true, configMap[0])
+	_, err := operations.ReplaceValue([]string{"terratest", "snapshotInput", "createSnapshot"}, true, cattleConfig)
 	require.NoError(t, err)
 
-	_, _, err = framework.ConfigTF(client, rancherConfig, terratestConfig, testUser, testPassword, "", configMap, newFile, rootBody, file, false, false, false, nil, nestedRancherModuleDir)
+	_, _, err = framework.ConfigTF(client, rancherConfig, terratestConfig, testUser, testPassword, "", []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, false, nil, nestedRancherModuleDir)
 	require.NoError(t, err)
 
 	terraform.Apply(t, terraformOptions)
@@ -123,17 +123,17 @@ func snapshotV2Prov(t *testing.T, client *rancher.Client, rancherConfig *rancher
 // restoreV2Prov restores the cluster to the previous state after a snapshot is taken.
 func restoreV2Prov(t *testing.T, client *rancher.Client, rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig,
 	terratestConfig *config.TerratestConfig, snapshotName, testUser, testPassword string, clusterID string, terraformOptions *terraform.Options,
-	configMap []map[string]any, newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File, nestedRancherModuleDir string) {
-	_, err := operations.ReplaceValue([]string{"terratest", "snapshotInput", "createSnapshot"}, false, configMap[0])
+	cattleConfig map[string]any, newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File, nestedRancherModuleDir string) {
+	_, err := operations.ReplaceValue([]string{"terratest", "snapshotInput", "createSnapshot"}, false, cattleConfig)
 	require.NoError(t, err)
 
-	_, err = operations.ReplaceValue([]string{"terratest", "snapshotInput", "restoreSnapshot"}, true, configMap[0])
+	_, err = operations.ReplaceValue([]string{"terratest", "snapshotInput", "restoreSnapshot"}, true, cattleConfig)
 	require.NoError(t, err)
 
-	_, err = operations.ReplaceValue([]string{"terratest", "snapshotInput", "snapshotName"}, snapshotName, configMap[0])
+	_, err = operations.ReplaceValue([]string{"terratest", "snapshotInput", "snapshotName"}, snapshotName, cattleConfig)
 	require.NoError(t, err)
 
-	_, _, err = framework.ConfigTF(client, rancherConfig, terratestConfig, testUser, testPassword, "", configMap, newFile, rootBody, file, false, false, false, nil, nestedRancherModuleDir)
+	_, _, err = framework.ConfigTF(client, rancherConfig, terratestConfig, testUser, testPassword, "", []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, false, nil, nestedRancherModuleDir)
 	require.NoError(t, err)
 
 	terraform.Apply(t, terraformOptions)
@@ -141,7 +141,7 @@ func restoreV2Prov(t *testing.T, client *rancher.Client, rancherConfig *rancher.
 	cluster, err := client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetDefault + "/" + terraformConfig.ResourcePrefix)
 	require.NoError(t, err)
 
-	err = provisioning.VerifyClusterReady(client, cluster)
+	err = provisioningActions.VerifyClusterReady(client, cluster)
 	require.NoError(t, err)
 
 	clusterObject, _, err := clusters.GetProvisioningClusterByName(client, terraformConfig.ResourcePrefix, namespace)

--- a/tests/rancher2/snapshot/snapshot_restore_test.go
+++ b/tests/rancher2/snapshot/snapshot_restore_test.go
@@ -12,6 +12,8 @@ import (
 	shepherdConfig "github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
+	clusterActions "github.com/rancher/tests/actions/clusters"
+	provisioningActions "github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -127,17 +129,18 @@ func (s *SnapshotRestoreTestSuite) TestTfpSnapshotRestore() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, s.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(s.T(), perTestTerraformOptions, keyPath)
 
-			clusterIDs, _ := provisioning.Provision(s.T(), s.client, s.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, false, clusterIDs, nil, nestedRancherModuleDir)
-			provisioning.VerifyClustersState(s.T(), s.client, clusterIDs)
-			provisioning.VerifyServiceAccountTokenSecret(s.T(), s.client, clusterIDs)
-
+			clusters, _ := provisioning.Provision(s.T(), s.client, s.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, false, clusterIDs, nil, nestedRancherModuleDir)
+			err = provisioningActions.VerifyClusterReady(s.client, clusters[0])
+			require.NoError(s.T(), err)
+			err = clusterActions.VerifyServiceAccountTokenSecret(s.client, clusters[0].Name)
+			require.NoError(s.T(), err)
 			cluster, err := s.client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetDefault + "/" + terraform.ResourcePrefix)
 			require.NoError(s.T(), err)
 
 			err = pods.VerifyClusterPods(s.client, cluster)
 			require.NoError(s.T(), err)
 
-			RestoreSnapshot(s.T(), s.client, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, nestedRancherModuleDir)
+			RestoreSnapshot(s.T(), s.client, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, cattleConfig, newFile, rootBody, file, nestedRancherModuleDir)
 
 			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
 			err = qase.UpdateSchemaParameters(tt.name, params)

--- a/tests/registries/registries_test.go
+++ b/tests/registries/registries_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/rancher/shepherd/extensions/defaults/namespaces"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
+	clusterActions "github.com/rancher/tests/actions/clusters"
+	provisioningActions "github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -135,27 +137,29 @@ func (r *TfpRegistriesTestSuite) TestTfpGlobalRegistry() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, r.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(r.T(), perTestTerraformOptions, keyPath)
 
-			clusterIDs, customClusterNames := provisioning.Provision(r.T(), r.client, r.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
-			provisioning.VerifyClustersState(r.T(), r.client, clusterIDs)
-			provisioning.VerifyServiceAccountTokenSecret(r.T(), r.client, clusterIDs)
-
+			clusters, customClusterNames := provisioning.Provision(r.T(), r.client, r.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+			err = provisioningActions.VerifyClusterReady(r.client, clusters[0])
+			require.NoError(r.T(), err)
+			err = clusterActions.VerifyServiceAccountTokenSecret(r.client, clusters[0].Name)
+			require.NoError(r.T(), err)
 			cluster, err := r.client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetDefault + "/" + terraform.ResourcePrefix)
 			require.NoError(r.T(), err)
 
 			err = pods.VerifyClusterPods(r.client, cluster)
 			require.NoError(r.T(), err)
 
-			provisioning.VerifyRegistry(r.T(), r.client, clusterIDs[0], terraform)
+			provisioning.VerifyRegistry(r.T(), r.client, clusters[0].ID, terraform)
 
 			if strings.Contains(terraform.Module, clustertypes.WINDOWS) {
-				clusterIDs, _ = provisioning.Provision(r.T(), r.client, r.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, true, true, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
-				provisioning.VerifyClustersState(r.T(), r.client, clusterIDs)
-				provisioning.VerifyServiceAccountTokenSecret(r.T(), r.client, clusterIDs)
-
+				clusters, _ = provisioning.Provision(r.T(), r.client, r.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, true, true, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+				err = provisioningActions.VerifyClusterReady(r.client, clusters[0])
+				require.NoError(r.T(), err)
+				err = clusterActions.VerifyServiceAccountTokenSecret(r.client, clusters[0].Name)
+				require.NoError(r.T(), err)
 				err = pods.VerifyClusterPods(r.client, cluster)
 				require.NoError(r.T(), err)
 
-				provisioning.VerifyRegistry(r.T(), r.client, clusterIDs[0], terraform)
+				provisioning.VerifyRegistry(r.T(), r.client, clusters[0].ID, terraform)
 			}
 
 			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
@@ -235,17 +239,18 @@ func (r *TfpRegistriesTestSuite) TestTfpAuthenticatedRegistry() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, r.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(r.T(), perTestTerraformOptions, keyPath)
 
-			clusterIDs, _ := provisioning.Provision(r.T(), r.client, r.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, nil, nestedRancherModuleDir)
-			provisioning.VerifyClustersState(r.T(), r.client, clusterIDs)
-			provisioning.VerifyServiceAccountTokenSecret(r.T(), r.client, clusterIDs)
-
+			clusters, _ := provisioning.Provision(r.T(), r.client, r.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, nil, nestedRancherModuleDir)
+			err = provisioningActions.VerifyClusterReady(r.client, clusters[0])
+			require.NoError(r.T(), err)
+			err = clusterActions.VerifyServiceAccountTokenSecret(r.client, clusters[0].Name)
+			require.NoError(r.T(), err)
 			cluster, err := r.client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetDefault + "/" + terraform.ResourcePrefix)
 			require.NoError(r.T(), err)
 
 			err = pods.VerifyClusterPods(r.client, cluster)
 			require.NoError(r.T(), err)
 
-			provisioning.VerifyRegistry(r.T(), r.client, clusterIDs[0], terraform)
+			provisioning.VerifyRegistry(r.T(), r.client, clusters[0].ID, terraform)
 
 			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
 			err = qase.UpdateSchemaParameters(tt.name, params)
@@ -333,27 +338,29 @@ func (r *TfpRegistriesTestSuite) TestTfpNonAuthenticatedRegistry() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, r.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(r.T(), perTestTerraformOptions, keyPath)
 
-			clusterIDs, customClusterNames := provisioning.Provision(r.T(), r.client, r.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
-			provisioning.VerifyClustersState(r.T(), r.client, clusterIDs)
-			provisioning.VerifyServiceAccountTokenSecret(r.T(), r.client, clusterIDs)
-
+			clusters, customClusterNames := provisioning.Provision(r.T(), r.client, r.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+			err = provisioningActions.VerifyClusterReady(r.client, clusters[0])
+			require.NoError(r.T(), err)
+			err = clusterActions.VerifyServiceAccountTokenSecret(r.client, clusters[0].Name)
+			require.NoError(r.T(), err)
 			cluster, err := r.client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetDefault + "/" + terraform.ResourcePrefix)
 			require.NoError(r.T(), err)
 
 			err = pods.VerifyClusterPods(r.client, cluster)
 			require.NoError(r.T(), err)
 
-			provisioning.VerifyRegistry(r.T(), r.client, clusterIDs[0], terraform)
+			provisioning.VerifyRegistry(r.T(), r.client, clusters[0].ID, terraform)
 
 			if strings.Contains(terraform.Module, clustertypes.WINDOWS) {
-				clusterIDs, _ = provisioning.Provision(r.T(), r.client, r.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, true, true, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
-				provisioning.VerifyClustersState(r.T(), r.client, clusterIDs)
-				provisioning.VerifyServiceAccountTokenSecret(r.T(), r.client, clusterIDs)
-
+				clusters, _ = provisioning.Provision(r.T(), r.client, r.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, true, true, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+				err = provisioningActions.VerifyClusterReady(r.client, clusters[0])
+				require.NoError(r.T(), err)
+				err = clusterActions.VerifyServiceAccountTokenSecret(r.client, clusters[0].Name)
+				require.NoError(r.T(), err)
 				err = pods.VerifyClusterPods(r.client, cluster)
 				require.NoError(r.T(), err)
 
-				provisioning.VerifyRegistry(r.T(), r.client, clusterIDs[0], terraform)
+				provisioning.VerifyRegistry(r.T(), r.client, clusters[0].ID, terraform)
 			}
 
 			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
@@ -442,17 +449,18 @@ func (r *TfpRegistriesTestSuite) TestTfpECRRegistry() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, r.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(r.T(), perTestTerraformOptions, keyPath)
 
-			clusterIDs, _ := provisioning.Provision(r.T(), r.client, r.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, nil, nestedRancherModuleDir)
-			provisioning.VerifyClustersState(r.T(), r.client, clusterIDs)
-			provisioning.VerifyServiceAccountTokenSecret(r.T(), r.client, clusterIDs)
-
+			clusters, _ := provisioning.Provision(r.T(), r.client, r.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, nil, nestedRancherModuleDir)
+			err = provisioningActions.VerifyClusterReady(r.client, clusters[0])
+			require.NoError(r.T(), err)
+			err = clusterActions.VerifyServiceAccountTokenSecret(r.client, clusters[0].Name)
+			require.NoError(r.T(), err)
 			cluster, err := r.client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetDefault + "/" + terraform.ResourcePrefix)
 			require.NoError(r.T(), err)
 
 			err = pods.VerifyClusterPods(r.client, cluster)
 			require.NoError(r.T(), err)
 
-			provisioning.VerifyRegistry(r.T(), r.client, clusterIDs[0], terraform)
+			provisioning.VerifyRegistry(r.T(), r.client, clusters[0].ID, terraform)
 
 			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
 			err = qase.UpdateSchemaParameters(tt.name, params)

--- a/tests/sanity/sanity_aks_provisioning_test.go
+++ b/tests/sanity/sanity_aks_provisioning_test.go
@@ -8,7 +8,10 @@ import (
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
+	clusterActions "github.com/rancher/tests/actions/clusters"
+	provisioningActions "github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/defaults/configs"
@@ -107,10 +110,13 @@ func (s *TfpSanityAKSProvisioningTestSuite) TestTfpProvisioningAKSSanity() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, s.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(s.T(), perTestTerraformOptions, keyPath)
 
-			clusterIDs, _ := provisioning.Provision(s.T(), s.client, s.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
-			provisioning.VerifyClustersState(s.T(), s.client, clusterIDs)
-			provisioning.VerifyServiceAccountTokenSecret(s.T(), s.client, clusterIDs)
-			provisioning.VerifyV3ClustersPods(s.T(), s.client, clusterIDs)
+			clusters, _ := provisioning.Provision(s.T(), s.client, s.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+			err = provisioningActions.VerifyClusterReady(s.client, clusters[0])
+			require.NoError(s.T(), err)
+			err = clusterActions.VerifyServiceAccountTokenSecret(s.client, clusters[0].Name)
+			require.NoError(s.T(), err)
+			err = pods.VerifyClusterPods(s.client, clusters[0])
+			require.NoError(s.T(), err)
 
 			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
 			err = qase.UpdateSchemaParameters(tt.name, params)

--- a/tests/sanity/sanity_dual_stack_provisioning_test.go
+++ b/tests/sanity/sanity_dual_stack_provisioning_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/rancher/shepherd/extensions/defaults/namespaces"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
+	clusterActions "github.com/rancher/tests/actions/clusters"
+	provisioningActions "github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -112,10 +114,11 @@ func (s *TfpSanityDualStackProvisioningTestSuite) TestTfpProvisioningSanityDualS
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, s.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(s.T(), perTestTerraformOptions, keyPath)
 
-			clusterIDs, _ := provisioning.Provision(s.T(), s.client, s.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
-			provisioning.VerifyClustersState(s.T(), s.client, clusterIDs)
-			provisioning.VerifyServiceAccountTokenSecret(s.T(), s.client, clusterIDs)
-
+			clusters, _ := provisioning.Provision(s.T(), s.client, s.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+			err = provisioningActions.VerifyClusterReady(s.client, clusters[0])
+			require.NoError(s.T(), err)
+			err = clusterActions.VerifyServiceAccountTokenSecret(s.client, clusters[0].Name)
+			require.NoError(s.T(), err)
 			cluster, err := s.client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetDefault + "/" + terraform.ResourcePrefix)
 			require.NoError(s.T(), err)
 

--- a/tests/sanity/sanity_eks_provisioning_test.go
+++ b/tests/sanity/sanity_eks_provisioning_test.go
@@ -8,7 +8,10 @@ import (
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
+	clusterActions "github.com/rancher/tests/actions/clusters"
+	provisioningActions "github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/defaults/configs"
@@ -107,10 +110,13 @@ func (s *TfpSanityEKSProvisioningTestSuite) TestTfpProvisioningEKSSanity() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, s.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(s.T(), perTestTerraformOptions, keyPath)
 
-			clusterIDs, _ := provisioning.Provision(s.T(), s.client, s.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
-			provisioning.VerifyClustersState(s.T(), s.client, clusterIDs)
-			provisioning.VerifyServiceAccountTokenSecret(s.T(), s.client, clusterIDs)
-			provisioning.VerifyV3ClustersPods(s.T(), s.client, clusterIDs)
+			clusters, _ := provisioning.Provision(s.T(), s.client, s.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+			err = provisioningActions.VerifyClusterReady(s.client, clusters[0])
+			require.NoError(s.T(), err)
+			err = clusterActions.VerifyServiceAccountTokenSecret(s.client, clusters[0].Name)
+			require.NoError(s.T(), err)
+			err = pods.VerifyClusterPods(s.client, clusters[0])
+			require.NoError(s.T(), err)
 
 			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
 			err = qase.UpdateSchemaParameters(tt.name, params)

--- a/tests/sanity/sanity_gke_provisioning_test.go
+++ b/tests/sanity/sanity_gke_provisioning_test.go
@@ -8,7 +8,10 @@ import (
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
+	clusterActions "github.com/rancher/tests/actions/clusters"
+	provisioningActions "github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/defaults/configs"
@@ -107,10 +110,13 @@ func (s *TfpSanityGKEProvisioningTestSuite) TestTfpProvisioningGKESanity() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, s.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(s.T(), perTestTerraformOptions, keyPath)
 
-			clusterIDs, _ := provisioning.Provision(s.T(), s.client, s.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
-			provisioning.VerifyClustersState(s.T(), s.client, clusterIDs)
-			provisioning.VerifyServiceAccountTokenSecret(s.T(), s.client, clusterIDs)
-			provisioning.VerifyV3ClustersPods(s.T(), s.client, clusterIDs)
+			clusters, _ := provisioning.Provision(s.T(), s.client, s.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+			err = provisioningActions.VerifyClusterReady(s.client, clusters[0])
+			require.NoError(s.T(), err)
+			err = clusterActions.VerifyServiceAccountTokenSecret(s.client, clusters[0].Name)
+			require.NoError(s.T(), err)
+			err = pods.VerifyClusterPods(s.client, clusters[0])
+			require.NoError(s.T(), err)
 
 			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
 			err = qase.UpdateSchemaParameters(tt.name, params)

--- a/tests/sanity/sanity_ipv6_hosted_provisioning_test.go
+++ b/tests/sanity/sanity_ipv6_hosted_provisioning_test.go
@@ -9,7 +9,10 @@ import (
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
+	clusterActions "github.com/rancher/tests/actions/clusters"
+	provisioningActions "github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/defaults/configs"
@@ -115,10 +118,13 @@ func (s *TfpSanityIPv6HostedProvisioningTestSuite) TestTfpProvisioningSanityIPv6
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, s.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(s.T(), perTestTerraformOptions, keyPath)
 
-			clusterIDs, _ := provisioning.Provision(s.T(), s.client, s.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
-			provisioning.VerifyClustersState(s.T(), s.client, clusterIDs)
-			provisioning.VerifyServiceAccountTokenSecret(s.T(), s.client, clusterIDs)
-			provisioning.VerifyV3ClustersPods(s.T(), s.client, clusterIDs)
+			clusters, _ := provisioning.Provision(s.T(), s.client, s.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+			err = provisioningActions.VerifyClusterReady(s.client, clusters[0])
+			require.NoError(s.T(), err)
+			err = clusterActions.VerifyServiceAccountTokenSecret(s.client, clusters[0].Name)
+			require.NoError(s.T(), err)
+			err = pods.VerifyClusterPods(s.client, clusters[0])
+			require.NoError(s.T(), err)
 
 			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
 			err = qase.UpdateSchemaParameters(tt.name, params)

--- a/tests/sanity/sanity_ipv6_provisioning_test.go
+++ b/tests/sanity/sanity_ipv6_provisioning_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/rancher/shepherd/extensions/defaults/namespaces"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
+	clusterActions "github.com/rancher/tests/actions/clusters"
+	provisioningActions "github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -112,10 +114,11 @@ func (s *TfpSanityIPv6ProvisioningTestSuite) TestTfpProvisioningSanityIPv6() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, s.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(s.T(), perTestTerraformOptions, keyPath)
 
-			clusterIDs, _ := provisioning.Provision(s.T(), s.client, s.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
-			provisioning.VerifyClustersState(s.T(), s.client, clusterIDs)
-			provisioning.VerifyServiceAccountTokenSecret(s.T(), s.client, clusterIDs)
-
+			clusters, _ := provisioning.Provision(s.T(), s.client, s.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+			err = provisioningActions.VerifyClusterReady(s.client, clusters[0])
+			require.NoError(s.T(), err)
+			err = clusterActions.VerifyServiceAccountTokenSecret(s.client, clusters[0].Name)
+			require.NoError(s.T(), err)
 			cluster, err := s.client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetDefault + "/" + terraform.ResourcePrefix)
 			require.NoError(s.T(), err)
 

--- a/tests/sanity/sanity_provisioning_test.go
+++ b/tests/sanity/sanity_provisioning_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/rancher/shepherd/extensions/defaults/namespaces"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
+	clusterActions "github.com/rancher/tests/actions/clusters"
+	provisioningActions "github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -126,10 +128,11 @@ func (s *TfpSanityProvisioningTestSuite) TestTfpProvisioningSanity() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, s.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(s.T(), perTestTerraformOptions, keyPath)
 
-			clusterIDs, customClusterNames := provisioning.Provision(s.T(), s.client, s.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
-			provisioning.VerifyClustersState(s.T(), s.client, clusterIDs)
-			provisioning.VerifyServiceAccountTokenSecret(s.T(), s.client, clusterIDs)
-
+			clusters, customClusterNames := provisioning.Provision(s.T(), s.client, s.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+			err = provisioningActions.VerifyClusterReady(s.client, clusters[0])
+			require.NoError(s.T(), err)
+			err = clusterActions.VerifyServiceAccountTokenSecret(s.client, clusters[0].Name)
+			require.NoError(s.T(), err)
 			cluster, err := s.client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetDefault + "/" + terraform.ResourcePrefix)
 			require.NoError(s.T(), err)
 
@@ -137,10 +140,11 @@ func (s *TfpSanityProvisioningTestSuite) TestTfpProvisioningSanity() {
 			require.NoError(s.T(), err)
 
 			if strings.Contains(terraform.Module, clustertypes.WINDOWS) {
-				clusterIDs, customClusterNames = provisioning.Provision(s.T(), s.client, s.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, true, true, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
-				provisioning.VerifyClustersState(s.T(), s.client, clusterIDs)
-				provisioning.VerifyServiceAccountTokenSecret(s.T(), s.client, clusterIDs)
-
+				clusters, customClusterNames = provisioning.Provision(s.T(), s.client, s.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, true, true, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+				err = provisioningActions.VerifyClusterReady(s.client, clusters[0])
+				require.NoError(s.T(), err)
+				err = clusterActions.VerifyServiceAccountTokenSecret(s.client, clusters[0].Name)
+				require.NoError(s.T(), err)
 				err = pods.VerifyClusterPods(s.client, cluster)
 				require.NoError(s.T(), err)
 			}
@@ -213,11 +217,12 @@ func (s *TfpSanityProvisioningTestSuite) TestTfpProvisioningSanityImported() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, s.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(s.T(), perTestTerraformOptions, keyPath)
 
-			clusterIDs, _ := provisioning.Provision(s.T(), s.client, s.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, nil, nestedRancherModuleDir)
-			provisioning.VerifyClustersState(s.T(), s.client, clusterIDs)
-			provisioning.VerifyServiceAccountTokenSecret(s.T(), s.client, clusterIDs)
-
-			clusterResp, err := s.client.Management.Cluster.ByID(clusterIDs[0])
+			clusters, _ := provisioning.Provision(s.T(), s.client, s.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, nil, nestedRancherModuleDir)
+			err = provisioningActions.VerifyClusterReady(s.client, clusters[0])
+			require.NoError(s.T(), err)
+			err = clusterActions.VerifyServiceAccountTokenSecret(s.client, clusters[0].Name)
+			require.NoError(s.T(), err)
+			clusterResp, err := s.client.Management.Cluster.ByID(clusters[0].ID)
 			require.NoError(s.T(), err)
 
 			cluster, err := s.client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetDefault + "/" + clusterResp.ID)

--- a/tests/sanity/sanity_upgrade_dual_stack_rancher_test.go
+++ b/tests/sanity/sanity_upgrade_dual_stack_rancher_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/rancher/shepherd/extensions/defaults/namespaces"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
+	clusterActions "github.com/rancher/tests/actions/clusters"
+	provisioningActions "github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tfp-automation/config"
@@ -126,10 +128,12 @@ func (s *TfpSanityDualStackUpgradeRancherTestSuite) provisionAndVerifyCluster(na
 
 				rancher, terraform, terratest, _ := config.LoadTFPConfigs(cattleConfig)
 
-				clusterIDs, _ = provisioning.Provision(t, s.client, standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, true, true, clusterIDs, nil, nestedRancherModuleDir)
-				provisioning.VerifyClustersState(t, s.client, clusterIDs)
-				provisioning.VerifyServiceAccountTokenSecret(t, s.client, clusterIDs)
+				clusters, _ := provisioning.Provision(t, s.client, standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, true, true, clusterIDs, nil, nestedRancherModuleDir)
+				err = provisioningActions.VerifyClusterReady(s.client, clusters[0])
+				require.NoError(t, err)
 
+				err = clusterActions.VerifyServiceAccountTokenSecret(s.client, clusters[0].Name)
+				require.NoError(t, err)
 				cluster, err := s.client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetDefault + "/" + terraform.ResourcePrefix)
 				require.NoError(t, err)
 

--- a/tests/sanity/sanity_upgrade_ipv6_rancher_test.go
+++ b/tests/sanity/sanity_upgrade_ipv6_rancher_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/rancher/shepherd/extensions/defaults/namespaces"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
+	clusterActions "github.com/rancher/tests/actions/clusters"
+	provisioningActions "github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tfp-automation/config"
@@ -126,10 +128,12 @@ func (s *TfpSanityIPv6UpgradeRancherTestSuite) provisionAndVerifyCluster(name st
 
 				rancher, terraform, terratest, _ := config.LoadTFPConfigs(cattleConfig)
 
-				clusterIDs, _ := provisioning.Provision(t, s.client, standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, true, true, clusterIDs, nil, nestedRancherModuleDir)
-				provisioning.VerifyClustersState(t, s.client, clusterIDs)
-				provisioning.VerifyServiceAccountTokenSecret(t, s.client, clusterIDs)
+				clusters, _ := provisioning.Provision(t, s.client, standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, true, true, clusterIDs, nil, nestedRancherModuleDir)
+				err = provisioningActions.VerifyClusterReady(s.client, clusters[0])
+				require.NoError(t, err)
 
+				err = clusterActions.VerifyServiceAccountTokenSecret(s.client, clusters[0].Name)
+				require.NoError(t, err)
 				cluster, err := s.client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetDefault + "/" + terraform.ResourcePrefix)
 				require.NoError(t, err)
 

--- a/tests/sanity/sanity_upgrade_rancher_test.go
+++ b/tests/sanity/sanity_upgrade_rancher_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/rancher/shepherd/extensions/defaults/namespaces"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
+	clusterActions "github.com/rancher/tests/actions/clusters"
+	provisioningActions "github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tfp-automation/config"
@@ -141,10 +143,12 @@ func (s *TfpSanityUpgradeRancherTestSuite) provisionAndVerifyCluster(name string
 
 				rancher, terraform, terratest, _ := config.LoadTFPConfigs(cattleConfig)
 
-				clusterIDs, customClusterNames := provisioning.Provision(t, s.client, standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, true, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
-				provisioning.VerifyClustersState(t, s.client, clusterIDs)
-				provisioning.VerifyServiceAccountTokenSecret(t, s.client, clusterIDs)
+				clusters, customClusterNames := provisioning.Provision(t, s.client, standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, true, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+				err = provisioningActions.VerifyClusterReady(s.client, clusters[0])
+				require.NoError(t, err)
 
+				err = clusterActions.VerifyServiceAccountTokenSecret(s.client, clusters[0].Name)
+				require.NoError(t, err)
 				cluster, err := s.client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetDefault + "/" + terraform.ResourcePrefix)
 				require.NoError(t, err)
 
@@ -152,10 +156,12 @@ func (s *TfpSanityUpgradeRancherTestSuite) provisionAndVerifyCluster(name string
 				require.NoError(t, err)
 
 				if strings.Contains(terraform.Module, clustertypes.WINDOWS) {
-					clusterIDs, customClusterNames = provisioning.Provision(t, s.client, standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, true, true, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
-					provisioning.VerifyClustersState(t, s.client, clusterIDs)
-					provisioning.VerifyServiceAccountTokenSecret(t, s.client, clusterIDs)
+					clusters, customClusterNames = provisioning.Provision(t, s.client, standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, true, true, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+					err = provisioningActions.VerifyClusterReady(s.client, clusters[0])
+					require.NoError(t, err)
 
+					err = clusterActions.VerifyServiceAccountTokenSecret(s.client, clusters[0].Name)
+					require.NoError(t, err)
 					err = pods.VerifyClusterPods(s.client, cluster)
 					require.NoError(t, err)
 				}


### PR DESCRIPTION
Changes:
* Updated the provision function to return the cluster object instead of the ids, this brings it inline with the style of rancher tests and allows us to do the following changes.
* Updated verify functions to use the rancher/tests versions of the verify funcs
* Deleted the duplicate verify functions in tfp-automation