### PR TITLE
Check for global registry after registry Rancher is up

### DIFF
--- a/tests/infrastructure/ranchers/create_rancher.go
+++ b/tests/infrastructure/ranchers/create_rancher.go
@@ -230,5 +230,12 @@ func SetupRegistryRancher(t *testing.T, session *session.Session, moduleKeyPath 
 	_, keyPath = rancher2.SetKeyPath(keypath.RancherKeyPath, terratestConfig.PathToRepo, "")
 	terraformOptions := framework.Setup(t, terraformConfig, terratestConfig, keyPath)
 
+	usesRegistryPrefix, err := reg.CheckAllClusterPodsForRegistryPrefix(client, local, globalRegistry)
+	require.NoError(t, err)
+
+	if !usesRegistryPrefix {
+		t.Fatalf("ERROR: not all of the local cluster pods are using the global registry")
+	}
+
 	return client, authRegistry, nonAuthRegistry, globalRegistry, standaloneTerraformOptions, terraformOptions, cattleConfig
 }


### PR DESCRIPTION
### Description
Small PR to check that the local cluster pods use the global registry for the `registries_test.go`. We have the same check in airgap Rancher, so we should do this as well.