### PR TITLE
Update all code to use nodePools instead of counts

### DIFF
--- a/.github/workflows/airgap-test.yaml
+++ b/.github/workflows/airgap-test.yaml
@@ -223,10 +223,15 @@ jobs:
               assetsPath: "${{ secrets.ASSETS_PATH }}"
               registryName: "${{ secrets.REGISTRY_NAME }}"
           terratest:
-            etcdCount: 1
-            controlPlaneCount: 1
-            workerCount: 1
-            windowsNodeCount: 1
+            nodepools:
+              - quantity: 1
+                etcd: true
+              - quantity: 1
+                controlplane: true
+              - quantity: 1
+                worker: true
+              - quantity: 1
+                windows: true
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
           EOF
 
@@ -502,10 +507,15 @@ jobs:
               assetsPath: "${{ secrets.ASSETS_PATH }}"
               registryName: "${{ secrets.REGISTRY_NAME }}"
           terratest:
-            etcdCount: 1
-            controlPlaneCount: 1
-            workerCount: 1
-            windowsNodeCount: 1
+            nodepools:
+              - quantity: 1
+                etcd: true
+              - quantity: 1
+                controlplane: true
+              - quantity: 1
+                worker: true
+              - quantity: 1
+                windows: true
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
           EOF
 
@@ -793,10 +803,15 @@ jobs:
               assetsPath: "${{ secrets.ASSETS_PATH }}"
               registryName: "${{ secrets.REGISTRY_NAME }}"
           terratest:
-            etcdCount: 1
-            controlPlaneCount: 1
-            workerCount: 1
-            windowsNodeCount: 1
+            nodepools:
+              - quantity: 1
+                etcd: true
+              - quantity: 1
+                controlplane: true
+              - quantity: 1
+                worker: true
+              - quantity: 1
+                windows: true
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
           EOF
 

--- a/.github/workflows/airgap-upgrade-test.yaml
+++ b/.github/workflows/airgap-upgrade-test.yaml
@@ -228,10 +228,15 @@ jobs:
               registryName: "${{ secrets.REGISTRY_NAME }}"
               upgradedAssetsPath: "${{ secrets.UPGRADED_ASSETS_PATH }}"
           terratest:
-            etcdCount: 1
-            controlPlaneCount: 1
-            workerCount: 1
-            windowsNodeCount: 1
+            nodepools:
+              - quantity: 1
+                etcd: true
+              - quantity: 1
+                controlplane: true
+              - quantity: 1
+                worker: true
+              - quantity: 1
+                windows: true
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
           EOF
 
@@ -514,10 +519,15 @@ jobs:
               registryName: "${{ secrets.REGISTRY_NAME }}"
               upgradedAssetsPath: "${{ secrets.UPGRADED_ASSETS_PATH }}"
           terratest:
-            etcdCount: 1
-            controlPlaneCount: 1
-            workerCount: 1
-            windowsNodeCount: 1
+            nodepools:
+              - quantity: 1
+                etcd: true
+              - quantity: 1
+                controlplane: true
+              - quantity: 1
+                worker: true
+              - quantity: 1
+                windows: true
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
           EOF
 
@@ -814,10 +824,15 @@ jobs:
               registryName: "${{ secrets.REGISTRY_NAME }}"
               upgradedAssetsPath: "${{ secrets.UPGRADED_ASSETS_PATH }}"
           terratest:
-            etcdCount: 1
-            controlPlaneCount: 1
-            workerCount: 1
-            windowsNodeCount: 1
+            nodepools:
+              - quantity: 1
+                etcd: true
+              - quantity: 1
+                controlplane: true
+              - quantity: 1
+                worker: true
+              - quantity: 1
+                windows: true
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
           EOF
 

--- a/.github/workflows/community-prime-upgrade-test.yaml
+++ b/.github/workflows/community-prime-upgrade-test.yaml
@@ -207,10 +207,15 @@ jobs:
               upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            etcdCount: ${{ vars.ETCD_COUNT }}
-            controlPlaneCount: ${{ vars.CP_COUNT }}
-            workerCount: ${{ vars.WORKER_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            nodepools:
+              - quantity: ${{ vars.ETCD_COUNT }}
+                etcd: true
+              - quantity: ${{ vars.CP_COUNT }}
+                controlplane: true
+              - quantity: ${{ vars.WORKER_COUNT }}
+                worker: true
+              - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
+                windows: true
           EOF
 
       - name: Export CATTLE_TEST_CONFIG

--- a/.github/workflows/post-release-sanity-upgrade.yaml
+++ b/.github/workflows/post-release-sanity-upgrade.yaml
@@ -243,10 +243,15 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            etcdCount: ${{ vars.ETCD_COUNT }}
-            controlPlaneCount: ${{ vars.CP_COUNT }}
-            workerCount: ${{ vars.WORKER_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            nodepools:
+              - quantity: ${{ vars.ETCD_COUNT }}
+                etcd: true
+              - quantity: ${{ vars.CP_COUNT }}
+                controlplane: true
+              - quantity: ${{ vars.WORKER_COUNT }}
+                worker: true
+              - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
+                windows: true
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -516,10 +521,15 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            etcdCount: ${{ vars.ETCD_COUNT }}
-            controlPlaneCount: ${{ vars.CP_COUNT }}
-            workerCount: ${{ vars.WORKER_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            nodepools:
+              - quantity: ${{ vars.ETCD_COUNT }}
+                etcd: true
+              - quantity: ${{ vars.CP_COUNT }}
+                controlplane: true
+              - quantity: ${{ vars.WORKER_COUNT }}
+                worker: true
+              - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
+                windows: true
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -789,10 +799,15 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            etcdCount: ${{ vars.ETCD_COUNT }}
-            controlPlaneCount: ${{ vars.CP_COUNT }}
-            workerCount: ${{ vars.WORKER_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            nodepools:
+              - quantity: ${{ vars.ETCD_COUNT }}
+                etcd: true
+              - quantity: ${{ vars.CP_COUNT }}
+                controlplane: true
+              - quantity: ${{ vars.WORKER_COUNT }}
+                worker: true
+              - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
+                windows: true
           EOF
 
       - name: Export CATTLE_TEST_CONFIG

--- a/.github/workflows/post-release-sanity.yaml
+++ b/.github/workflows/post-release-sanity.yaml
@@ -229,10 +229,15 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_14 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            etcdCount: ${{ vars.ETCD_COUNT }}
-            controlPlaneCount: ${{ vars.CP_COUNT }}
-            workerCount: ${{ vars.WORKER_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            nodepools:
+              - quantity: ${{ vars.ETCD_COUNT }}
+                etcd: true
+              - quantity: ${{ vars.CP_COUNT }}
+                controlplane: true
+              - quantity: ${{ vars.WORKER_COUNT }}
+                worker: true
+              - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
+                windows: true
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -488,10 +493,15 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_14 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            etcdCount: ${{ vars.ETCD_COUNT }}
-            controlPlaneCount: ${{ vars.CP_COUNT }}
-            workerCount: ${{ vars.WORKER_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            nodepools:
+              - quantity: ${{ vars.ETCD_COUNT }}
+                etcd: true
+              - quantity: ${{ vars.CP_COUNT }}
+                controlplane: true
+              - quantity: ${{ vars.WORKER_COUNT }}
+                worker: true
+              - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
+                windows: true
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -747,10 +757,15 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_13 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            etcdCount: ${{ vars.ETCD_COUNT }}
-            controlPlaneCount: ${{ vars.CP_COUNT }}
-            workerCount: ${{ vars.WORKER_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            nodepools:
+              - quantity: ${{ vars.ETCD_COUNT }}
+                etcd: true
+              - quantity: ${{ vars.CP_COUNT }}
+                controlplane: true
+              - quantity: ${{ vars.WORKER_COUNT }}
+                worker: true
+              - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
+                windows: true
           EOF
 
       - name: Export CATTLE_TEST_CONFIG

--- a/.github/workflows/prime-community-upgrade-test.yaml
+++ b/.github/workflows/prime-community-upgrade-test.yaml
@@ -219,10 +219,15 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            etcdCount: ${{ vars.ETCD_COUNT }}
-            controlPlaneCount: ${{ vars.CP_COUNT }}
-            workerCount: ${{ vars.WORKER_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            nodepools:
+              - quantity: ${{ vars.ETCD_COUNT }}
+                etcd: true
+              - quantity: ${{ vars.CP_COUNT }}
+                controlplane: true
+              - quantity: ${{ vars.WORKER_COUNT }}
+                worker: true
+              - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
+                windows: true
           EOF
 
       - name: Export CATTLE_TEST_CONFIG

--- a/.github/workflows/proxy-test.yaml
+++ b/.github/workflows/proxy-test.yaml
@@ -238,10 +238,15 @@ jobs:
               registryUsername: "${{ secrets.REGISTRY_USERNAME }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            etcdCount: ${{ vars.ETCD_COUNT }}
-            controlPlaneCount: ${{ vars.CP_COUNT }}
-            workerCount: ${{ vars.WORKER_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            nodepools:
+              - quantity: ${{ vars.ETCD_COUNT }}
+                etcd: true
+              - quantity: ${{ vars.CP_COUNT }}
+                controlplane: true
+              - quantity: ${{ vars.WORKER_COUNT }}
+                worker: true
+              - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
+                windows: true
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -530,10 +535,15 @@ jobs:
               registryUsername: "${{ secrets.REGISTRY_USERNAME }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            etcdCount: ${{ vars.ETCD_COUNT }}
-            controlPlaneCount: ${{ vars.CP_COUNT }}
-            workerCount: ${{ vars.WORKER_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            nodepools:
+              - quantity: ${{ vars.ETCD_COUNT }}
+                etcd: true
+              - quantity: ${{ vars.CP_COUNT }}
+                controlplane: true
+              - quantity: ${{ vars.WORKER_COUNT }}
+                worker: true
+              - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
+                windows: true
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -824,10 +834,15 @@ jobs:
               registryUsername: "${{ secrets.REGISTRY_USERNAME }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            etcdCount: ${{ vars.ETCD_COUNT }}
-            controlPlaneCount: ${{ vars.CP_COUNT }}
-            workerCount: ${{ vars.WORKER_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            nodepools:
+              - quantity: ${{ vars.ETCD_COUNT }}
+                etcd: true
+              - quantity: ${{ vars.CP_COUNT }}
+                controlplane: true
+              - quantity: ${{ vars.WORKER_COUNT }}
+                worker: true
+              - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
+                windows: true
           EOF
 
       - name: Export CATTLE_TEST_CONFIG

--- a/.github/workflows/proxy-upgrade-test.yaml
+++ b/.github/workflows/proxy-upgrade-test.yaml
@@ -245,10 +245,15 @@ jobs:
               registryUsername: "${{ secrets.REGISTRY_USERNAME }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            etcdCount: ${{ vars.ETCD_COUNT }}
-            controlPlaneCount: ${{ vars.CP_COUNT }}
-            workerCount: ${{ vars.WORKER_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            nodepools:
+              - quantity: ${{ vars.ETCD_COUNT }}
+                etcd: true
+              - quantity: ${{ vars.CP_COUNT }}
+                controlplane: true
+              - quantity: ${{ vars.WORKER_COUNT }}
+                worker: true
+              - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
+                windows: true
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -544,10 +549,15 @@ jobs:
               registryUsername: "${{ secrets.REGISTRY_USERNAME }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            etcdCount: ${{ vars.ETCD_COUNT }}
-            controlPlaneCount: ${{ vars.CP_COUNT }}
-            workerCount: ${{ vars.WORKER_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            nodepools:
+              - quantity: ${{ vars.ETCD_COUNT }}
+                etcd: true
+              - quantity: ${{ vars.CP_COUNT }}
+                controlplane: true
+              - quantity: ${{ vars.WORKER_COUNT }}
+                worker: true
+              - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
+                windows: true
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -845,10 +855,15 @@ jobs:
               registryUsername: "${{ secrets.REGISTRY_USERNAME }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            etcdCount: ${{ vars.ETCD_COUNT }}
-            controlPlaneCount: ${{ vars.CP_COUNT }}
-            workerCount: ${{ vars.WORKER_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            nodepools:
+              - quantity: ${{ vars.ETCD_COUNT }}
+                etcd: true
+              - quantity: ${{ vars.CP_COUNT }}
+                controlplane: true
+              - quantity: ${{ vars.WORKER_COUNT }}
+                worker: true
+              - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
+                windows: true
           EOF
 
       - name: Export CATTLE_TEST_CONFIG

--- a/.github/workflows/rancher2-airgap-recurring-test.yaml
+++ b/.github/workflows/rancher2-airgap-recurring-test.yaml
@@ -214,10 +214,15 @@ jobs:
               assetsPath: "${{ secrets.ASSETS_PATH }}"
               registryName: "${{ secrets.REGISTRY_NAME }}"
           terratest:
-            etcdCount: 1
-            controlPlaneCount: 1
-            workerCount: 1
-            windowsNodeCount: 1
+            nodepools:
+              - quantity: 1
+                etcd: true
+              - quantity: 1
+                controlplane: true
+              - quantity: 1
+                worker: true
+              - quantity: 1
+                windows: true
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
           EOF
 
@@ -490,10 +495,15 @@ jobs:
               assetsPath: "${{ secrets.ASSETS_PATH }}"
               registryName: "${{ secrets.REGISTRY_NAME }}"
           terratest:
-            etcdCount: 1
-            controlPlaneCount: 1
-            workerCount: 1
-            windowsNodeCount: 1
+            nodepools:
+              - quantity: 1
+                etcd: true
+              - quantity: 1
+                controlplane: true
+              - quantity: 1
+                worker: true
+              - quantity: 1
+                windows: true
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
           EOF
 
@@ -778,10 +788,15 @@ jobs:
               assetsPath: "${{ secrets.ASSETS_PATH }}"
               registryName: "${{ secrets.REGISTRY_NAME }}"
           terratest:
-            etcdCount: 1
-            controlPlaneCount: 1
-            workerCount: 1
-            windowsNodeCount: 1
+            nodepools:
+              - quantity: 1
+                etcd: true
+              - quantity: 1
+                controlplane: true
+              - quantity: 1
+                worker: true
+              - quantity: 1
+                windows: true
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
           EOF
 

--- a/.github/workflows/rancher2-recurring-test.yaml
+++ b/.github/workflows/rancher2-recurring-test.yaml
@@ -231,10 +231,15 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            etcdCount: ${{ vars.ETCD_COUNT }}
-            controlPlaneCount: ${{ vars.CP_COUNT }}
-            workerCount: ${{ vars.WORKER_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            nodepools:
+              - quantity: ${{ vars.ETCD_COUNT }}
+                etcd: true
+              - quantity: ${{ vars.CP_COUNT }}
+                controlplane: true
+              - quantity: ${{ vars.WORKER_COUNT }}
+                worker: true
+              - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
+                windows: true
             snapshotInput: {}
             aksKubernetesVersion: "${{ vars.AKS_KUBERNETES_VERSION_2_15 }}"
             eksKubernetesVersion: "${{ vars.EKS_KUBERNETES_VERSION_2_15 }}"
@@ -535,10 +540,15 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_14 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            etcdCount: ${{ vars.ETCD_COUNT }}
-            controlPlaneCount: ${{ vars.CP_COUNT }}
-            workerCount: ${{ vars.WORKER_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            nodepools:
+              - quantity: ${{ vars.ETCD_COUNT }}
+                etcd: true
+              - quantity: ${{ vars.CP_COUNT }}
+                controlplane: true
+              - quantity: ${{ vars.WORKER_COUNT }}
+                worker: true
+              - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
+                windows: true
             snapshotInput: {}
             aksKubernetesVersion: "${{ vars.AKS_KUBERNETES_VERSION_2_14 }}"
             eksKubernetesVersion: "${{ vars.EKS_KUBERNETES_VERSION_2_14 }}"
@@ -832,10 +842,15 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_13 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            etcdCount: ${{ vars.ETCD_COUNT }}
-            controlPlaneCount: ${{ vars.CP_COUNT }}
-            workerCount: ${{ vars.WORKER_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            nodepools:
+              - quantity: ${{ vars.ETCD_COUNT }}
+                etcd: true
+              - quantity: ${{ vars.CP_COUNT }}
+                controlplane: true
+              - quantity: ${{ vars.WORKER_COUNT }}
+                worker: true
+              - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
+                windows: true
             snapshotInput: {}
             aksKubernetesVersion: "${{ vars.AKS_KUBERNETES_VERSION_2_13 }}"
             eksKubernetesVersion: "${{ vars.EKS_KUBERNETES_VERSION_2_13 }}"

--- a/.github/workflows/registry-test.yaml
+++ b/.github/workflows/registry-test.yaml
@@ -226,10 +226,15 @@ jobs:
               ecrURI: "${{ secrets.ECR_URI }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            etcdCount: ${{ vars.ETCD_COUNT }}
-            controlPlaneCount: ${{ vars.CP_COUNT }}
-            workerCount: ${{ vars.WORKER_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            nodepools:
+              - quantity: ${{ vars.ETCD_COUNT }}
+                etcd: true
+              - quantity: ${{ vars.CP_COUNT }}
+                controlplane: true
+              - quantity: ${{ vars.WORKER_COUNT }}
+                worker: true
+              - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
+                windows: true
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -507,10 +512,15 @@ jobs:
               ecrURI: "${{ secrets.ECR_URI }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            etcdCount: ${{ vars.ETCD_COUNT }}
-            controlPlaneCount: ${{ vars.CP_COUNT }}
-            workerCount: ${{ vars.WORKER_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            nodepools:
+              - quantity: ${{ vars.ETCD_COUNT }}
+                etcd: true
+              - quantity: ${{ vars.CP_COUNT }}
+                controlplane: true
+              - quantity: ${{ vars.WORKER_COUNT }}
+                worker: true
+              - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
+                windows: true
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -800,10 +810,15 @@ jobs:
               ecrURI: "${{ secrets.ECR_URI }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            etcdCount: ${{ vars.ETCD_COUNT }}
-            controlPlaneCount: ${{ vars.CP_COUNT }}
-            workerCount: ${{ vars.WORKER_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            nodepools:
+              - quantity: ${{ vars.ETCD_COUNT }}
+                etcd: true
+              - quantity: ${{ vars.CP_COUNT }}
+                controlplane: true
+              - quantity: ${{ vars.WORKER_COUNT }}
+                worker: true
+              - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
+                windows: true
           EOF
 
       - name: Export CATTLE_TEST_CONFIG

--- a/.github/workflows/sanity-arm64-test.yaml
+++ b/.github/workflows/sanity-arm64-test.yaml
@@ -222,10 +222,15 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            etcdCount: ${{ vars.ETCD_COUNT }}
-            controlPlaneCount: ${{ vars.CP_COUNT }}
-            workerCount: ${{ vars.WORKER_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            nodepools:
+              - quantity: ${{ vars.ETCD_COUNT }}
+                etcd: true
+              - quantity: ${{ vars.CP_COUNT }}
+                controlplane: true
+              - quantity: ${{ vars.WORKER_COUNT }}
+                worker: true
+              - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
+                windows: true
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -507,10 +512,15 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_14 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            etcdCount: ${{ vars.ETCD_COUNT }}
-            controlPlaneCount: ${{ vars.CP_COUNT }}
-            workerCount: ${{ vars.WORKER_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            nodepools:
+              - quantity: ${{ vars.ETCD_COUNT }}
+                etcd: true
+              - quantity: ${{ vars.CP_COUNT }}
+                controlplane: true
+              - quantity: ${{ vars.WORKER_COUNT }}
+                worker: true
+              - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
+                windows: true
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -794,10 +804,15 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_13 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            etcdCount: ${{ vars.ETCD_COUNT }}
-            controlPlaneCount: ${{ vars.CP_COUNT }}
-            workerCount: ${{ vars.WORKER_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            nodepools:
+              - quantity: ${{ vars.ETCD_COUNT }}
+                etcd: true
+              - quantity: ${{ vars.CP_COUNT }}
+                controlplane: true
+              - quantity: ${{ vars.WORKER_COUNT }}
+                worker: true
+              - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
+                windows: true
           EOF
 
       - name: Export CATTLE_TEST_CONFIG

--- a/.github/workflows/sanity-dualstack-upgrade-test.yaml
+++ b/.github/workflows/sanity-dualstack-upgrade-test.yaml
@@ -240,10 +240,15 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            etcdCount: ${{ vars.ETCD_COUNT }}
-            controlPlaneCount: ${{ vars.CP_COUNT }}
-            workerCount: ${{ vars.WORKER_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            nodepools:
+              - quantity: ${{ vars.ETCD_COUNT }}
+                etcd: true
+              - quantity: ${{ vars.CP_COUNT }}
+                controlplane: true
+              - quantity: ${{ vars.WORKER_COUNT }}
+                worker: true
+              - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
+                windows: true
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -534,10 +539,15 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            etcdCount: ${{ vars.ETCD_COUNT }}
-            controlPlaneCount: ${{ vars.CP_COUNT }}
-            workerCount: ${{ vars.WORKER_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            nodepools:
+              - quantity: ${{ vars.ETCD_COUNT }}
+                etcd: true
+              - quantity: ${{ vars.CP_COUNT }}
+                controlplane: true
+              - quantity: ${{ vars.WORKER_COUNT }}
+                worker: true
+              - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
+                windows: true
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -829,10 +839,15 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            etcdCount: ${{ vars.ETCD_COUNT }}
-            controlPlaneCount: ${{ vars.CP_COUNT }}
-            workerCount: ${{ vars.WORKER_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            nodepools:
+              - quantity: ${{ vars.ETCD_COUNT }}
+                etcd: true
+              - quantity: ${{ vars.CP_COUNT }}
+                controlplane: true
+              - quantity: ${{ vars.WORKER_COUNT }}
+                worker: true
+              - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
+                windows: true
           EOF
 
       - name: Export CATTLE_TEST_CONFIG

--- a/.github/workflows/sanity-ipv6-upgrade-test.yaml
+++ b/.github/workflows/sanity-ipv6-upgrade-test.yaml
@@ -240,10 +240,15 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            etcdCount: ${{ vars.ETCD_COUNT }}
-            controlPlaneCount: ${{ vars.CP_COUNT }}
-            workerCount: ${{ vars.WORKER_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            nodepools:
+              - quantity: ${{ vars.ETCD_COUNT }}
+                etcd: true
+              - quantity: ${{ vars.CP_COUNT }}
+                controlplane: true
+              - quantity: ${{ vars.WORKER_COUNT }}
+                worker: true
+              - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
+                windows: true
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -534,10 +539,15 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            etcdCount: ${{ vars.ETCD_COUNT }}
-            controlPlaneCount: ${{ vars.CP_COUNT }}
-            workerCount: ${{ vars.WORKER_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            nodepools:
+              - quantity: ${{ vars.ETCD_COUNT }}
+                etcd: true
+              - quantity: ${{ vars.CP_COUNT }}
+                controlplane: true
+              - quantity: ${{ vars.WORKER_COUNT }}
+                worker: true
+              - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
+                windows: true
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -829,10 +839,15 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            etcdCount: ${{ vars.ETCD_COUNT }}
-            controlPlaneCount: ${{ vars.CP_COUNT }}
-            workerCount: ${{ vars.WORKER_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            nodepools:
+              - quantity: ${{ vars.ETCD_COUNT }}
+                etcd: true
+              - quantity: ${{ vars.CP_COUNT }}
+                controlplane: true
+              - quantity: ${{ vars.WORKER_COUNT }}
+                worker: true
+              - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
+                windows: true
           EOF
 
       - name: Export CATTLE_TEST_CONFIG

--- a/.github/workflows/sanity-mixed-arch-test.yaml
+++ b/.github/workflows/sanity-mixed-arch-test.yaml
@@ -225,10 +225,15 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            etcdCount: ${{ vars.ETCD_COUNT }}
-            controlPlaneCount: ${{ vars.CP_COUNT }}
-            workerCount: ${{ vars.WORKER_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            nodepools:
+              - quantity: ${{ vars.ETCD_COUNT }}
+                etcd: true
+              - quantity: ${{ vars.CP_COUNT }}
+                controlplane: true
+              - quantity: ${{ vars.WORKER_COUNT }}
+                worker: true
+              - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
+                windows: true
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -513,10 +518,15 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_14 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            etcdCount: ${{ vars.ETCD_COUNT }}
-            controlPlaneCount: ${{ vars.CP_COUNT }}
-            workerCount: ${{ vars.WORKER_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            nodepools:
+              - quantity: ${{ vars.ETCD_COUNT }}
+                etcd: true
+              - quantity: ${{ vars.CP_COUNT }}
+                controlplane: true
+              - quantity: ${{ vars.WORKER_COUNT }}
+                worker: true
+              - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
+                windows: true
           EOF
 
       - name: Export CATTLE_TEST_CONFIG

--- a/.github/workflows/sanity-test.yaml
+++ b/.github/workflows/sanity-test.yaml
@@ -341,10 +341,15 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            etcdCount: ${{ vars.ETCD_COUNT }}
-            controlPlaneCount: ${{ vars.CP_COUNT }}
-            workerCount: ${{ vars.WORKER_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            nodepools:
+              - quantity: ${{ vars.ETCD_COUNT }}
+                etcd: true
+              - quantity: ${{ vars.CP_COUNT }}
+                controlplane: true
+              - quantity: ${{ vars.WORKER_COUNT }}
+                worker: true
+              - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
+                windows: true
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -727,10 +732,15 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_14 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            etcdCount: ${{ vars.ETCD_COUNT }}
-            controlPlaneCount: ${{ vars.CP_COUNT }}
-            workerCount: ${{ vars.WORKER_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            nodepools:
+              - quantity: ${{ vars.ETCD_COUNT }}
+                etcd: true
+              - quantity: ${{ vars.CP_COUNT }}
+                controlplane: true
+              - quantity: ${{ vars.WORKER_COUNT }}
+                worker: true
+              - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
+                windows: true
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -1115,10 +1125,15 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_13 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            etcdCount: ${{ vars.ETCD_COUNT }}
-            controlPlaneCount: ${{ vars.CP_COUNT }}
-            workerCount: ${{ vars.WORKER_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            nodepools:
+              - quantity: ${{ vars.ETCD_COUNT }}
+                etcd: true
+              - quantity: ${{ vars.CP_COUNT }}
+                controlplane: true
+              - quantity: ${{ vars.WORKER_COUNT }}
+                worker: true
+              - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
+                windows: true
           EOF
 
       - name: Export CATTLE_TEST_CONFIG

--- a/.github/workflows/sanity-turtles-off-test.yaml
+++ b/.github/workflows/sanity-turtles-off-test.yaml
@@ -238,10 +238,15 @@ jobs:
                 turtles: "false"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            etcdCount: ${{ vars.ETCD_COUNT }}
-            controlPlaneCount: ${{ vars.CP_COUNT }}
-            workerCount: ${{ vars.WORKER_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            nodepools:
+              - quantity: ${{ vars.ETCD_COUNT }}
+                etcd: true
+              - quantity: ${{ vars.CP_COUNT }}
+                controlplane: true
+              - quantity: ${{ vars.WORKER_COUNT }}
+                worker: true
+              - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
+                windows: true
           EOF
 
       - name: Export CATTLE_TEST_CONFIG

--- a/.github/workflows/sanity-upgrade-arm64-test.yaml
+++ b/.github/workflows/sanity-upgrade-arm64-test.yaml
@@ -229,10 +229,15 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            etcdCount: ${{ vars.ETCD_COUNT }}
-            controlPlaneCount: ${{ vars.CP_COUNT }}
-            workerCount: ${{ vars.WORKER_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            nodepools:
+              - quantity: ${{ vars.ETCD_COUNT }}
+                etcd: true
+              - quantity: ${{ vars.CP_COUNT }}
+                controlplane: true
+              - quantity: ${{ vars.WORKER_COUNT }}
+                worker: true
+              - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
+                windows: true
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -521,10 +526,15 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            etcdCount: ${{ vars.ETCD_COUNT }}
-            controlPlaneCount: ${{ vars.CP_COUNT }}
-            workerCount: ${{ vars.WORKER_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            nodepools:
+              - quantity: ${{ vars.ETCD_COUNT }}
+                etcd: true
+              - quantity: ${{ vars.CP_COUNT }}
+                controlplane: true
+              - quantity: ${{ vars.WORKER_COUNT }}
+                worker: true
+              - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
+                windows: true
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -815,10 +825,15 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            etcdCount: ${{ vars.ETCD_COUNT }}
-            controlPlaneCount: ${{ vars.CP_COUNT }}
-            workerCount: ${{ vars.WORKER_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            nodepools:
+              - quantity: ${{ vars.ETCD_COUNT }}
+                etcd: true
+              - quantity: ${{ vars.CP_COUNT }}
+                controlplane: true
+              - quantity: ${{ vars.WORKER_COUNT }}
+                worker: true
+              - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
+                windows: true
           EOF
 
       - name: Export CATTLE_TEST_CONFIG

--- a/.github/workflows/sanity-upgrade-test.yaml
+++ b/.github/workflows/sanity-upgrade-test.yaml
@@ -348,10 +348,15 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            etcdCount: ${{ vars.ETCD_COUNT }}
-            controlPlaneCount: ${{ vars.CP_COUNT }}
-            workerCount: ${{ vars.WORKER_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            nodepools:
+              - quantity: ${{ vars.ETCD_COUNT }}
+                etcd: true
+              - quantity: ${{ vars.CP_COUNT }}
+                controlplane: true
+              - quantity: ${{ vars.WORKER_COUNT }}
+                worker: true
+              - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
+                windows: true
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -740,10 +745,15 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            etcdCount: ${{ vars.ETCD_COUNT }}
-            controlPlaneCount: ${{ vars.CP_COUNT }}
-            workerCount: ${{ vars.WORKER_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            nodepools:
+              - quantity: ${{ vars.ETCD_COUNT }}
+                etcd: true
+              - quantity: ${{ vars.CP_COUNT }}
+                controlplane: true
+              - quantity: ${{ vars.WORKER_COUNT }}
+                worker: true
+              - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
+                windows: true
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -1135,10 +1145,15 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            etcdCount: ${{ vars.ETCD_COUNT }}
-            controlPlaneCount: ${{ vars.CP_COUNT }}
-            workerCount: ${{ vars.WORKER_COUNT }}
-            windowsNodeCount: ${{ vars.WINDOWS_NODE_COUNT }}
+            nodepools:
+              - quantity: ${{ vars.ETCD_COUNT }}
+                etcd: true
+              - quantity: ${{ vars.CP_COUNT }}
+                controlplane: true
+              - quantity: ${{ vars.WORKER_COUNT }}
+                worker: true
+              - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
+                windows: true
           EOF
 
       - name: Export CATTLE_TEST_CONFIG

--- a/README.md
+++ b/README.md
@@ -654,7 +654,6 @@ terratest:
   eksKubernetesVersion: ""
   gkeKubernetesVersion: ""
   kubernetesVersion: ""
-  nodeCount: 3
 
   # Below are the expected formats for all module kubernetes versions
   

--- a/config/config.go
+++ b/config/config.go
@@ -63,6 +63,14 @@ var WorkerNodePool = Nodepool{
 	Quantity:     3,
 }
 
+var WindowsNodePool = Nodepool{
+	Etcd:         false,
+	Controlplane: false,
+	Worker:       false,
+	Windows:      true,
+	Quantity:     1,
+}
+
 var AllRolesNodePool = Nodepool{
 	Etcd:         true,
 	Controlplane: true,
@@ -91,6 +99,7 @@ type Nodepool struct {
 	Quantity          int64  `json:"quantity,omitempty" yaml:"quantity,omitempty"`
 	Etcd              bool   `json:"etcd,omitempty" yaml:"etcd,omitempty"`
 	Controlplane      bool   `json:"controlplane,omitempty" yaml:"controlplane,omitempty"`
+	Windows           bool   `json:"windows,omitempty" yaml:"windows,omitempty"`
 	DiskSize          int64  `json:"diskSize,omitempty" yaml:"diskSize,omitempty"`
 	Worker            bool   `json:"worker,omitempty" yaml:"worker,omitempty"`
 	InstanceType      string `json:"instanceType,omitempty" yaml:"instanceType,omitempty"`
@@ -222,16 +231,12 @@ type TerratestConfig struct {
 	GKEKubernetesVersion string     `json:"gkeKubernetesVersion,omitempty" yaml:"gkeKubernetesVersion,omitempty"`
 	KubernetesVersion    string     `json:"kubernetesVersion,omitempty" yaml:"kubernetesVersion,omitempty"`
 	LocalQaseReporting   bool       `json:"localQaseReporting,omitempty" yaml:"localQaseReporting,omitempty" default:"false"`
-	EtcdCount            int64      `json:"etcdCount,omitempty" yaml:"etcdCount,omitempty"`
-	ControlPlaneCount    int64      `json:"controlPlaneCount,omitempty" yaml:"controlPlaneCount,omitempty"`
-	WorkerCount          int64      `json:"workerCount,omitempty" yaml:"workerCount,omitempty"`
 	Nodepools            []Nodepool `json:"nodepools,omitempty" yaml:"nodepools,omitempty"`
 	PathToRepo           string     `json:"pathToRepo,omitempty" yaml:"pathToRepo,omitempty"`
 	PSACT                string     `json:"psact,omitempty" yaml:"psact,omitempty"`
 	SnapshotInput        Snapshots  `json:"snapshotInput,omitempty" yaml:"snapshotInput,omitempty"`
 	StandaloneLogging    bool       `json:"standaloneLogging,omitempty" yaml:"standaloneLogging,omitempty"`
 	TFLogging            bool       `json:"tfLogging,omitempty" yaml:"tfLogging,omitempty"`
-	WindowsNodeCount     int64      `json:"windowsNodeCount,omitempty" yaml:"windowsNodeCount,omitempty"`
 }
 
 // LoadTFPConfigs loads the TFP configurations from the provided map

--- a/config/provisioning.yaml
+++ b/config/provisioning.yaml
@@ -59,6 +59,6 @@ terratest:
       etcd: false
       controlplane: false
       worker: true
-  nodeCount: 3
+    - quantity: 1
+      windows: true
   kubernetesVersion: ""
-  windowsNodeCount: 1

--- a/framework/set/provisioning/custom/locals/setLocals.go
+++ b/framework/set/provisioning/custom/locals/setLocals.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rancher/tfp-automation/framework/set/defaults/providers/aws"
 	"github.com/rancher/tfp-automation/framework/set/defaults/rancher2"
 	"github.com/rancher/tfp-automation/framework/set/defaults/rancher2/clusters"
+	customnodepools "github.com/rancher/tfp-automation/framework/set/provisioning/custom/nodepools"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -29,42 +30,32 @@ func SetLocals(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
 
 	if strings.Contains(terraformConfig.Module, general.Custom) {
 		if terraformConfig.DownstreamClusterProvider == aws.Aws {
-			expression := fmt.Sprintf(`concat(`+aws.AwsInstance+`.%s-etcd.*.public_ip, `+
-				aws.AwsInstance+`.%s-control-plane.*.public_ip, `+
-				aws.AwsInstance+`.%s-worker.*.public_ip)`, terraformConfig.ResourcePrefix, terraformConfig.ResourcePrefix, terraformConfig.ResourcePrefix)
+			expression, err := customnodepools.BuildAWSPublicIPExpression(terraformConfig, terratestConfig)
+			if err != nil {
+				return nil, err
+			}
+
 			value := hclwrite.Tokens{
 				{Type: hclsyntax.TokenIdent, Bytes: []byte(expression)},
 			}
 
 			localsBlockBody.SetAttributeRaw(allPublicIPs, value)
 		}
-
-		expression := fmt.Sprintf(`concat([for i in range(%d) : "--etcd"], [for i in range(%d) : "--controlplane"], [for i in range(%d) : "--worker"])`,
-			terratestConfig.EtcdCount, terratestConfig.ControlPlaneCount, terratestConfig.WorkerCount)
-		value := hclwrite.Tokens{
-			{Type: hclsyntax.TokenIdent, Bytes: []byte(expression)},
-		}
-
-		localsBlockBody.SetAttributeRaw(clusters.RoleFlags, value)
-	} else {
-		var roleFlags []cty.Value
-
-		for range terratestConfig.EtcdCount {
-			roleFlags = append(roleFlags, cty.StringVal(clusters.EtcdRoleFlag))
-		}
-
-		for range terratestConfig.ControlPlaneCount {
-			roleFlags = append(roleFlags, cty.StringVal(clusters.ControlPlaneRoleFlag))
-		}
-
-		for range terratestConfig.WorkerCount {
-			roleFlags = append(roleFlags, cty.StringVal(clusters.WorkerRoleFlag))
-		}
-
-		localsBlockBody.SetAttributeValue(clusters.RoleFlags, cty.ListVal(roleFlags))
 	}
 
-	totalNodeCount := terratestConfig.EtcdCount + terratestConfig.ControlPlaneCount + terratestConfig.WorkerCount
+	roleFlags, err := customnodepools.BuildRoleFlags(terraformConfig, terratestConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	roleFlagValues := make([]cty.Value, 0, len(roleFlags))
+	for _, roleFlag := range roleFlags {
+		roleFlagValues = append(roleFlagValues, cty.StringVal(roleFlag))
+	}
+
+	localsBlockBody.SetAttributeValue(clusters.RoleFlags, cty.ListVal(roleFlagValues))
+
+	totalNodeCount := customnodepools.TotalNodeCount(terratestConfig)
 	resourcePrefixExpression := fmt.Sprintf(`[for i in range(%d) : "%s-${i}"]`, totalNodeCount, terraformConfig.ResourcePrefix)
 	resourcePrefixValue := hclwrite.Tokens{
 		{Type: hclsyntax.TokenIdent, Bytes: []byte(resourcePrefixExpression)},

--- a/framework/set/provisioning/custom/nodepools/customNodepools.go
+++ b/framework/set/provisioning/custom/nodepools/customNodepools.go
@@ -1,0 +1,137 @@
+package nodepools
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/framework/set/defaults/providers/aws"
+	"github.com/rancher/tfp-automation/framework/set/defaults/rancher2/clusters"
+	rancher2resources "github.com/rancher/tfp-automation/framework/set/resources/rancher2"
+)
+
+type AWSInstanceGroup struct {
+	ResourceName string
+	AMI          string
+	InstanceType string
+	Quantity     int64
+}
+
+// TotalNodeCount returns the number of non-Windows nodes across all configured nodepools.
+func TotalNodeCount(terratestConfig *config.TerratestConfig) int64 {
+	var totalNodeCount int64
+
+	for _, pool := range terratestConfig.Nodepools {
+		if pool.Windows {
+			continue
+		}
+
+		totalNodeCount += pool.Quantity
+	}
+
+	return totalNodeCount
+}
+
+// WindowsNodeCount returns the total number of Windows nodes across all configured nodepools.
+func WindowsNodeCount(terratestConfig *config.TerratestConfig) int64 {
+	var totalNodeCount int64
+
+	for _, pool := range terratestConfig.Nodepools {
+		if !pool.Windows {
+			continue
+		}
+
+		totalNodeCount += pool.Quantity
+	}
+
+	return totalNodeCount
+}
+
+// BuildRoleFlags expands nodepool role flags into one entry per non-Windows node.
+func BuildRoleFlags(terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig) ([]string, error) {
+	roleFlags := make([]string, 0, TotalNodeCount(terratestConfig))
+
+	for count, pool := range terratestConfig.Nodepools {
+		if pool.Windows {
+			continue
+		}
+
+		_, err := rancher2resources.SetResourceNodepoolValidation(terraformConfig, pool, strconv.Itoa(count))
+		if err != nil {
+			return nil, err
+		}
+
+		poolRoleFlags := buildPoolRoleFlags(pool)
+		for i := int64(0); i < pool.Quantity; i++ {
+			roleFlags = append(roleFlags, poolRoleFlags)
+		}
+	}
+
+	return roleFlags, nil
+}
+
+// BuildAWSInstanceGroups converts non-Windows nodepools into AWS instance group definitions.
+func BuildAWSInstanceGroups(terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig) ([]AWSInstanceGroup, error) {
+	instanceGroups := make([]AWSInstanceGroup, 0, len(terratestConfig.Nodepools))
+
+	for count, pool := range terratestConfig.Nodepools {
+		if pool.Windows {
+			continue
+		}
+
+		_, err := rancher2resources.SetResourceNodepoolValidation(terraformConfig, pool, strconv.Itoa(count))
+		if err != nil {
+			return nil, err
+		}
+
+		ami := terraformConfig.AWSConfig.AMI
+		instanceType := terraformConfig.AWSConfig.AWSInstanceType
+		if pool.Worker && terraformConfig.MixedArchitecture {
+			ami = terraformConfig.AWSConfig.ARMAMI
+			instanceType = terraformConfig.AWSConfig.ARMInstanceType
+		}
+
+		instanceGroups = append(instanceGroups, AWSInstanceGroup{
+			ResourceName: fmt.Sprintf("%s-pool-%d", terraformConfig.ResourcePrefix, count),
+			AMI:          ami,
+			InstanceType: instanceType,
+			Quantity:     pool.Quantity,
+		})
+	}
+
+	return instanceGroups, nil
+}
+
+// BuildAWSPublicIPExpression builds the Terraform expression for all AWS instance public IPs.
+func BuildAWSPublicIPExpression(terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig) (string, error) {
+	instanceGroups, err := BuildAWSInstanceGroups(terraformConfig, terratestConfig)
+	if err != nil {
+		return "", err
+	}
+
+	groupExpressions := make([]string, 0, len(instanceGroups))
+	for _, group := range instanceGroups {
+		groupExpressions = append(groupExpressions, fmt.Sprintf("%s.%s.*.public_ip", aws.AwsInstance, group.ResourceName))
+	}
+
+	return fmt.Sprintf("flatten([%s])", strings.Join(groupExpressions, ", ")), nil
+}
+
+func buildPoolRoleFlags(pool config.Nodepool) string {
+	roleFlags := make([]string, 0, 3)
+
+	if pool.Etcd {
+		roleFlags = append(roleFlags, clusters.EtcdRoleFlag)
+	}
+
+	if pool.Controlplane {
+		roleFlags = append(roleFlags, clusters.ControlPlaneRoleFlag)
+	}
+
+	if pool.Worker {
+		roleFlags = append(roleFlags, clusters.WorkerRoleFlag)
+	}
+
+	return strings.Join(roleFlags, " ")
+}

--- a/framework/set/provisioning/custom/setConfig.go
+++ b/framework/set/provisioning/custom/setConfig.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rancher/tfp-automation/framework/set/defaults/general"
 	awsDefaults "github.com/rancher/tfp-automation/framework/set/defaults/providers/aws"
 	vsphereDefaults "github.com/rancher/tfp-automation/framework/set/defaults/providers/vsphere"
+	customnodepools "github.com/rancher/tfp-automation/framework/set/provisioning/custom/nodepools"
 	"github.com/rancher/tfp-automation/framework/set/provisioning/custom/nullresource"
 	"github.com/rancher/tfp-automation/framework/set/resources/providers/aws"
 	"github.com/rancher/tfp-automation/framework/set/resources/providers/vsphere"
@@ -22,18 +23,14 @@ func SetCustomRKE2K3s(terraformConfig *config.TerraformConfig, terratestConfig *
 	newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File) (*hclwrite.File, *os.File, error) {
 	switch terraformConfig.Provider {
 	case awsDefaults.Aws:
-		aws.CreateCustomClusterAWSInstances(rootBody, terraformConfig, terratestConfig, terraformConfig.ResourcePrefix+"-etcd",
-			terraformConfig.AWSConfig.AMI, terraformConfig.AWSConfig.AWSInstanceType, terratestConfig.EtcdCount)
+		instanceGroups, err := customnodepools.BuildAWSInstanceGroups(terraformConfig, terratestConfig)
+		if err != nil {
+			return nil, nil, err
+		}
 
-		aws.CreateCustomClusterAWSInstances(rootBody, terraformConfig, terratestConfig, terraformConfig.ResourcePrefix+"-control-plane",
-			terraformConfig.AWSConfig.AMI, terraformConfig.AWSConfig.AWSInstanceType, terratestConfig.ControlPlaneCount)
-
-		if terraformConfig.MixedArchitecture {
-			aws.CreateCustomClusterAWSInstances(rootBody, terraformConfig, terratestConfig, terraformConfig.ResourcePrefix+"-worker",
-				terraformConfig.AWSConfig.ARMAMI, terraformConfig.AWSConfig.ARMInstanceType, terratestConfig.WorkerCount)
-		} else {
-			aws.CreateCustomClusterAWSInstances(rootBody, terraformConfig, terratestConfig, terraformConfig.ResourcePrefix+"-worker",
-				terraformConfig.AWSConfig.AMI, terraformConfig.AWSConfig.AWSInstanceType, terratestConfig.WorkerCount)
+		for _, instanceGroup := range instanceGroups {
+			aws.CreateCustomClusterAWSInstances(rootBody, terraformConfig, terratestConfig, instanceGroup.ResourceName,
+				instanceGroup.AMI, instanceGroup.InstanceType, instanceGroup.Quantity)
 		}
 	case vsphereDefaults.Vsphere:
 		dataCenterExpression := fmt.Sprintf(general.Data + `.` + vsphereDefaults.VsphereDatacenter + `.` + vsphereDefaults.VsphereDatacenter + `.id`)

--- a/framework/set/provisioning/imported/nullresource/importWindowsNullResource.go
+++ b/framework/set/provisioning/imported/nullresource/importWindowsNullResource.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rancher/tfp-automation/defaults/modules"
 	"github.com/rancher/tfp-automation/framework/set/defaults/general"
 	"github.com/rancher/tfp-automation/framework/set/defaults/providers/aws"
+	customnodepools "github.com/rancher/tfp-automation/framework/set/provisioning/custom/nodepools"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -25,10 +26,11 @@ func CreateImportedWindowsNullResource(rootBody *hclwrite.Body, terraformConfig 
 	connectionBlockBody := connectionBlock.Body()
 
 	var hostExpression string
+	windowsCount := customnodepools.WindowsNodeCount(terratestConfig)
 
-	if terratestConfig.WindowsNodeCount == 1 {
+	if windowsCount == 1 {
 		hostExpression = `"${` + aws.AwsInstance + `.` + terraformConfig.ResourcePrefix + `-windows[0].` + general.PublicIp + `}"`
-	} else if terratestConfig.WindowsNodeCount > 1 {
+	} else if windowsCount > 1 {
 		hostExpression = `"${` + aws.AwsInstance + `.` + terraformConfig.ResourcePrefix + `-windows[` + general.Count + `.` + general.Index + `].` + general.PublicIp + `}"`
 	}
 

--- a/framework/set/provisioning/nodedriver/setConfig.go
+++ b/framework/set/provisioning/nodedriver/setConfig.go
@@ -170,6 +170,10 @@ func SetRKE2K3s(terraformConfig *config.TerraformConfig, terratestConfig *config
 	}
 
 	for count, pool := range terratestConfig.Nodepools {
+		if pool.Windows {
+			continue
+		}
+
 		err = setMachinePool(terraformConfig, count, pool, rkeConfigBlockBody, mixedArchitecture)
 		if err != nil {
 			return nil, nil, err

--- a/framework/set/resources/providers/aws/windowsInstances.go
+++ b/framework/set/resources/providers/aws/windowsInstances.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rancher/tfp-automation/framework/format"
 	"github.com/rancher/tfp-automation/framework/set/defaults/general"
 	"github.com/rancher/tfp-automation/framework/set/defaults/providers/aws"
+	customnodepools "github.com/rancher/tfp-automation/framework/set/provisioning/custom/nodepools"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -34,7 +35,7 @@ func CreateWindowsAWSInstances(rootBody *hclwrite.Body, terraformConfig *config.
 	configBlock := rootBody.AppendNewBlock(general.Resource, []string{aws.AwsInstance, hostnamePrefix + "-windows"})
 	configBlockBody := configBlock.Body()
 
-	configBlockBody.SetAttributeValue(general.Count, cty.NumberIntVal(terratestConfig.WindowsNodeCount))
+	configBlockBody.SetAttributeValue(general.Count, cty.NumberIntVal(customnodepools.WindowsNodeCount(terratestConfig)))
 
 	if strings.Contains(terraformConfig.Module, clustertypes.WINDOWS) && strings.Contains(terraformConfig.Module, "2019") {
 		configBlockBody.SetAttributeValue(aws.Ami, cty.StringVal(terraformConfig.AWSConfig.Windows2019AMI))

--- a/framework/set/resources/providers/google/instances.go
+++ b/framework/set/resources/providers/google/instances.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/framework/set/defaults/general"
 	googleDefaults "github.com/rancher/tfp-automation/framework/set/defaults/providers/google"
+	customnodepools "github.com/rancher/tfp-automation/framework/set/provisioning/custom/nodepools"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -19,7 +20,7 @@ func CreateGoogleCloudInstances(rootBody *hclwrite.Body, terraformConfig *config
 	configBlockBody := configBlock.Body()
 
 	if strings.Contains(terraformConfig.Module, general.Custom) {
-		totalNodeCount := terratestConfig.EtcdCount + terratestConfig.ControlPlaneCount + terratestConfig.WorkerCount
+		totalNodeCount := customnodepools.TotalNodeCount(terratestConfig)
 		configBlockBody.SetAttributeValue(general.Count, cty.NumberIntVal(totalNodeCount))
 	}
 

--- a/framework/set/resources/providers/harvester/instances.go
+++ b/framework/set/resources/providers/harvester/instances.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/framework/set/defaults/general"
 	"github.com/rancher/tfp-automation/framework/set/defaults/providers/harvester"
+	customnodepools "github.com/rancher/tfp-automation/framework/set/provisioning/custom/nodepools"
 	"github.com/zclconf/go-cty/cty"
 	"golang.org/x/crypto/ssh"
 )
@@ -74,7 +75,7 @@ func CreateHarvesterInstances(rootBody *hclwrite.Body, terraformConfig *config.T
 	configBlockBody := configBlock.Body()
 
 	if strings.Contains(terraformConfig.Module, general.Custom) {
-		totalNodeCount := terratestConfig.EtcdCount + terratestConfig.ControlPlaneCount + terratestConfig.WorkerCount
+		totalNodeCount := customnodepools.TotalNodeCount(terratestConfig)
 		configBlockBody.SetAttributeValue(general.Count, cty.NumberIntVal(totalNodeCount))
 	}
 

--- a/framework/set/resources/providers/linode/instances.go
+++ b/framework/set/resources/providers/linode/instances.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rancher/tfp-automation/framework/format"
 	"github.com/rancher/tfp-automation/framework/set/defaults/general"
 	linodeDefaults "github.com/rancher/tfp-automation/framework/set/defaults/providers/linode"
+	customnodepools "github.com/rancher/tfp-automation/framework/set/provisioning/custom/nodepools"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -20,7 +21,7 @@ func CreateLinodeInstances(rootBody *hclwrite.Body, terraformConfig *config.Terr
 	configBlockBody := configBlock.Body()
 
 	if strings.Contains(terraformConfig.Module, general.Custom) {
-		totalNodeCount := terratestConfig.EtcdCount + terratestConfig.ControlPlaneCount + terratestConfig.WorkerCount
+		totalNodeCount := customnodepools.TotalNodeCount(terratestConfig)
 		configBlockBody.SetAttributeValue(general.Count, cty.NumberIntVal(totalNodeCount))
 	}
 

--- a/framework/set/resources/providers/vsphere/virtualMachine.go
+++ b/framework/set/resources/providers/vsphere/virtualMachine.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/framework/set/defaults/general"
 	"github.com/rancher/tfp-automation/framework/set/defaults/providers/vsphere"
+	customnodepools "github.com/rancher/tfp-automation/framework/set/provisioning/custom/nodepools"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -20,7 +21,7 @@ func CreateVsphereVirtualMachine(rootBody *hclwrite.Body, terraformConfig *confi
 	vmBlockBody := vmBlock.Body()
 
 	if strings.Contains(terraformConfig.Module, general.Custom) {
-		totalNodeCount := terratestConfig.EtcdCount + terratestConfig.ControlPlaneCount + terratestConfig.WorkerCount
+		totalNodeCount := customnodepools.TotalNodeCount(terratestConfig)
 		vmBlockBody.SetAttributeValue(general.Count, cty.NumberIntVal(totalNodeCount))
 
 		vmNameExpression := fmt.Sprintf(` "%s-${%s.%s}"`, hostnamePrefix, general.Count, general.Index)

--- a/tests/proxy/README.md
+++ b/tests/proxy/README.md
@@ -116,10 +116,21 @@ terraform:
 # TERRATEST CONFIG
 #######################
 terratest:  
-  etcdCount: 3
-  controlPlaneCount: 2
-  workerCount: 3
-  windowsNodeCount: 1
+  nodepools:
+    - quantity: 3
+      etcd: true
+      controlplane: false
+      worker: false
+    - quantity: 2
+      etcd: false
+      controlplane: true
+      worker: false
+    - quantity: 3
+      etcd: false
+      controlplane: false
+      worker: true
+    - quantity: 1
+      windows: true
   pathToRepo: "go/src/github.com/rancher/tfp-automation"
 ```
 

--- a/tests/proxy/proxy_provisioning_test.go
+++ b/tests/proxy/proxy_provisioning_test.go
@@ -65,6 +65,7 @@ func (p *TfpProxyProvisioningTestSuite) TestTfpNoProxyProvisioning() {
 	var clusterIDs []string
 
 	nodeRolesDedicated := []config.Nodepool{config.EtcdNodePool, config.ControlPlaneNodePool, config.WorkerNodePool}
+	nodeRolesWindows := []config.Nodepool{config.EtcdNodePool, config.ControlPlaneNodePool, config.WorkerNodePool, config.WindowsNodePool}
 
 	tests := []struct {
 		name      string
@@ -72,8 +73,8 @@ func (p *TfpProxyProvisioningTestSuite) TestTfpNoProxyProvisioning() {
 		module    string
 	}{
 		{"No_Proxy_RKE2", nodeRolesDedicated, modules.NodeDriverAWSRKE2},
-		{"No_Proxy_RKE2_Windows_2019", nil, modules.CustomAWSRKE2Windows2019},
-		{"No_Proxy_RKE2_Windows_2022", nil, modules.CustomAWSRKE2Windows2022},
+		{"No_Proxy_RKE2_Windows_2019", nodeRolesWindows, modules.CustomAWSRKE2Windows2019},
+		{"No_Proxy_RKE2_Windows_2022", nodeRolesWindows, modules.CustomAWSRKE2Windows2022},
 		{"No_Proxy_K3S", nodeRolesDedicated, modules.NodeDriverAWSK3S},
 	}
 
@@ -171,6 +172,7 @@ func (p *TfpProxyProvisioningTestSuite) TestTfpProxyProvisioning() {
 	standardToken := standardUserToken.Token
 
 	nodeRolesDedicated := []config.Nodepool{config.EtcdNodePool, config.ControlPlaneNodePool, config.WorkerNodePool}
+	nodeRolesWindows := []config.Nodepool{config.EtcdNodePool, config.ControlPlaneNodePool, config.WorkerNodePool, config.WindowsNodePool}
 
 	tests := []struct {
 		name      string
@@ -178,8 +180,8 @@ func (p *TfpProxyProvisioningTestSuite) TestTfpProxyProvisioning() {
 		module    string
 	}{
 		{"Proxy_Provisioning_RKE2", nodeRolesDedicated, modules.NodeDriverAWSRKE2},
-		{"Proxy_Provisioning_RKE2_Windows_2019", nil, modules.CustomAWSRKE2Windows2019},
-		{"Proxy_Provisioning_RKE2_Windows_2022", nil, modules.CustomAWSRKE2Windows2022},
+		{"Proxy_Provisioning_RKE2_Windows_2019", nodeRolesWindows, modules.CustomAWSRKE2Windows2019},
+		{"Proxy_Provisioning_RKE2_Windows_2022", nodeRolesWindows, modules.CustomAWSRKE2Windows2022},
 		{"Proxy_Provisioning_K3S", nodeRolesDedicated, modules.NodeDriverAWSK3S},
 	}
 

--- a/tests/proxy/proxy_upgrade_rancher_test.go
+++ b/tests/proxy/proxy_upgrade_rancher_test.go
@@ -93,6 +93,7 @@ func (p *TfpProxyUpgradeRancherTestSuite) provisionAndVerifyCluster(name string,
 
 	customClusterNames := []string{}
 	nodeRolesDedicated := []config.Nodepool{config.EtcdNodePool, config.ControlPlaneNodePool, config.WorkerNodePool}
+	nodeRolesWindows := []config.Nodepool{config.EtcdNodePool, config.ControlPlaneNodePool, config.WorkerNodePool, config.WindowsNodePool}
 
 	tests := []struct {
 		name      string
@@ -100,8 +101,8 @@ func (p *TfpProxyUpgradeRancherTestSuite) provisionAndVerifyCluster(name string,
 		module    string
 	}{
 		{name + "_RKE2", nodeRolesDedicated, modules.NodeDriverAWSRKE2},
-		{name + "_RKE2_Windows_2019", nil, modules.CustomAWSRKE2Windows2019},
-		{name + "_RKE2_Windows_2022", nil, modules.CustomAWSRKE2Windows2022},
+		{name + "_RKE2_Windows_2019", nodeRolesWindows, modules.CustomAWSRKE2Windows2019},
+		{name + "_RKE2_Windows_2022", nodeRolesWindows, modules.CustomAWSRKE2Windows2022},
 		{name + "_K3S", nodeRolesDedicated, modules.NodeDriverAWSK3S},
 	}
 

--- a/tests/rancher2/airgap/README.md
+++ b/tests/rancher2/airgap/README.md
@@ -75,10 +75,21 @@ terraform:
     sshTimeout: "5m"
 
 terratest:
-  etcdCount: 1
-  controlPlaneCount: 1
-  workerCount: 1
-  windowsNodeCount: 1
+  nodepools:
+    - quantity: 1
+      etcd: true
+      controlplane: false
+      worker: false
+    - quantity: 1
+      etcd: false
+      controlplane: true
+      worker: false
+    - quantity: 1
+      etcd: false
+      controlplane: false
+      worker: true
+    - quantity: 1
+      windows: true
 ```
 
 See the below examples on how to run the tests:

--- a/tests/rancher2/os/README.md
+++ b/tests/rancher2/os/README.md
@@ -53,22 +53,19 @@ terraform:
 ```yaml
 terratest:
   nodepools:
-    - quantity: 1
+    - quantity: 3
       etcd: true
       controlplane: false
       worker: false
-    - quantity: 1
+    - quantity: 2
       etcd: false
       controlplane: true
       worker: false
-    - quantity: 1
+    - quantity: 3
       etcd: false
       controlplane: false
       worker: true
   kubernetesVersion: [v1.32.2-rancher1-1, v1.32.2+rke2r1, v1.32.2+k3s1]
-  etcdCount: 3
-  controlPlaneCount: 2
-  workerCount: 3
 ```
 
 ### Run Command:

--- a/tests/rancher2/os/defaults.yaml
+++ b/tests/rancher2/os/defaults.yaml
@@ -52,7 +52,4 @@ terratest:
       etcd: false
       controlplane: false
       worker: true
-  etcdCount: 3
-  controlPlaneCount: 2
-  workerCount: 3
   kubernetesVersion: [v1.32.3-rancher1-1, v1.32.3+rke2r1, v1.32.3+k3s1]

--- a/tests/rancher2/provisioning/README.md
+++ b/tests/rancher2/provisioning/README.md
@@ -97,10 +97,21 @@ terraform:
     standaloneNetwork: ""
     vsphereUser: ""
 terratest:
-  etcdCount: 3
-  controlPlaneCount: 2
-  workerCount: 3
-  windowsNodeCount: 1
+  nodepools:
+    - quantity: 3
+      etcd: true
+      controlplane: false
+      worker: false
+    - quantity: 2
+      etcd: false
+      controlplane: true
+      worker: false
+    - quantity: 3
+      etcd: false
+      controlplane: false
+      worker: true
+    - quantity: 1
+      windows: true
 ```
 
 For running the imported clusters, reference the example config block below:
@@ -186,10 +197,21 @@ terraform:
     rke2Version: ""                     # Ensure rke2r1 suffix is appended (i.e. v1.xx.x+rke2r1)
 
 terratest:
-  etcdCount: 3
-  controlPlaneCount: 2
-  workerCount: 3
-  windowsNodeCount: 1
+  nodepools:
+    - quantity: 3
+      etcd: true
+      controlplane: false
+      worker: false
+    - quantity: 2
+      etcd: false
+      controlplane: true
+      worker: false
+    - quantity: 3
+      etcd: false
+      controlplane: false
+      worker: true
+    - quantity: 1
+      windows: true
   pathToRepo: "go/src/github.com/rancher/tfp-automation"
 ```
 

--- a/tests/rancher2/provisioning/defaults.yaml
+++ b/tests/rancher2/provisioning/defaults.yaml
@@ -58,9 +58,14 @@ terraform:
     rke2Version: ""
 
 terratest:
-  etcdCount: 3
-  controlPlaneCount: 2
-  workerCount: 3
-  windowsNodeCount: 1
+  nodepools:
+    - quantity: 3
+      etcd: true
+    - quantity: 2
+      controlplane: true
+    - quantity: 3
+      worker: true
+    - quantity: 1
+      windows: true
   pathToRepo: ""
   snapshotInput: {}

--- a/tests/rancher2/psact/defaults.yaml
+++ b/tests/rancher2/psact/defaults.yaml
@@ -57,9 +57,14 @@ terraform:
     rke2Version: ""
 
 terratest:
-  etcdCount: 3
-  controlPlaneCount: 2
-  workerCount: 3
-  windowsNodeCount: 1
+  nodepools:
+    - quantity: 3
+      etcd: true
+    - quantity: 2
+      controlplane: true
+    - quantity: 3
+      worker: true
+    - quantity: 1
+      windows: true
   pathToRepo: ""
   snapshotInput: {}

--- a/tests/rancher2/rbac/defaults.yaml
+++ b/tests/rancher2/rbac/defaults.yaml
@@ -100,9 +100,14 @@ terraform:
     rke2Version: ""
 
 terratest:
-  etcdCount: 3
-  controlPlaneCount: 2
-  workerCount: 3
-  windowsNodeCount: 1
+  nodepools:
+    - quantity: 3
+      etcd: true
+    - quantity: 2
+      controlplane: true
+    - quantity: 3
+      worker: true
+    - quantity: 1
+      windows: true
   pathToRepo: ""
   snapshotInput: {}

--- a/tests/rancher2/snapshot/defaults.yaml
+++ b/tests/rancher2/snapshot/defaults.yaml
@@ -57,9 +57,14 @@ terraform:
     rke2Version: ""
 
 terratest:
-  etcdCount: 3
-  controlPlaneCount: 2
-  workerCount: 3
-  windowsNodeCount: 1
+  nodepools:
+    - quantity: 3
+      etcd: true
+    - quantity: 2
+      controlplane: true
+    - quantity: 3
+      worker: true
+    - quantity: 1
+      windows: true
   pathToRepo: ""
   snapshotInput: {}

--- a/tests/registries/registries_test.go
+++ b/tests/registries/registries_test.go
@@ -265,6 +265,7 @@ func (r *TfpRegistriesTestSuite) TestTfpGlobalRegistry() {
 	require.NoError(r.T(), err)
 
 	standardToken := standardUserToken.Token
+	nodeRolesWindows := []config.Nodepool{config.EtcdNodePool, config.ControlPlaneNodePool, config.WorkerNodePool, config.WindowsNodePool}
 
 	tests := []struct {
 		name      string
@@ -272,8 +273,8 @@ func (r *TfpRegistriesTestSuite) TestTfpGlobalRegistry() {
 		nodeRoles []config.Nodepool
 	}{
 		{"Global_RKE2", modules.NodeDriverAWSRKE2, nodeRolesDedicated},
-		{"Global_RKE2_Windows_2019", modules.CustomAWSRKE2Windows2019, nil},
-		{"Global_RKE2_Windows_2022", modules.CustomAWSRKE2Windows2022, nil},
+		{"Global_RKE2_Windows_2019", modules.CustomAWSRKE2Windows2019, nodeRolesWindows},
+		{"Global_RKE2_Windows_2022", modules.CustomAWSRKE2Windows2022, nodeRolesWindows},
 		{"Global_K3S", modules.NodeDriverAWSK3S, nodeRolesAll},
 	}
 
@@ -376,6 +377,7 @@ func (r *TfpRegistriesTestSuite) TestTfpNonAuthenticatedRegistry() {
 
 	nodeRolesAll := []config.Nodepool{config.AllRolesNodePool}
 	nodeRolesDedicated := []config.Nodepool{config.EtcdNodePool, config.ControlPlaneNodePool, config.WorkerNodePool}
+	nodeRolesWindows := []config.Nodepool{config.EtcdNodePool, config.ControlPlaneNodePool, config.WorkerNodePool, config.WindowsNodePool}
 	customClusterNames := []string{}
 
 	tests := []struct {
@@ -384,8 +386,8 @@ func (r *TfpRegistriesTestSuite) TestTfpNonAuthenticatedRegistry() {
 		nodeRoles []config.Nodepool
 	}{
 		{"Non_Auth_RKE2", modules.NodeDriverAWSRKE2, nodeRolesDedicated},
-		{"Non_Auth_RKE2_Windows_2019", modules.CustomAWSRKE2Windows2019, nil},
-		{"Non_Auth_RKE2_Windows_2022", modules.CustomAWSRKE2Windows2022, nil},
+		{"Non_Auth_RKE2_Windows_2019", modules.CustomAWSRKE2Windows2019, nodeRolesWindows},
+		{"Non_Auth_RKE2_Windows_2022", modules.CustomAWSRKE2Windows2022, nodeRolesWindows},
 		{"Non_Auth_K3S", modules.NodeDriverAWSK3S, nodeRolesAll},
 	}
 

--- a/tests/sanity/README.md
+++ b/tests/sanity/README.md
@@ -125,10 +125,21 @@ terraform:
 # TERRATEST CONFIG
 #######################
 terratest:  
-  etcdCount: 3
-  controlPlaneCount: 2
-  workerCount: 3
-  windowsNodeCount: 1
+  nodepools:
+    - quantity: 3
+      etcd: true
+      controlplane: false
+      worker: false
+    - quantity: 2
+      etcd: false
+      controlplane: true
+      worker: false
+    - quantity: 3
+      etcd: false
+      controlplane: false
+      worker: true
+    - quantity: 1
+      windows: true
   pathToRepo: "go/src/github.com/rancher/tfp-automation"
 ```
 

--- a/tests/sanity/sanity_provisioning_test.go
+++ b/tests/sanity/sanity_provisioning_test.go
@@ -74,6 +74,7 @@ func (s *TfpSanityProvisioningTestSuite) TestTfpProvisioningSanity() {
 	standardToken := standardUserToken.Token
 
 	nodeRolesDedicated := []config.Nodepool{config.EtcdNodePool, config.ControlPlaneNodePool, config.WorkerNodePool}
+	nodeRolesWindows := []config.Nodepool{config.EtcdNodePool, config.ControlPlaneNodePool, config.WorkerNodePool, config.WindowsNodePool}
 	rke2Module, rke2Windows2019, rke2Windows2022, k3sModule := provisioning.DownstreamClusterModules(s.terraformConfig)
 
 	tests := []struct {
@@ -82,8 +83,8 @@ func (s *TfpSanityProvisioningTestSuite) TestTfpProvisioningSanity() {
 		module    string
 	}{
 		{"Sanity_RKE2", nodeRolesDedicated, rke2Module},
-		{"Sanity_RKE2_Windows_2019", nil, rke2Windows2019},
-		{"Sanity_RKE2_Windows_2022", nil, rke2Windows2022},
+		{"Sanity_RKE2_Windows_2019", nodeRolesWindows, rke2Windows2019},
+		{"Sanity_RKE2_Windows_2022", nodeRolesWindows, rke2Windows2022},
 		{"Sanity_K3S", nodeRolesDedicated, k3sModule},
 	}
 

--- a/tests/sanity/sanity_upgrade_rancher_test.go
+++ b/tests/sanity/sanity_upgrade_rancher_test.go
@@ -93,6 +93,7 @@ func (s *TfpSanityUpgradeRancherTestSuite) provisionAndVerifyCluster(name string
 
 	customClusterNames := []string{}
 	nodeRolesDedicated := []config.Nodepool{config.EtcdNodePool, config.ControlPlaneNodePool, config.WorkerNodePool}
+	nodeRolesWindows := []config.Nodepool{config.EtcdNodePool, config.ControlPlaneNodePool, config.WorkerNodePool, config.WindowsNodePool}
 	rke2Module, rke2Windows2019, rke2Windows2022, k3sModule := provisioning.DownstreamClusterModules(s.terraformConfig)
 	tests := []struct {
 		name      string
@@ -100,8 +101,8 @@ func (s *TfpSanityUpgradeRancherTestSuite) provisionAndVerifyCluster(name string
 		module    string
 	}{
 		{name + "_RKE2", nodeRolesDedicated, rke2Module},
-		{name + "_RKE2_Windows_2019", nil, rke2Windows2019},
-		{name + "_RKE2_Windows_2022", nil, rke2Windows2022},
+		{name + "_RKE2_Windows_2019", nodeRolesWindows, rke2Windows2019},
+		{name + "_RKE2_Windows_2022", nodeRolesWindows, rke2Windows2022},
 		{name + "_K3S", nodeRolesDedicated, k3sModule},
 	}
 


### PR DESCRIPTION
Description: Adds support for multi role custom cluster nodes. Also cleans up old logic
Changes:
* Removed etcd, controlplane, worker, windows counts from terratest
* Updated nodepools to have a windows var
* Updated all relevent code to point at nodepools instead of the old count vars