### PR TITLE
Save test results only on scheduled runs

### DIFF
--- a/.github/workflows/airgap-test.yaml
+++ b/.github/workflows/airgap-test.yaml
@@ -308,13 +308,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"airgap-test\", \"job\": \"v2-15\" }" > test-result-airgap-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-airgap-test-v2-15-${{ github.run_id }}
@@ -587,13 +587,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"airgap-test\", \"job\": \"v2-14\" }" > test-result-airgap-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-airgap-test-v2-14-${{ github.run_id }}
@@ -878,13 +878,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"airgap-test\", \"job\": \"v2-13\" }" > test-result-airgap-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-airgap-test-v2-13-${{ github.run_id }}

--- a/.github/workflows/airgap-upgrade-test.yaml
+++ b/.github/workflows/airgap-upgrade-test.yaml
@@ -313,13 +313,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"airgap-upgrade-test\", \"job\": \"v2-15\" }" > test-result-airgap-upgrade-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-airgap-upgrade-test-v2-15-${{ github.run_id }}
@@ -599,13 +599,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"airgap-upgrade-test\", \"job\": \"v2-14\" }" > test-result-airgap-upgrade-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-airgap-upgrade-test-v2-14-${{ github.run_id }}
@@ -899,13 +899,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"airgap-upgrade-test\", \"job\": \"v2-13\" }" > test-result-airgap-upgrade-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always()&& github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-airgap-upgrade-test-v2-13-${{ github.run_id }}

--- a/.github/workflows/community-prime-upgrade-test.yaml
+++ b/.github/workflows/community-prime-upgrade-test.yaml
@@ -291,13 +291,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"community-prime-upgrade\", \"job\": \"v2-14\" }" > test-result-community-prime-upgrade-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-community-prime-upgrade-test-v2-14-${{ github.run_id }}

--- a/.github/workflows/kdm-test.yaml
+++ b/.github/workflows/kdm-test.yaml
@@ -295,13 +295,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"kdm-test\", \"job\": \"v2-15\" }" > test-result-kdm-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-kdm-test-v2-15-${{ github.run_id }}
@@ -566,13 +566,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"kdm-test\", \"job\": \"v2-14\" }" > test-result-kdm-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-kdm-test-v2-14-${{ github.run_id }}
@@ -839,13 +839,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"kdm-test\", \"job\": \"v2-13\" }" > test-result-kdm-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-kdm-test-v2-13-${{ github.run_id }}

--- a/.github/workflows/mcm-test.yaml
+++ b/.github/workflows/mcm-test.yaml
@@ -272,13 +272,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"mcm-test\", \"job\": \"v2-15\" }" > test-result-mcm-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-mcm-test-v2-15-${{ github.run_id }}
@@ -517,13 +517,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"mcm-test\", \"job\": \"v2-14\" }" > test-result-mcm-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-mcm-test-v2-14-${{ github.run_id }}
@@ -763,13 +763,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"mcm-test\", \"job\": \"v2-13\" }" > test-result-mcm-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-mcm-test-v2-13-${{ github.run_id }}

--- a/.github/workflows/post-release-sanity-upgrade.yaml
+++ b/.github/workflows/post-release-sanity-upgrade.yaml
@@ -319,13 +319,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"post-release-sanity-upgrade\", \"job\": \"v2-15\" }" > test-result-post-release-sanity-upgrade-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-post-release-sanity-upgrade-test-v2-15-${{ github.run_id }}
@@ -592,13 +592,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"post-release-sanity-upgrade\", \"job\": \"v2-14\" }" > test-result-post-release-sanity-upgrade-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-post-release-sanity-upgrade-test-v2-14-${{ github.run_id }}
@@ -865,13 +865,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"post-release-sanity-upgrade\", \"job\": \"v2-13\" }" > test-result-post-release-sanity-upgrade-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-post-release-sanity-upgrade-test-v2-13-${{ github.run_id }}

--- a/.github/workflows/post-release-sanity.yaml
+++ b/.github/workflows/post-release-sanity.yaml
@@ -305,13 +305,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"post-release-sanity\", \"job\": \"v2-15\" }" > test-result-post-release-sanity-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-post-release-sanity-test-v2-15-${{ github.run_id }}
@@ -564,13 +564,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"post-release-sanity\", \"job\": \"v2-14\" }" > test-result-post-release-sanity-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-post-release-sanity-test-v2-14-${{ github.run_id }}
@@ -823,13 +823,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"post-release-sanity\", \"job\": \"v2-13\" }" > test-result-post-release-sanity-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-post-release-sanity-test-v2-13-${{ github.run_id }}

--- a/.github/workflows/prime-community-upgrade-test.yaml
+++ b/.github/workflows/prime-community-upgrade-test.yaml
@@ -303,13 +303,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"prime-community-upgrade-test\", \"job\": \"v2-14\" }" > test-result-prime-community-upgrade-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-prime-community-upgrade-test-v2-14-${{ github.run_id }}

--- a/.github/workflows/proxy-test.yaml
+++ b/.github/workflows/proxy-test.yaml
@@ -322,13 +322,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"proxy-test\", \"job\": \"v2-15\" }" > test-result-proxy-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-proxy-test-v2-15-${{ github.run_id }}
@@ -614,13 +614,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"proxy-test\", \"job\": \"v2-14\" }" > test-result-proxy-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-proxy-test-v2-14-${{ github.run_id }}
@@ -908,13 +908,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"proxy-test\", \"job\": \"v2-13\" }" > test-result-proxy-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-proxy-test-v2-13-${{ github.run_id }}

--- a/.github/workflows/proxy-upgrade-test.yaml
+++ b/.github/workflows/proxy-upgrade-test.yaml
@@ -329,13 +329,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"proxy-upgrade-test\", \"job\": \"v2-15\" }" > test-result-proxy-upgrade-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-proxy-upgrade-test-v2-15-${{ github.run_id }}
@@ -628,13 +628,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"proxy-upgrade-test\", \"job\": \"v2-14\" }" > test-result-proxy-upgrade-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-proxy-upgrade-test-v2-14-${{ github.run_id }}
@@ -929,13 +929,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"proxy-upgrade-test\", \"job\": \"v2-13\" }" > test-result-proxy-upgrade-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-proxy-upgrade-test-v2-13-${{ github.run_id }}

--- a/.github/workflows/rancher2-airgap-recurring-test.yaml
+++ b/.github/workflows/rancher2-airgap-recurring-test.yaml
@@ -304,13 +304,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"rancher2-airgap-recurring-test\", \"job\": \"v2-15\" }" > test-result-rancher2-airgap-recurring-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-rancher2-airgap-recurring-test-v2-15-${{ github.run_id }}
@@ -580,13 +580,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"rancher2-airgap-recurring-test\", \"job\": \"v2-14\" }" > test-result-rancher2-airgap-recurring-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-rancher2-airgap-recurring-test-v2-14-${{ github.run_id }}
@@ -868,13 +868,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"rancher2-airgap-recurring-test\", \"job\": \"v2-13\" }" > test-result-rancher2-airgap-recurring-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-rancher2-airgap-recurring-test-v2-13-${{ github.run_id }}

--- a/.github/workflows/rancher2-recurring-test.yaml
+++ b/.github/workflows/rancher2-recurring-test.yaml
@@ -324,13 +324,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"rancher2-recurring-test\", \"job\": \"v2-15\" }" > test-result-rancher2-recurring-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-rancher2-recurring-test-v2-15-${{ github.run_id }}
@@ -628,13 +628,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"rancher2-recurring-test\", \"job\": \"v2-14\" }" > test-result-rancher2-recurring-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-rancher2-recurring-test-v2-14-${{ github.run_id }}
@@ -925,13 +925,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"rancher2-recurring-test\", \"job\": \"v2-13\" }" > test-result-rancher2-recurring-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-rancher2-recurring-test-v2-13-${{ github.run_id }}

--- a/.github/workflows/registry-test.yaml
+++ b/.github/workflows/registry-test.yaml
@@ -310,13 +310,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"registry-test\", \"job\": \"v2-15\" }" > test-result-registry-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-registry-test-v2-15-${{ github.run_id }}
@@ -591,13 +591,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"registry-test\", \"job\": \"v2-14\" }" > test-result-registry-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-registry-test-v2-14-${{ github.run_id }}
@@ -884,13 +884,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"registry-test\", \"job\": \"v2-13\" }" > test-result-registry-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-registry-test-v2-13-${{ github.run_id }}

--- a/.github/workflows/sanity-aks-test.yaml
+++ b/.github/workflows/sanity-aks-test.yaml
@@ -291,13 +291,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"sanity-aks-test\", \"job\": \"v2-15\" }" > test-result-sanity-aks-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-sanity-aks-test-v2-15-${{ github.run_id }}
@@ -551,13 +551,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"sanity-aks-test\", \"job\": \"v2-14\" }" > test-result-sanity-aks-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-sanity-aks-test-v2-14-${{ github.run_id }}
@@ -813,13 +813,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"sanity-aks-test\", \"job\": \"v2-13\" }" > test-result-sanity-aks-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-sanity-aks-test-v2-13-${{ github.run_id }}

--- a/.github/workflows/sanity-arm64-test.yaml
+++ b/.github/workflows/sanity-arm64-test.yaml
@@ -306,13 +306,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"sanity-arm64-test\", \"job\": \"v2-15\" }" > test-result-sanity-arm64-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-sanity-arm64-test-v2-15-${{ github.run_id }}
@@ -591,13 +591,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"sanity-arm64-test\", \"job\": \"v2-14\" }" > test-result-sanity-arm64-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-sanity-arm64-test-v2-14-${{ github.run_id }}
@@ -878,13 +878,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"sanity-arm64-test\", \"job\": \"v2-13\" }" > test-result-sanity-arm64-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-sanity-arm64-test-v2-13-${{ github.run_id }}

--- a/.github/workflows/sanity-dualstack-test.yaml
+++ b/.github/workflows/sanity-dualstack-test.yaml
@@ -313,13 +313,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"sanity-dualstack-test\", \"job\": \"v2-15\" }" > test-result-sanity-dualstack-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-sanity-dualstack-test-v2-15-${{ github.run_id }}
@@ -595,13 +595,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"sanity-dualstack-test\", \"job\": \"v2-14\" }" > test-result-sanity-dualstack-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-sanity-dualstack-test-v2-14-${{ github.run_id }}
@@ -878,13 +878,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"sanity-dualstack-test\", \"job\": \"v2-13\" }" > test-result-sanity-dualstack-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-sanity-dualstack-test-v2-13-${{ github.run_id }}

--- a/.github/workflows/sanity-dualstack-upgrade-test.yaml
+++ b/.github/workflows/sanity-dualstack-upgrade-test.yaml
@@ -324,13 +324,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"sanity-dualstack-upgrade-test\", \"job\": \"v2-15\" }" > test-result-sanity-dualstack-upgrade-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-sanity-dualstack-upgrade-test-v2-15-${{ github.run_id }}
@@ -618,13 +618,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"sanity-dualstack-upgrade-test\", \"job\": \"v2-14\" }" > test-result-sanity-dualstack-upgrade-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-sanity-dualstack-upgrade-test-v2-14-${{ github.run_id }}
@@ -913,13 +913,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"sanity-dualstack-upgrade-test\", \"job\": \"v2-13\" }" > test-result-sanity-dualstack-upgrade-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-sanity-dualstack-upgrade-test-v2-13-${{ github.run_id }}

--- a/.github/workflows/sanity-eks-test.yaml
+++ b/.github/workflows/sanity-eks-test.yaml
@@ -298,13 +298,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"sanity-eks-test\", \"job\": \"v2-15\" }" > test-result-sanity-eks-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-sanity-eks-test-v2-15-${{ github.run_id }}
@@ -565,13 +565,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"sanity-eks-test\", \"job\": \"v2-14\" }" > test-result-sanity-eks-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-sanity-eks-test-v2-14-${{ github.run_id }}
@@ -834,13 +834,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"sanity-eks-test\", \"job\": \"v2-13\" }" > test-result-sanity-eks-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-sanity-eks-test-v2-13-${{ github.run_id }}

--- a/.github/workflows/sanity-gke-test.yaml
+++ b/.github/workflows/sanity-gke-test.yaml
@@ -280,13 +280,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"sanity-gke-test\", \"job\": \"v2-15\" }" > test-result-sanity-gke-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-sanity-gke-test-v2-15-${{ github.run_id }}
@@ -529,13 +529,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"sanity-gke-test\", \"job\": \"v2-14\" }" > test-result-sanity-gke-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-sanity-gke-test-v2-14-${{ github.run_id }}
@@ -780,13 +780,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"sanity-gke-test\", \"job\": \"v2-13\" }" > test-result-sanity-gke-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-sanity-gke-test-v2-13-${{ github.run_id }}

--- a/.github/workflows/sanity-ipv6-hosted-cluster-test.yaml
+++ b/.github/workflows/sanity-ipv6-hosted-cluster-test.yaml
@@ -316,13 +316,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"sanity-ipv6-hosted-cluster-test\", \"job\": \"v2-15\" }" > test-result-sanity-ipv6-hosted-cluster-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-sanity-ipv6-hosted-cluster-test-v2-15-${{ github.run_id }}
@@ -601,13 +601,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"sanity-ipv6-hosted-cluster-test\", \"job\": \"v2-14\" }" > test-result-sanity-ipv6-hosted-cluster-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-sanity-ipv6-hosted-cluster-test-v2-14-${{ github.run_id }}

--- a/.github/workflows/sanity-ipv6-test.yaml
+++ b/.github/workflows/sanity-ipv6-test.yaml
@@ -313,13 +313,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"sanity-ipv6-test\", \"job\": \"v2-15\" }" > test-result-sanity-ipv6-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-sanity-ipv6-test-v2-15-${{ github.run_id }}
@@ -595,13 +595,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"sanity-ipv6-test\", \"job\": \"v2-14\" }" > test-result-sanity-ipv6-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-sanity-ipv6-test-v2-14-${{ github.run_id }}
@@ -878,13 +878,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"sanity-ipv6-test\", \"job\": \"v2-13\" }" > test-result-sanity-ipv6-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-sanity-ipv6-test-v2-13-${{ github.run_id }}

--- a/.github/workflows/sanity-ipv6-upgrade-test.yaml
+++ b/.github/workflows/sanity-ipv6-upgrade-test.yaml
@@ -324,13 +324,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"sanity-ipv6-upgrade-test\", \"job\": \"v2-15\" }" > test-result-sanity-ipv6-upgrade-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-sanity-ipv6-upgrade-test-v2-15-${{ github.run_id }}
@@ -618,13 +618,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"sanity-ipv6-upgrade-test\", \"job\": \"v2-14\" }" > test-result-sanity-ipv6-upgrade-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-sanity-ipv6-upgrade-test-v2-14-${{ github.run_id }}
@@ -913,13 +913,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"sanity-ipv6-upgrade-test\", \"job\": \"v2-13\" }" > test-result-sanity-ipv6-upgrade-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-sanity-ipv6-upgrade-test-v2-13-${{ github.run_id }}

--- a/.github/workflows/sanity-mixed-arch-test.yaml
+++ b/.github/workflows/sanity-mixed-arch-test.yaml
@@ -309,13 +309,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"sanity-mixed-arch-test\", \"job\": \"v2-15\" }" > test-result-sanity-mixed-arch-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-sanity-mixed-arch-test-v2-15-${{ github.run_id }}
@@ -597,13 +597,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"sanity-mixed-arch-test\", \"job\": \"v2-14\" }" > test-result-sanity-mixed-arch-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-sanity-mixed-arch-test-v2-14-${{ github.run_id }}

--- a/.github/workflows/sanity-test.yaml
+++ b/.github/workflows/sanity-test.yaml
@@ -431,13 +431,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"sanity-test\", \"job\": \"v2-15\" }" > test-result-sanity-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-sanity-test-v2-15-${{ github.run_id }}
@@ -817,13 +817,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"sanity-test\", \"job\": \"v2-14\" }" > test-result-sanity-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-sanity-test-v2-14-${{ github.run_id }}
@@ -1205,13 +1205,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"sanity-test\", \"job\": \"v2-13\" }" > test-result-sanity-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-sanity-test-v2-13-${{ github.run_id }}

--- a/.github/workflows/sanity-turtles-off-test.yaml
+++ b/.github/workflows/sanity-turtles-off-test.yaml
@@ -318,13 +318,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"sanity-turtles-off-test\", \"job\": \"v2-15\" }" > test-result-sanity-turtles-off-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-sanity-turtles-off-test-v2-15-${{ github.run_id }}
@@ -606,13 +606,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"sanity-turtles-off-test\", \"job\": \"v2-14\" }" > test-result-sanity-turtles-off-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-sanity-turtles-off-test-v2-14-${{ github.run_id }}
@@ -896,13 +896,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"sanity-turtles-off-test\", \"job\": \"v2-13\" }" > test-result-sanity-turtles-off-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-sanity-turtles-off-test-v2-13-${{ github.run_id }}

--- a/.github/workflows/sanity-upgrade-arm64-test.yaml
+++ b/.github/workflows/sanity-upgrade-arm64-test.yaml
@@ -313,13 +313,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"sanity-upgrade-arm64-test\", \"job\": \"v2-15\" }" > test-result-sanity-upgrade-arm64-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-sanity-upgrade-arm64-test-v2-15-${{ github.run_id }}
@@ -605,13 +605,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"sanity-upgrade-arm64-test\", \"job\": \"v2-14\" }" > test-result-sanity-upgrade-arm64-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-sanity-upgrade-arm64-test-v2-14-${{ github.run_id }}
@@ -899,13 +899,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"sanity-upgrade-arm64-test\", \"job\": \"v2-13\" }" > test-result-sanity-upgrade-arm64-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-sanity-upgrade-arm64-test-v2-13-${{ github.run_id }}

--- a/.github/workflows/sanity-upgrade-test.yaml
+++ b/.github/workflows/sanity-upgrade-test.yaml
@@ -438,13 +438,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
-          *
+          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"sanity-upgrade-test\", \"job\": \"v2-15\" }" > test-result-sanity-upgrade-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-sanity-upgrade-test-v2-15-${{ github.run_id }}
@@ -830,13 +830,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"sanity-upgrade-test\", \"job\": \"v2-14\" }" > test-result-sanity-upgrade-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-sanity-upgrade-test-v2-14-${{ github.run_id }}
@@ -1225,13 +1225,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"sanity-upgrade-test\", \"job\": \"v2-13\" }" > test-result-sanity-upgrade-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-sanity-upgrade-test-v2-13-${{ github.run_id }}


### PR DESCRIPTION
### Description
Thinking further through the recent weekly report results, we want to limit this to strictly just scheduled runs. We often test PR changes in GHA, so this will quickly create meaningless results. We want to ensure that the data we are parsing is strictly from scheduled runs only.