### PR TITLE
General QOL for registries_test.go

### DIFF
--- a/framework/set/resources/registries/createRegistry/auth-registry.sh
+++ b/framework/set/resources/registries/createRegistry/auth-registry.sh
@@ -14,7 +14,59 @@ RANCHER_AGENT_IMAGE=${11}
 
 set -e
 
-manageImages() {
+docker_login() {
+    echo "Logging into private registry ${HOST}..."
+    sudo docker login https://registry-1.docker.io -u "${DOCKERHUB_USER}" -p "${DOCKERHUB_PASS}"
+}
+
+create_registry() {
+    if [ "$(sudo docker ps -q -f name=${REGISTRY_NAME})" ]; then
+        echo "Private registry ${REGISTRY_NAME} already exists. Skipping..."
+    else
+        sudo mkdir -p /home/${USER}/auth
+        sudo htpasswd -Bbn ${REGISTRY_USER} ${REGISTRY_PASS} | sudo tee /home/${USER}/auth/htpasswd
+
+        echo "Creating a self-signed certificate..."
+        sudo mkdir -p /home/${USER}/certs
+        sudo openssl req -newkey rsa:4096 -nodes -sha256 \
+            -keyout /home/${USER}/certs/domain.key \
+            -addext "subjectAltName = DNS:${HOST}" \
+            -x509 -days 365 -out /home/${USER}/certs/domain.crt \
+            -subj "/C=US/ST=CA/L=SUSE/O=Dis/CN=${HOST}"
+
+        echo "Copying the certificate to the /etc/docker/certs.d/${HOST} directory..."
+        sudo mkdir -p /etc/docker/certs.d/${HOST}
+        sudo cp /home/${USER}/certs/domain.crt /etc/docker/certs.d/${HOST}/ca.crt
+
+        echo "Creating a private registry..."
+        sudo docker run -d --restart=always --name "${REGISTRY_NAME}" \
+            -v /home/${USER}/auth:/auth \
+            -v /home/${USER}/certs:/certs \
+            -e REGISTRY_AUTH=htpasswd \
+            -e REGISTRY_AUTH_HTPASSWD_REALM="Registry Realm" \
+            -e REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd \
+            -e REGISTRY_HTTP_ADDR=0.0.0.0:443 \
+            -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt \
+            -e REGISTRY_HTTP_TLS_KEY=/certs/domain.key \
+            -p 443:443 registry:2
+    fi
+
+    echo "Logging into private registry ${HOST}..."
+    sudo docker login -u ${REGISTRY_USER} -p ${REGISTRY_PASS} https://${HOST}
+}
+
+fetch_images() {
+    echo "Fetching Rancher image lists..."
+    sudo wget ${ASSET_DIR}${RANCHER_VERSION}/rancher-images.txt -O /home/${USER}/rancher-images.txt
+    sudo wget ${ASSET_DIR}${RANCHER_VERSION}/rancher-windows-images.txt -O /home/${USER}/rancher-windows-images.txt
+
+    if [ ! -z "${RANCHER_AGENT_IMAGE}" ]; then
+        sudo sed -i "s|rancher/rancher:|${RANCHER_IMAGE}:|g" /home/${USER}/rancher-images.txt
+        sudo sed -i "s|rancher/rancher-agent:|${RANCHER_AGENT_IMAGE}:|g" /home/${USER}/rancher-images.txt
+    fi
+}
+
+manage_images() {
     ACTION=$1
     mapfile -t IMAGES < /home/${USER}/rancher-images.txt
     PARALLEL_ACTIONS=10
@@ -43,7 +95,7 @@ action() {
     fi
 }
 
-verifyImages() {
+verify_images() {
     echo "Verifying images in registry..."
 
     mapfile -t IMAGES < /home/${USER}/rancher-images.txt
@@ -74,64 +126,9 @@ verifyImages() {
     echo "Image verification complete."
 }
 
-echo "Logging into Docker Hub..."
-sudo docker login https://registry-1.docker.io -u "${DOCKERHUB_USER}" -p "${DOCKERHUB_PASS}"
-
-if [ "$(sudo docker ps -q -f name=${REGISTRY_NAME})" ]; then
-    echo "Private registry ${REGISTRY_NAME} already exists. Skipping..."
-else
-    sudo mkdir -p /home/${USER}/auth
-    sudo htpasswd -Bbn ${REGISTRY_USER} ${REGISTRY_PASS} | sudo tee /home/${USER}/auth/htpasswd
-
-    echo "Creating a self-signed certificate..."
-    sudo mkdir -p /home/${USER}/certs
-    sudo openssl req -newkey rsa:4096 -nodes -sha256 \
-        -keyout /home/${USER}/certs/domain.key \
-        -addext "subjectAltName = DNS:${HOST}" \
-        -x509 -days 365 -out /home/${USER}/certs/domain.crt \
-        -subj "/C=US/ST=CA/L=SUSE/O=Dis/CN=${HOST}"
-
-    echo "Copying the certificate to the /etc/docker/certs.d/${HOST} directory..."
-    sudo mkdir -p /etc/docker/certs.d/${HOST}
-    sudo cp /home/${USER}/certs/domain.crt /etc/docker/certs.d/${HOST}/ca.crt
-
-    echo "Creating a private registry..."
-    sudo docker run -d --restart=always --name "${REGISTRY_NAME}" \
-        -v /home/${USER}/auth:/auth \
-        -v /home/${USER}/certs:/certs \
-        -e REGISTRY_AUTH=htpasswd \
-        -e REGISTRY_AUTH_HTPASSWD_REALM="Registry Realm" \
-        -e REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd \
-        -e REGISTRY_HTTP_ADDR=0.0.0.0:443 \
-        -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt \
-        -e REGISTRY_HTTP_TLS_KEY=/certs/domain.key \
-        -p 443:443 registry:2
-fi
-
-echo "Logging into private registry ${HOST}..."
-sudo docker login -u ${REGISTRY_USER} -p ${REGISTRY_PASS} https://${HOST}
-
-echo "Fetching Rancher image lists..."
-sudo wget ${ASSET_DIR}${RANCHER_VERSION}/rancher-images.txt -O /home/${USER}/rancher-images.txt
-sudo wget ${ASSET_DIR}${RANCHER_VERSION}/rancher-windows-images.txt -O /home/${USER}/rancher-windows-images.txt
-sudo wget ${ASSET_DIR}${RANCHER_VERSION}/rancher-save-images.sh -O /home/${USER}/rancher-save-images.sh
-sudo wget ${ASSET_DIR}${RANCHER_VERSION}/rancher-load-images.sh -O /home/${USER}/rancher-load-images.sh
-    
-sudo chmod +x /home/${USER}/rancher-save-images.sh /home/${USER}/rancher-load-images.sh
-sudo sed -i "s/docker save/# docker save /g" /home/${USER}/rancher-save-images.sh
-sudo sed -i "s/docker load/# docker load /g" /home/${USER}/rancher-load-images.sh
-sudo sed -i '/mirrored-prometheus-windows-exporter/d' /home/${USER}/rancher-images.txt
-
-if [ ! -z "${RANCHER_AGENT_IMAGE}" ]; then
-    sudo sed -i "s|rancher/rancher:|${RANCHER_IMAGE}:|g" /home/${USER}/rancher-images.txt
-    sudo sed -i "s|rancher/rancher-agent:|${RANCHER_AGENT_IMAGE}:|g" /home/${USER}/rancher-images.txt
-fi
-
-echo "Pulling the images..."
-manageImages "pull"
-
-echo "Pushing the newly tagged images..."
-manageImages "push"
-
-echo "Verifying all images exist in registry..."
-verifyImages
+docker_login
+create_registry
+fetch_images
+manage_images "pull"
+manage_images "push"
+verify_images

--- a/framework/set/resources/registries/createRegistry/ecr-registry.sh
+++ b/framework/set/resources/registries/createRegistry/ecr-registry.sh
@@ -14,7 +14,7 @@ RANCHER_AGENT_IMAGE=${11}
 
 set -e
 
-configureAWS() {
+configure_aws() {
     echo "Configuring AWS CLI..."
     aws configure set aws_access_key_id "$AWS_ACCESS_KEY_ID"
     aws configure set aws_secret_access_key "$AWS_SECRET_ACCESS_KEY"
@@ -24,7 +24,49 @@ configureAWS() {
     aws ecr get-login-password --region "$AWS_REGION" | sudo docker login --username AWS --password-stdin "${ECR}"
 }
 
-manageImages() {
+docker_login() {
+    echo "Logging into Docker Hub..."
+    sudo docker login https://registry-1.docker.io -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_PASSWORD}
+}
+
+copy_certs() {
+    echo "Creating a self-signed certificate..."
+    mkdir -p certs
+    openssl req -newkey rsa:4096 -nodes -sha256 -keyout certs/domain.key -addext "subjectAltName = DNS:${ECR}" \
+                                                                         -x509 -days 365 -out certs/domain.crt \
+                                                                         -subj "/C=US/ST=CA/L=SUSE/O=Dis/CN=${ECR}"
+
+    echo "Copying the certificate to the /etc/docker/certs.d/${ECR} directory..."
+    sudo mkdir -p /etc/docker/certs.d/${ECR}
+    sudo cp certs/domain.crt /etc/docker/certs.d/${ECR}/ca.crt
+}
+
+fetch_images() {
+    echo "Downloading ${RANCHER_VERSION} image list and scripts..."
+    wget ${ASSET_DIR}${RANCHER_VERSION}/rancher-images.txt
+
+    echo "Cutting the tags from the image names..."
+    while read LINE; do
+        echo ${LINE} | cut -d: -f1
+    done < rancher-images.txt > rancher-images-no-tags.txt
+
+    echo "Creating ECR repositories..."
+    for IMAGE in $(cat rancher-images-no-tags.txt); do
+        if aws ecr describe-repositories --repository-names ${IMAGE} >/dev/null 2>&1; then
+            echo "Repository ${IMAGE} already exists. Skipping."
+        else
+            echo "Creating repository ${IMAGE}..."
+            aws ecr create-repository --repository-name ${IMAGE}
+        fi
+    done
+
+    if [ ! -z "${RANCHER_AGENT_IMAGE}" ]; then
+        sudo sed -i "s|rancher/rancher:|${RANCHER_IMAGE}:|g" /home/${USER}/rancher-images.txt
+        sudo sed -i "s|rancher/rancher-agent:|${RANCHER_AGENT_IMAGE}:|g" /home/${USER}/rancher-images.txt
+    fi
+}
+
+manage_images() {
     ACTION=$1
     mapfile -t IMAGES < /home/${USER}/rancher-images.txt
     PARALLEL_ACTIONS=10
@@ -53,7 +95,7 @@ action() {
     fi
 }
 
-verifyImages() {
+verify_images() {
     echo "Verifying images in ECR registry..."
 
     mapfile -t IMAGES < /home/${USER}/rancher-images.txt
@@ -84,58 +126,10 @@ verifyImages() {
     echo "Image verification complete."
 }
 
-configureAWS
-
-echo "Logging into Docker Hub..."
-sudo docker login https://registry-1.docker.io -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_PASSWORD}
-
-echo "Creating a self-signed certificate..."
-mkdir -p certs
-openssl req -newkey rsa:4096 -nodes -sha256 \
-    -keyout certs/domain.key \
-    -addext "subjectAltName = DNS:${ECR}" \
-    -x509 -days 365 -out certs/domain.crt \
-    -subj "/C=US/ST=CA/L=SUSE/O=Dis/CN=${ECR}"
-
-echo "Copying the certificate to the /etc/docker/certs.d/${ECR} directory..."
-sudo mkdir -p /etc/docker/certs.d/${ECR}
-sudo cp certs/domain.crt /etc/docker/certs.d/${ECR}/ca.crt
-
-echo "Downloading ${RANCHER_VERSION} image list and scripts..."
-wget ${ASSET_DIR}${RANCHER_VERSION}/rancher-images.txt
-wget ${ASSET_DIR}${RANCHER_VERSION}/rancher-save-images.sh
-
-echo "Cutting the tags from the image names..."
-while read LINE; do
-    echo ${LINE} | cut -d: -f1
-done < rancher-images.txt > rancher-images-no-tags.txt
-
-echo "Creating ECR repositories..."
-for IMAGE in $(cat rancher-images-no-tags.txt); do
-    if aws ecr describe-repositories --repository-names ${IMAGE} >/dev/null 2>&1; then
-        echo "Repository ${IMAGE} already exists. Skipping."
-    else
-        echo "Creating repository ${IMAGE}..."
-        aws ecr create-repository --repository-name ${IMAGE}
-    fi
-done
-
-echo "Saving the images..."
-sudo sed -i "s/docker save/# docker save /g" /home/${USER}/rancher-save-images.sh
-
-chmod +x rancher-save-images.sh
-./rancher-save-images.sh --image-list ./rancher-images.txt
-
-if [ ! -z "${RANCHER_AGENT_IMAGE}" ]; then
-    sudo sed -i "s|rancher/rancher:|${RANCHER_IMAGE}:|g" /home/${USER}/rancher-images.txt
-    sudo sed -i "s|rancher/rancher-agent:|${RANCHER_AGENT_IMAGE}:|g" /home/${USER}/rancher-images.txt
-fi
-
-echo "Pulling the images..."
-manageImages "pull"
-
-echo "Pushing the newly tagged images..."
-manageImages "push"
-
-echo "Verifying all images exist in ECR..."
-verifyImages
+configure_aws
+docker_login
+copy_certs
+fetch_images
+manage_images "pull"
+manage_images "push"
+verify_images

--- a/framework/set/resources/registries/rancher/setup.sh
+++ b/framework/set/resources/registries/rancher/setup.sh
@@ -93,7 +93,13 @@ install_cert_manager() {
     kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.crds.yaml
     helm repo add jetstack https://charts.jetstack.io
     helm repo update
-    helm upgrade --install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --version ${CERT_MANAGER_VERSION}
+
+    helm upgrade --install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --version ${CERT_MANAGER_VERSION} \
+                                                              --set image.repository=${REGISTRY}/quay.io/jetstack/cert-manager-controller \
+                                                              --set webhook.image.repository=${REGISTRY}/quay.io/jetstack/cert-manager-webhook \
+                                                              --set cainjector.image.repository=${REGISTRY}/quay.io/jetstack/cert-manager-cainjector \
+                                                              --set startupapicheck.image.repository=${REGISTRY}/quay.io/jetstack/cert-manager-startupapicheck
+    
     kubectl get pods --namespace cert-manager
 
     echo "Waiting 1 minute for Rancher"

--- a/framework/set/resources/registries/rke2/add-servers.sh
+++ b/framework/set/resources/registries/rke2/add-servers.sh
@@ -19,23 +19,19 @@ sudo touch /etc/rancher/rke2/config.yaml
 
 echo "server: https://${RKE2_SERVER_IP}:9345
 token: ${RKE2_TOKEN}
+system-default-registry: ${REGISTRY}
 tls-san:
   - ${RKE2_SERVER_IP}" | sudo tee /etc/rancher/rke2/config.yaml > /dev/null
 
-sudo tee -a /etc/rancher/rke2/registries.yaml > /dev/null << EOF
+
+sudo tee /etc/rancher/rke2/registries.yaml > /dev/null << EOF
 mirrors:
-  docker.io:
-    endpoint:
-      - "https://registry-1.docker.io"
-  "${REGISTRY}":
+  "docker.io":
     endpoint:
       - "https://${REGISTRY}"
-
+    rewrite:
+      "^rancher/(.*)": "${REGISTRY}/rancher/\$1"
 configs:
-  "docker.io":
-    auth:
-      username: "${REGISTRY_USERNAME}"
-      password: "${REGISTRY_PASSWORD}"
   "${REGISTRY}":
     tls:
       insecure_skip_verify: true

--- a/framework/set/resources/registries/rke2/init-server.sh
+++ b/framework/set/resources/registries/rke2/init-server.sh
@@ -18,23 +18,18 @@ sudo mkdir -p /etc/rancher/rke2
 sudo touch /etc/rancher/rke2/config.yaml
 
 echo "token: ${RKE2_TOKEN}
+system-default-registry: ${REGISTRY}
 tls-san:
   - ${RKE2_SERVER_IP}" | sudo tee /etc/rancher/rke2/config.yaml > /dev/null
 
-sudo tee -a /etc/rancher/rke2/registries.yaml > /dev/null << EOF
+sudo tee /etc/rancher/rke2/registries.yaml > /dev/null << EOF
 mirrors:
-  docker.io:
-    endpoint:
-      - "https://registry-1.docker.io"
-  "${REGISTRY}":
+  "docker.io":
     endpoint:
       - "https://${REGISTRY}"
-
+    rewrite:
+      "^rancher/(.*)": "${REGISTRY}/rancher/\$1"
 configs:
-  "docker.io":
-    auth:
-      username: "${REGISTRY_USERNAME}"
-      password: "${REGISTRY_PASSWORD}"
   "${REGISTRY}":
     tls:
       insecure_skip_verify: true

--- a/tests/registries/registries_test.go
+++ b/tests/registries/registries_test.go
@@ -62,6 +62,193 @@ func (r *TfpRegistriesTestSuite) SetupSuite() {
 	r.rancherConfig, r.terraformConfig, r.terratestConfig, r.standaloneConfig = config.LoadTFPConfigs(r.cattleConfig)
 }
 
+func (r *TfpRegistriesTestSuite) TestTfpAuthenticatedRegistry() {
+	var err error
+	var testUser, testPassword string
+	var clusterIDs []string
+
+	r.standardUserClient, testUser, testPassword, err = standarduser.CreateStandardUser(r.client)
+	require.NoError(r.T(), err)
+
+	standardUserToken, err := ranchers.CreateStandardUserToken(r.T(), r.terraformOptions, r.rancherConfig, testUser, testPassword)
+	require.NoError(r.T(), err)
+
+	standardToken := standardUserToken.Token
+
+	nodeRolesAll := []config.Nodepool{config.AllRolesNodePool}
+	nodeRolesDedicated := []config.Nodepool{config.EtcdNodePool, config.ControlPlaneNodePool, config.WorkerNodePool}
+
+	tests := []struct {
+		name      string
+		module    string
+		nodeRoles []config.Nodepool
+	}{
+		{"Auth_RKE2", modules.EC2RKE2, nodeRolesDedicated},
+		{"Auth_K3S", modules.EC2K3s, nodeRolesAll},
+	}
+
+	for _, tt := range tests {
+		r.T().Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			nestedRancherModuleDir, perTestTerraformOptions, err := nested.CreateNestedModules(r.terraformConfig, r.terratestConfig, r.terraformOptions, tt.name, configs.NestedRancherModuleDir)
+			require.NoError(t, err)
+			defer os.RemoveAll(nestedRancherModuleDir)
+
+			newFile, rootBody, file := rancher2.InitializeNestedMainTFs(nestedRancherModuleDir)
+			defer file.Close()
+
+			cattleConfig, err := provisioning.UniquifyTerraform(r.cattleConfig)
+			require.NoError(t, err)
+
+			_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, standardToken, cattleConfig)
+			require.NoError(r.T(), err)
+
+			_, err = operations.ReplaceValue([]string{"terratest", "nodepools"}, tt.nodeRoles, cattleConfig)
+			require.NoError(r.T(), err)
+
+			_, err = operations.ReplaceValue([]string{"terraform", "module"}, tt.module, cattleConfig)
+			require.NoError(r.T(), err)
+
+			_, err = operations.ReplaceValue([]string{"terraform", "privateRegistries", "systemDefaultRegistry"}, r.authRegistry, cattleConfig)
+			require.NoError(r.T(), err)
+
+			_, err = operations.ReplaceValue([]string{"terraform", "privateRegistries", "url"}, r.authRegistry, cattleConfig)
+			require.NoError(r.T(), err)
+
+			_, err = operations.ReplaceValue([]string{"terraform", "standaloneRegistry", "authenticated"}, true, cattleConfig)
+			require.NoError(r.T(), err)
+
+			provisioning.GetK8sVersion(r.standardUserClient, cattleConfig)
+
+			rancher, terraform, terratest, _ := config.LoadTFPConfigs(cattleConfig)
+
+			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, r.terratestConfig.PathToRepo, "")
+			defer cleanup.Cleanup(r.T(), perTestTerraformOptions, keyPath)
+
+			clusterIDs, _ := provisioning.Provision(r.T(), r.client, r.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, nil, nestedRancherModuleDir)
+			provisioning.VerifyClustersState(r.T(), r.client, clusterIDs)
+			provisioning.VerifyServiceAccountTokenSecret(r.T(), r.client, clusterIDs)
+
+			cluster, err := r.client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetDefault + "/" + terraform.ResourcePrefix)
+			require.NoError(r.T(), err)
+
+			err = pods.VerifyClusterPods(r.client, cluster)
+			require.NoError(r.T(), err)
+
+			provisioning.VerifyRegistry(r.T(), r.client, clusterIDs[0], terraform)
+
+			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
+			err = qase.UpdateSchemaParameters(tt.name, params)
+			if err != nil {
+				logrus.Warningf("Failed to upload schema parameters %s", err)
+			}
+		})
+	}
+
+	if r.terratestConfig.LocalQaseReporting {
+		results.ReportTest(r.terratestConfig)
+	}
+}
+
+func (r *TfpRegistriesTestSuite) TestTfpECRRegistry() {
+	var err error
+	var testUser, testPassword string
+	var clusterIDs []string
+
+	r.standardUserClient, testUser, testPassword, err = standarduser.CreateStandardUser(r.client)
+	require.NoError(r.T(), err)
+
+	standardUserToken, err := ranchers.CreateStandardUserToken(r.T(), r.terraformOptions, r.rancherConfig, testUser, testPassword)
+	require.NoError(r.T(), err)
+
+	standardToken := standardUserToken.Token
+
+	nodeRolesAll := []config.Nodepool{config.AllRolesNodePool}
+	nodeRolesDedicated := []config.Nodepool{config.EtcdNodePool, config.ControlPlaneNodePool, config.WorkerNodePool}
+
+	tests := []struct {
+		name      string
+		module    string
+		nodeRoles []config.Nodepool
+	}{
+		{"ECR_RKE2", modules.EC2RKE2, nodeRolesDedicated},
+		{"ECR_K3S", modules.EC2K3s, nodeRolesAll},
+	}
+
+	for _, tt := range tests {
+		r.T().Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			nestedRancherModuleDir, perTestTerraformOptions, err := nested.CreateNestedModules(r.terraformConfig, r.terratestConfig, r.terraformOptions, tt.name, configs.NestedRancherModuleDir)
+			require.NoError(t, err)
+			defer os.RemoveAll(nestedRancherModuleDir)
+
+			newFile, rootBody, file := rancher2.InitializeNestedMainTFs(nestedRancherModuleDir)
+			defer file.Close()
+
+			cattleConfig, err := provisioning.UniquifyTerraform(r.cattleConfig)
+			require.NoError(t, err)
+
+			_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, standardToken, cattleConfig)
+			require.NoError(r.T(), err)
+
+			_, err = operations.ReplaceValue([]string{"terratest", "nodepools"}, tt.nodeRoles, cattleConfig)
+			require.NoError(r.T(), err)
+
+			_, err = operations.ReplaceValue([]string{"terraform", "module"}, tt.module, cattleConfig)
+			require.NoError(r.T(), err)
+
+			_, err = operations.ReplaceValue([]string{"terraform", "privateRegistries", "systemDefaultRegistry"}, r.terraformConfig.StandaloneRegistry.ECRURI, cattleConfig)
+			require.NoError(r.T(), err)
+
+			_, err = operations.ReplaceValue([]string{"terraform", "privateRegistries", "url"}, r.terraformConfig.StandaloneRegistry.ECRURI, cattleConfig)
+			require.NoError(r.T(), err)
+
+			_, err = operations.ReplaceValue([]string{"terraform", "privateRegistries", "username"}, r.terraformConfig.StandaloneRegistry.ECRUsername, cattleConfig)
+			require.NoError(r.T(), err)
+
+			_, err = operations.ReplaceValue([]string{"terraform", "privateRegistries", "password"}, r.terraformConfig.StandaloneRegistry.ECRPassword, cattleConfig)
+			require.NoError(r.T(), err)
+
+			_, err = operations.ReplaceValue([]string{"terraform", "standaloneRegistry", "authenticated"}, true, cattleConfig)
+			require.NoError(r.T(), err)
+
+			_, err = operations.ReplaceValue([]string{"terraform", "privateRegistries", "authConfigSecretName"}, r.terraformConfig.PrivateRegistries.AuthConfigSecretName+"-ecr", cattleConfig)
+			require.NoError(r.T(), err)
+
+			provisioning.GetK8sVersion(r.standardUserClient, cattleConfig)
+
+			rancher, terraform, terratest, _ := config.LoadTFPConfigs(cattleConfig)
+
+			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, r.terratestConfig.PathToRepo, "")
+			defer cleanup.Cleanup(r.T(), perTestTerraformOptions, keyPath)
+
+			clusterIDs, _ := provisioning.Provision(r.T(), r.client, r.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, nil, nestedRancherModuleDir)
+			provisioning.VerifyClustersState(r.T(), r.client, clusterIDs)
+			provisioning.VerifyServiceAccountTokenSecret(r.T(), r.client, clusterIDs)
+
+			cluster, err := r.client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetDefault + "/" + terraform.ResourcePrefix)
+			require.NoError(r.T(), err)
+
+			err = pods.VerifyClusterPods(r.client, cluster)
+			require.NoError(r.T(), err)
+
+			provisioning.VerifyRegistry(r.T(), r.client, clusterIDs[0], terraform)
+
+			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
+			err = qase.UpdateSchemaParameters(tt.name, params)
+			if err != nil {
+				logrus.Warningf("Failed to upload schema parameters %s", err)
+			}
+		})
+	}
+
+	if r.terratestConfig.LocalQaseReporting {
+		results.ReportTest(r.terratestConfig)
+	}
+}
+
 func (r *TfpRegistriesTestSuite) TestTfpGlobalRegistry() {
 	var err error
 	var testUser, testPassword string
@@ -171,95 +358,6 @@ func (r *TfpRegistriesTestSuite) TestTfpGlobalRegistry() {
 	}
 }
 
-func (r *TfpRegistriesTestSuite) TestTfpAuthenticatedRegistry() {
-	var err error
-	var testUser, testPassword string
-	var clusterIDs []string
-
-	r.standardUserClient, testUser, testPassword, err = standarduser.CreateStandardUser(r.client)
-	require.NoError(r.T(), err)
-
-	standardUserToken, err := ranchers.CreateStandardUserToken(r.T(), r.terraformOptions, r.rancherConfig, testUser, testPassword)
-	require.NoError(r.T(), err)
-
-	standardToken := standardUserToken.Token
-
-	nodeRolesAll := []config.Nodepool{config.AllRolesNodePool}
-	nodeRolesDedicated := []config.Nodepool{config.EtcdNodePool, config.ControlPlaneNodePool, config.WorkerNodePool}
-
-	tests := []struct {
-		name      string
-		module    string
-		nodeRoles []config.Nodepool
-	}{
-		{"Auth_RKE2", modules.EC2RKE2, nodeRolesDedicated},
-		{"Auth_K3S", modules.EC2K3s, nodeRolesAll},
-	}
-
-	for _, tt := range tests {
-		r.T().Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			nestedRancherModuleDir, perTestTerraformOptions, err := nested.CreateNestedModules(r.terraformConfig, r.terratestConfig, r.terraformOptions, tt.name, configs.NestedRancherModuleDir)
-			require.NoError(t, err)
-			defer os.RemoveAll(nestedRancherModuleDir)
-
-			newFile, rootBody, file := rancher2.InitializeNestedMainTFs(nestedRancherModuleDir)
-			defer file.Close()
-
-			cattleConfig, err := provisioning.UniquifyTerraform(r.cattleConfig)
-			require.NoError(t, err)
-
-			_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, standardToken, cattleConfig)
-			require.NoError(r.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terratest", "nodepools"}, tt.nodeRoles, cattleConfig)
-			require.NoError(r.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "module"}, tt.module, cattleConfig)
-			require.NoError(r.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "privateRegistries", "systemDefaultRegistry"}, r.authRegistry, cattleConfig)
-			require.NoError(r.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "privateRegistries", "url"}, r.authRegistry, cattleConfig)
-			require.NoError(r.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "standaloneRegistry", "authenticated"}, true, cattleConfig)
-			require.NoError(r.T(), err)
-
-			provisioning.GetK8sVersion(r.standardUserClient, cattleConfig)
-
-			rancher, terraform, terratest, _ := config.LoadTFPConfigs(cattleConfig)
-
-			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, r.terratestConfig.PathToRepo, "")
-			defer cleanup.Cleanup(r.T(), perTestTerraformOptions, keyPath)
-
-			clusterIDs, _ := provisioning.Provision(r.T(), r.client, r.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, nil, nestedRancherModuleDir)
-			provisioning.VerifyClustersState(r.T(), r.client, clusterIDs)
-			provisioning.VerifyServiceAccountTokenSecret(r.T(), r.client, clusterIDs)
-
-			cluster, err := r.client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetDefault + "/" + terraform.ResourcePrefix)
-			require.NoError(r.T(), err)
-
-			err = pods.VerifyClusterPods(r.client, cluster)
-			require.NoError(r.T(), err)
-
-			provisioning.VerifyRegistry(r.T(), r.client, clusterIDs[0], terraform)
-
-			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
-			err = qase.UpdateSchemaParameters(tt.name, params)
-			if err != nil {
-				logrus.Warningf("Failed to upload schema parameters %s", err)
-			}
-		})
-	}
-
-	if r.terratestConfig.LocalQaseReporting {
-		results.ReportTest(r.terratestConfig)
-	}
-}
-
 func (r *TfpRegistriesTestSuite) TestTfpNonAuthenticatedRegistry() {
 	var err error
 	var testUser, testPassword string
@@ -355,104 +453,6 @@ func (r *TfpRegistriesTestSuite) TestTfpNonAuthenticatedRegistry() {
 
 				provisioning.VerifyRegistry(r.T(), r.client, clusterIDs[0], terraform)
 			}
-
-			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
-			err = qase.UpdateSchemaParameters(tt.name, params)
-			if err != nil {
-				logrus.Warningf("Failed to upload schema parameters %s", err)
-			}
-		})
-	}
-
-	if r.terratestConfig.LocalQaseReporting {
-		results.ReportTest(r.terratestConfig)
-	}
-}
-
-func (r *TfpRegistriesTestSuite) TestTfpECRRegistry() {
-	var err error
-	var testUser, testPassword string
-	var clusterIDs []string
-
-	r.standardUserClient, testUser, testPassword, err = standarduser.CreateStandardUser(r.client)
-	require.NoError(r.T(), err)
-
-	standardUserToken, err := ranchers.CreateStandardUserToken(r.T(), r.terraformOptions, r.rancherConfig, testUser, testPassword)
-	require.NoError(r.T(), err)
-
-	standardToken := standardUserToken.Token
-
-	nodeRolesAll := []config.Nodepool{config.AllRolesNodePool}
-	nodeRolesDedicated := []config.Nodepool{config.EtcdNodePool, config.ControlPlaneNodePool, config.WorkerNodePool}
-
-	tests := []struct {
-		name      string
-		module    string
-		nodeRoles []config.Nodepool
-	}{
-		{"ECR_RKE2", modules.EC2RKE2, nodeRolesDedicated},
-		{"ECR_K3S", modules.EC2K3s, nodeRolesAll},
-	}
-
-	for _, tt := range tests {
-		r.T().Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			nestedRancherModuleDir, perTestTerraformOptions, err := nested.CreateNestedModules(r.terraformConfig, r.terratestConfig, r.terraformOptions, tt.name, configs.NestedRancherModuleDir)
-			require.NoError(t, err)
-			defer os.RemoveAll(nestedRancherModuleDir)
-
-			newFile, rootBody, file := rancher2.InitializeNestedMainTFs(nestedRancherModuleDir)
-			defer file.Close()
-
-			cattleConfig, err := provisioning.UniquifyTerraform(r.cattleConfig)
-			require.NoError(t, err)
-
-			_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, standardToken, cattleConfig)
-			require.NoError(r.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terratest", "nodepools"}, tt.nodeRoles, cattleConfig)
-			require.NoError(r.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "module"}, tt.module, cattleConfig)
-			require.NoError(r.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "privateRegistries", "systemDefaultRegistry"}, r.terraformConfig.StandaloneRegistry.ECRURI, cattleConfig)
-			require.NoError(r.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "privateRegistries", "url"}, r.terraformConfig.StandaloneRegistry.ECRURI, cattleConfig)
-			require.NoError(r.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "privateRegistries", "username"}, r.terraformConfig.StandaloneRegistry.ECRUsername, cattleConfig)
-			require.NoError(r.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "privateRegistries", "password"}, r.terraformConfig.StandaloneRegistry.ECRPassword, cattleConfig)
-			require.NoError(r.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "standaloneRegistry", "authenticated"}, true, cattleConfig)
-			require.NoError(r.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "privateRegistries", "authConfigSecretName"}, r.terraformConfig.PrivateRegistries.AuthConfigSecretName+"-ecr", cattleConfig)
-			require.NoError(r.T(), err)
-
-			provisioning.GetK8sVersion(r.standardUserClient, cattleConfig)
-
-			rancher, terraform, terratest, _ := config.LoadTFPConfigs(cattleConfig)
-
-			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, r.terratestConfig.PathToRepo, "")
-			defer cleanup.Cleanup(r.T(), perTestTerraformOptions, keyPath)
-
-			clusterIDs, _ := provisioning.Provision(r.T(), r.client, r.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, nil, nestedRancherModuleDir)
-			provisioning.VerifyClustersState(r.T(), r.client, clusterIDs)
-			provisioning.VerifyServiceAccountTokenSecret(r.T(), r.client, clusterIDs)
-
-			cluster, err := r.client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetDefault + "/" + terraform.ResourcePrefix)
-			require.NoError(r.T(), err)
-
-			err = pods.VerifyClusterPods(r.client, cluster)
-			require.NoError(r.T(), err)
-
-			provisioning.VerifyRegistry(r.T(), r.client, clusterIDs[0], terraform)
 
 			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
 			err = qase.UpdateSchemaParameters(tt.name, params)


### PR DESCRIPTION
### Description
Long overdue, but this is a PR that will provides much-needed QOL changes to the `registries_test.go`. See below the specifics:
- Refactors `auth_registry.sh` and `ecr-registry.sh` to utilize functions like `non-auth-registry.sh` - better code readability
- For the local cluster, ensure ALL pods are using the global registry prefix (including RKE2 / cert-manager workloads)
- Restructure test functions in alphabetical (more to satisfy my OCD)