### PR TITLE
Fix conditional in close-qase-run

### DIFF
--- a/.github/workflows/post-release-sanity-upgrade.yaml
+++ b/.github/workflows/post-release-sanity-upgrade.yaml
@@ -879,7 +879,14 @@ jobs:
 
   close-qase-run:
     needs: [create-qase-run, v2-14, v2-14-prime, v2-13]
-    if: always()
+    if: always() && (
+        ((github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13'))) && !contains(github.event.inputs.rancher_version, '-alpha') &&
+        (github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13'))) && !contains(github.event.inputs.rancher_version, '-rc') &&
+        (github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13'))) && !contains(github.event.inputs.rancher_version, '-head')) ||
+        ((github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.14') || startsWith(inputs.rancher_version, 'v2.13'))) && !contains(inputs.rancher_version, '-alpha') &&
+        (github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.14') || startsWith(inputs.rancher_version, 'v2.13'))) && !contains(inputs.rancher_version, '-rc') &&
+        (github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.14') || startsWith(inputs.rancher_version, 'v2.13'))) && !contains(inputs.rancher_version, '-head'))
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/post-release-sanity.yaml
+++ b/.github/workflows/post-release-sanity.yaml
@@ -837,7 +837,14 @@ jobs:
 
   close-qase-run:
     needs: [create-qase-run, v2-14, v2-14-prime, v2-13]
-    if: always()
+    if: always() && (
+        ((github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13'))) && !contains(github.event.inputs.rancher_version, '-alpha') &&
+        (github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13'))) && !contains(github.event.inputs.rancher_version, '-rc') &&
+        (github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13'))) && !contains(github.event.inputs.rancher_version, '-head')) ||
+        ((github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.14') || startsWith(inputs.rancher_version, 'v2.13'))) && !contains(inputs.rancher_version, '-alpha') &&
+        (github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.14') || startsWith(inputs.rancher_version, 'v2.13'))) && !contains(inputs.rancher_version, '-rc') &&
+        (github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.14') || startsWith(inputs.rancher_version, 'v2.13'))) && !contains(inputs.rancher_version, '-head'))
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
### Description
The `close-qase-run` conditional is incorrect. It needs to ensure that it matches the `create-qase-run` while ensuring `always()` is set. As of now, it will always run when an alpha, rc or non-released version is triggered, which is incorrect.