### PR TITLE
Remove old configmap logic

### DIFF
--- a/framework/set/provisioning/custom/locals/setLocals.go
+++ b/framework/set/provisioning/custom/locals/setLocals.go
@@ -22,7 +22,7 @@ const (
 
 // SetLocals is a function that will set the locals configurations in the main.tf file.
 func SetLocals(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig,
-	configMap []map[string]any, newFile *hclwrite.File, file *os.File, customClusterNames []string) (*os.File, error) {
+	newFile *hclwrite.File, file *os.File, customClusterName string) (*os.File, error) {
 	localsBlock := rootBody.AppendNewBlock(general.Locals, nil)
 	localsBlockBody := localsBlock.Body()
 
@@ -61,18 +61,18 @@ func SetLocals(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
 
 	localsBlockBody.SetAttributeRaw(clusters.ResourcePrefix, resourcePrefixValue)
 
-	setV2ClusterLocalBlock(localsBlockBody, terraformConfig, customClusterNames)
+	setV2ClusterLocalBlock(localsBlockBody, terraformConfig, customClusterName)
 
 	return file, nil
 }
 
-func setV2ClusterLocalBlock(localsBlockBody *hclwrite.Body, terraformConfig *config.TerraformConfig, customClusterNames []string) {
-	for _, name := range customClusterNames {
-		setCustomClusterLocalBlock(localsBlockBody, name, terraformConfig)
+func setV2ClusterLocalBlock(localsBlockBody *hclwrite.Body, terraformConfig *config.TerraformConfig, customClusterName string) {
+	if customClusterName != "" {
+		setCustomClusterLocalBlock(localsBlockBody, customClusterName, terraformConfig)
 	}
 
 	//Temporary workaround until fetching insecure node command is available for rancher2_cluster_v2 resoureces with tfp-rancher2
-	if strings.Contains(terraformConfig.Module, general.Custom) {
+	if (strings.Contains(terraformConfig.Module, general.Custom)) && customClusterName != terraformConfig.ResourcePrefix {
 		setCustomClusterLocalBlock(localsBlockBody, terraformConfig.ResourcePrefix, terraformConfig)
 	}
 }

--- a/framework/set/provisioning/custom/setConfig.go
+++ b/framework/set/provisioning/custom/setConfig.go
@@ -19,7 +19,7 @@ import (
 )
 
 // SetCustomRKE2K3s is a function that will set the custom RKE2/K3s cluster configurations in the main.tf file.
-func SetCustomRKE2K3s(terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig, configMap []map[string]any,
+func SetCustomRKE2K3s(terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig,
 	newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File) (*hclwrite.File, *os.File, error) {
 	switch terraformConfig.Provider {
 	case awsDefaults.Aws:

--- a/framework/set/provisioning/custom/setWindowsConfig.go
+++ b/framework/set/provisioning/custom/setWindowsConfig.go
@@ -9,7 +9,7 @@ import (
 )
 
 // SetCustomRKE2Windows is a function that will set the custom RKE2 cluster configurations in the main.tf file.
-func SetCustomRKE2Windows(terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig, configMap []map[string]any,
+func SetCustomRKE2Windows(terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig,
 	newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File) (*hclwrite.File, *os.File, error) {
 	nullresource.CustomWindowsNullResource(rootBody, terraformConfig, terraformConfig.ResourcePrefix)
 	rootBody.AppendNewline()

--- a/framework/set/resources/rancher2/setProvidersAndUsersTF.go
+++ b/framework/set/resources/rancher2/setProvidersAndUsersTF.go
@@ -9,7 +9,6 @@ import (
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	"github.com/rancher/shepherd/extensions/token"
 	shepherdConfig "github.com/rancher/shepherd/pkg/config"
-	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/framework/set/defaults/general"
 	"github.com/rancher/tfp-automation/framework/set/defaults/providers/aws"
@@ -57,26 +56,27 @@ const (
 
 // SetProvidersAndUsersTF is a helper function that will set the general Terraform configurations in the main.tf file.
 func SetProvidersAndUsersTF(rancherConfig *rancher.Config, testUser, testPassword string, authProvider bool,
-	newFile *hclwrite.File, rootBody *hclwrite.Body, configMap []map[string]any, customModule bool) (*hclwrite.File, *hclwrite.Body) {
-	createRequiredProviders(rootBody, configMap, customModule)
-	createProvider(rancherConfig, rootBody, configMap, customModule)
+	newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, customModule bool) (*hclwrite.File, *hclwrite.Body) {
+	createRequiredProviders(rootBody, terraformConfig, customModule)
+	createProvider(rancherConfig, rootBody, terraformConfig, customModule)
 	createProviderAlias(rancherConfig, rootBody)
 
 	return newFile, rootBody
 }
 
 // createRequiredProviders creates the required_providers block.
-func createRequiredProviders(rootBody *hclwrite.Body, configMap []map[string]any, customModule bool) {
+func createRequiredProviders(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, customModule bool) {
 	tfBlock := rootBody.AppendNewBlock(terraform, nil)
 	tfBlockBody := tfBlock.Body()
 
 	reqProvsBlock := tfBlockBody.AppendNewBlock(requiredProviders, nil)
 	reqProvsBlockBody := reqProvsBlock.Body()
 
-	terraformConfig := new(config.TerraformConfig)
-	operations.LoadObjectFromMap(config.TerraformConfigurationFileKey, configMap[0], terraformConfig)
+	if terraformConfig == nil {
+		return
+	}
 
-	source, rancherProviderVersion, cloudProviderVersion, localProviderVersion, rkeProviderVersion := getRequiredProviderVersions(configMap)
+	source, rancherProviderVersion, cloudProviderVersion, localProviderVersion, rkeProviderVersion := getRequiredProviderVersions(terraformConfig)
 
 	if rancherProviderVersion != "" {
 		reqProvsBlockBody.SetAttributeValue(rancher2Const, cty.ObjectVal(map[string]cty.Value{
@@ -124,11 +124,12 @@ func createRequiredProviders(rootBody *hclwrite.Body, configMap []map[string]any
 }
 
 // createProvider creates a provider block for the given rancher config.
-func createProvider(rancherConfig *rancher.Config, rootBody *hclwrite.Body, configMap []map[string]any, customModule bool) {
-	_, _, cloudProviderVersion, _, _ := getRequiredProviderVersions(configMap)
+func createProvider(rancherConfig *rancher.Config, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, customModule bool) {
+	_, _, cloudProviderVersion, _, _ := getRequiredProviderVersions(terraformConfig)
 
-	terraformConfig := new(config.TerraformConfig)
-	operations.LoadObjectFromMap(config.TerraformConfigurationFileKey, configMap[0], terraformConfig)
+	if terraformConfig == nil {
+		return
+	}
 
 	if cloudProviderVersion != "" && terraformConfig.Provider == aws.Aws && customModule {
 		awsProvBlock := rootBody.AppendNewBlock(general.Provider, []string{aws.Aws})
@@ -217,34 +218,34 @@ func createProviderAlias(rancherConfig *rancher.Config, rootBody *hclwrite.Body)
 }
 
 // Determines the required providers from the list of configs.
-func getRequiredProviderVersions(configMap []map[string]any) (source, rancherProviderVersion, rkeProviderVersion, localProviderVersion,
+func getRequiredProviderVersions(terraformConfig *config.TerraformConfig) (source, rancherProviderVersion, rkeProviderVersion, localProviderVersion,
 	cloudProviderVersion string) {
-	for _, cattleConfig := range configMap {
-		terraformConfig := new(config.TerraformConfig)
-		operations.LoadObjectFromMap(config.TerraformConfigurationFileKey, cattleConfig, terraformConfig)
-		module := terraformConfig.Module
+	if terraformConfig == nil {
+		return source, rancherProviderVersion, rkeProviderVersion, localProviderVersion, cloudProviderVersion
+	}
 
-		rancherProviderVersion = os.Getenv(providerEnvVar)
-		if rancherProviderVersion == "" {
-			logrus.Fatalf("Expected env var not set %s", providerEnvVar)
+	module := terraformConfig.Module
+
+	rancherProviderVersion = os.Getenv(providerEnvVar)
+	if rancherProviderVersion == "" {
+		logrus.Fatalf("Expected env var not set %s", providerEnvVar)
+	}
+
+	source = "rancher/rancher2"
+	if strings.Contains(rancherProviderVersion, rc) {
+		source = "terraform.local/local/rancher2"
+	}
+
+	if strings.Contains(module, general.Custom) || strings.Contains(module, general.Import) ||
+		strings.Contains(module, ec2) {
+		cloudProviderVersion = os.Getenv(cloudProviderEnvVar)
+		if cloudProviderVersion == "" {
+			logrus.Fatalf("Expected env var not set %s", cloudProviderEnvVar)
 		}
 
-		source = "rancher/rancher2"
-		if strings.Contains(rancherProviderVersion, rc) {
-			source = "terraform.local/local/rancher2"
-		}
-
-		if strings.Contains(module, general.Custom) || strings.Contains(module, general.Import) ||
-			strings.Contains(module, ec2) {
-			cloudProviderVersion = os.Getenv(cloudProviderEnvVar)
-			if cloudProviderVersion == "" {
-				logrus.Fatalf("Expected env var not set %s", cloudProviderEnvVar)
-			}
-
-			localProviderVersion = os.Getenv(localProviderEnvVar)
-			if localProviderVersion == "" {
-				logrus.Fatalf("Expected env var not set %s", localProviderEnvVar)
-			}
+		localProviderVersion = os.Getenv(localProviderEnvVar)
+		if localProviderVersion == "" {
+			logrus.Fatalf("Expected env var not set %s", localProviderEnvVar)
 		}
 	}
 

--- a/framework/set/setAuthConfig.go
+++ b/framework/set/setAuthConfig.go
@@ -21,9 +21,11 @@ import (
 func AuthConfig(rancherConfig *rancher.Config, testUser, testPassword string, configMap []map[string]any, newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File) error {
 	var err error
 
-	newFile, rootBody = resources.SetProvidersAndUsersTF(rancherConfig, testUser, testPassword, true, newFile, rootBody, configMap, false)
+	_, terraform, _, _ := config.LoadTFPConfigs(configMap[0])
 
-	rancherConfig, terraform, _, _ := config.LoadTFPConfigs(configMap[0])
+	newFile, rootBody = resources.SetProvidersAndUsersTF(rancherConfig, testUser, testPassword, true, newFile, rootBody, terraform, false)
+
+	rancherConfig, terraform, _, _ = config.LoadTFPConfigs(configMap[0])
 	authProvider := terraform.AuthProvider
 
 	switch authProvider {

--- a/framework/set/setConfigTF.go
+++ b/framework/set/setConfigTF.go
@@ -18,8 +18,9 @@ import (
 
 // ConfigTF sets the main.tf file based on the module type.
 func ConfigTF(client *rancher.Client, rancherConfig *rancher.Config, terratestConfig *config.TerratestConfig, testUser, testPassword string,
-	rbacRole config.Role, configMap []map[string]any, newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File, isWindows, persistClusters,
-	customModule bool, customClusterNames []string, nestedRancherModuleDir string) ([]string, []string, error) {
+	rbacRole config.Role, terraformConfig *config.TerraformConfig,
+	newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File, isWindows, persistClusters,
+	customModule bool, customClusterName string, nestedRancherModuleDir string) ([]string, string, error) {
 	var err error
 
 	clusterNames := []string{}
@@ -30,62 +31,56 @@ func ConfigTF(client *rancher.Client, rancherConfig *rancher.Config, terratestCo
 	}
 
 	if !strings.Contains(string(newFile.Bytes()), general.RequiredProviders) {
-		newFile, rootBody = rancher2.SetProvidersAndUsersTF(rancherConfig, testUser, testPassword, false, newFile, rootBody, configMap, customModule)
+		newFile, rootBody = rancher2.SetProvidersAndUsersTF(rancherConfig, testUser, testPassword, false, newFile, rootBody, terraformConfig, customModule)
 	}
 
-	rootBody.AppendNewline()
+	if strings.Contains(terraformConfig.Module, clustertypes.CUSTOM) {
+		containsCustomModule = true
+	}
 
-	for i, cattleConfig := range configMap {
-		_, terraformConfig, terratestConfig, _ := config.LoadTFPConfigs(cattleConfig)
+	clusterNames = append(clusterNames, terraformConfig.ResourcePrefix)
 
-		if strings.Contains(terraformConfig.Module, clustertypes.CUSTOM) {
-			containsCustomModule = true
+	if strings.Contains(terraformConfig.Module, general.Custom) {
+		customClusterName = terraformConfig.ResourcePrefix
+	}
+
+	if terraformConfig.Module == modules.HostedAzureAKS || terraformConfig.Module == modules.HostedAWSEKS || terraformConfig.Module == modules.HostedGoogleGKE {
+		newFile, file, err = HostedClusters(terraformConfig, terratestConfig, newFile, rootBody, file)
+		if err != nil {
+			return clusterNames, "", err
+		}
+	}
+
+	if !strings.Contains(terraformConfig.Module, general.Custom) && !strings.Contains(terraformConfig.Module, general.Import) &&
+		terraformConfig.Module != modules.HostedAzureAKS && terraformConfig.Module != modules.HostedAWSEKS && terraformConfig.Module != modules.HostedGoogleGKE {
+		newFile, file, err = NodeDriverClusters(client, terraformConfig, terratestConfig, rbacRole, newFile, rootBody, file)
+		if err != nil {
+			return clusterNames, "", err
+		}
+	}
+
+	if strings.Contains(terraformConfig.Module, general.Custom) {
+		newFile, file, err = CustomClusters(client, terraformConfig, terratestConfig, newFile, rootBody, file, isWindows)
+		if err != nil {
+			return clusterNames, "", err
+		}
+	}
+
+	if strings.Contains(terraformConfig.Module, general.Import) {
+		newFile, file, err = ImportedClusters(client, terraformConfig, terratestConfig, newFile, rootBody, file, isWindows)
+		if err != nil {
+			return clusterNames, "", err
+		}
+	}
+
+	if containsCustomModule {
+		localsBlock := newFile.Body().FirstMatchingBlock(general.Locals, nil)
+		if localsBlock != nil {
+			newFile.Body().RemoveBlock(localsBlock)
 		}
 
-		clusterNames = append(clusterNames, terraformConfig.ResourcePrefix)
-
-		if strings.Contains(terraformConfig.Module, general.Custom) {
-			customClusterNames = append(customClusterNames, terraformConfig.ResourcePrefix)
-		}
-
-		if terraformConfig.Module == modules.HostedAzureAKS || terraformConfig.Module == modules.HostedAWSEKS || terraformConfig.Module == modules.HostedGoogleGKE {
-			newFile, file, err = HostedClusters(terraformConfig, terratestConfig, newFile, rootBody, file)
-			if err != nil {
-				return clusterNames, nil, err
-			}
-		}
-
-		if !strings.Contains(terraformConfig.Module, general.Custom) && !strings.Contains(terraformConfig.Module, general.Import) &&
-			terraformConfig.Module != modules.HostedAzureAKS && terraformConfig.Module != modules.HostedAWSEKS && terraformConfig.Module != modules.HostedGoogleGKE {
-			newFile, file, err = NodeDriverClusters(client, terraformConfig, terratestConfig, rbacRole, newFile, rootBody, file)
-			if err != nil {
-				return clusterNames, nil, err
-			}
-		}
-
-		if strings.Contains(terraformConfig.Module, general.Custom) {
-			newFile, file, err = CustomClusters(client, terraformConfig, terratestConfig, newFile, rootBody, file, configMap, isWindows)
-			if err != nil {
-				return clusterNames, nil, err
-			}
-		}
-
-		if strings.Contains(terraformConfig.Module, general.Import) {
-			newFile, file, err = ImportedClusters(client, terraformConfig, terratestConfig, newFile, rootBody, file, configMap, isWindows)
-			if err != nil {
-				return clusterNames, nil, err
-			}
-		}
-
-		if i == len(configMap)-1 && containsCustomModule {
-			localsBlock := newFile.Body().FirstMatchingBlock(general.Locals, nil)
-			if localsBlock != nil {
-				newFile.Body().RemoveBlock(localsBlock)
-			}
-
-			file, err = locals.SetLocals(rootBody, terraformConfig, terratestConfig, configMap, newFile, file, customClusterNames)
-			rootBody.AppendNewline()
-		}
+		file, err = locals.SetLocals(rootBody, terraformConfig, terratestConfig, newFile, file, customClusterName)
+		rootBody.AppendNewline()
 	}
 
 	// This is needed to ensure there is no duplications in the main.tf file.
@@ -93,14 +88,14 @@ func ConfigTF(client *rancher.Client, rancherConfig *rancher.Config, terratestCo
 	file, err = os.Create(mainTFPath)
 	if err != nil {
 		logrus.Infof("Failed to reset/overwrite main.tf file. Error: %v", err)
-		return clusterNames, customClusterNames, err
+		return clusterNames, customClusterName, err
 	}
 
 	_, err = file.Write(newFile.Bytes())
 	if err != nil {
 		logrus.Infof("Failed to write configurations to main.tf file. Error: %v", err)
-		return clusterNames, customClusterNames, err
+		return clusterNames, customClusterName, err
 	}
 
-	return clusterNames, customClusterNames, nil
+	return clusterNames, customClusterName, nil
 }

--- a/framework/set/setCustomClusters.go
+++ b/framework/set/setCustomClusters.go
@@ -11,19 +11,19 @@ import (
 
 // CustomClusters is a function that will set the custom clusters in the main.tf file.
 func CustomClusters(client *rancher.Client, terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig,
-	newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File, configMap []map[string]any,
+	newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File,
 	isWindows bool) (*hclwrite.File, *os.File, error) {
 	var err error
 
 	if !isWindows {
-		newFile, file, err = custom.SetCustomRKE2K3s(terraformConfig, terratestConfig, configMap, newFile, rootBody, file)
+		newFile, file, err = custom.SetCustomRKE2K3s(terraformConfig, terratestConfig, newFile, rootBody, file)
 		if err != nil {
 			return newFile, file, err
 		}
 	}
 
 	if isWindows {
-		newFile, file, err := custom.SetCustomRKE2Windows(terraformConfig, terratestConfig, configMap, newFile, rootBody, file)
+		newFile, file, err := custom.SetCustomRKE2Windows(terraformConfig, terratestConfig, newFile, rootBody, file)
 		if err != nil {
 			return newFile, file, err
 		}

--- a/framework/set/setImportedClusters.go
+++ b/framework/set/setImportedClusters.go
@@ -11,7 +11,7 @@ import (
 
 // ImportedClusters is a function that will set the imported clusters in the main.tf file.
 func ImportedClusters(client *rancher.Client, terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig,
-	newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File, configMap []map[string]any,
+	newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File,
 	isWindows bool) (*hclwrite.File, *os.File, error) {
 	var err error
 

--- a/pipeline/qase/schemaParams.go
+++ b/pipeline/qase/schemaParams.go
@@ -9,10 +9,9 @@ import (
 	"github.com/rancher/tfp-automation/defaults/modules"
 )
 
-// GetProvisioningSchemaParams gets a set of params from the cattle config and returns a qase params object
-func GetProvisioningSchemaParams(configMap map[string]any) []upstream.TestCaseParameterCreate {
+// GetProvisioningSchemaParams gets a set of params from the terraform/terratest config and returns a qase params object
+func GetProvisioningSchemaParams(terraform *config.TerraformConfig, terratest *config.TerratestConfig) []upstream.TestCaseParameterCreate {
 	var params []upstream.TestCaseParameterCreate
-	_, terraform, terratest, _ := config.LoadTFPConfigs(configMap)
 
 	params = append(params,
 		getRunType(terraform),

--- a/tests/extensions/provisioning/buildModule.go
+++ b/tests/extensions/provisioning/buildModule.go
@@ -14,10 +14,10 @@ import (
 )
 
 // BuildModule is a function that builds the Terraform module.
-func BuildModule(t *testing.T, rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig, configMap []map[string]any) error {
+func BuildModule(t *testing.T, rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig) error {
 	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, terratestConfig.PathToRepo, "")
 
-	_, _, err := framework.ConfigTF(nil, rancherConfig, terratestConfig, "", "", "", configMap, nil, nil, nil, false, false, false, nil, "")
+	_, _, err := framework.ConfigTF(nil, rancherConfig, terratestConfig, "", "", "", terraformConfig, nil, nil, nil, false, false, false, "", "")
 	if err != nil {
 		return err
 	}

--- a/tests/extensions/provisioning/defaultK8sVersion.go
+++ b/tests/extensions/provisioning/defaultK8sVersion.go
@@ -5,39 +5,32 @@ import (
 
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/shepherd/extensions/clusters/kubernetesversions"
-	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/defaults/clustertypes"
 )
 
 // GetK8sVersion is a function that will set the Kubernetes version if the user has not specified one. It
 // will get the latest version or the second latest version based on the versionType.
-func GetK8sVersion(client *rancher.Client, cattleConfig map[string]any) error {
-	terraform := new(config.TerraformConfig)
-	operations.LoadObjectFromMap(config.TerraformConfigurationFileKey, cattleConfig, terraform)
-
-	terratest := new(config.TerratestConfig)
-	operations.LoadObjectFromMap(config.TerratestConfigurationFileKey, cattleConfig, terratest)
-
+func GetK8sVersion(client *rancher.Client, terraform *config.TerraformConfig, terratest *config.TerratestConfig) (*config.TerratestConfig, error) {
 	defaultVersion := terratest.KubernetesVersion
 	if terratest.KubernetesVersion == "" {
 		if strings.Contains(terraform.Module, clustertypes.RKE2) {
 			defaultVersions, err := kubernetesversions.Default(client, clustertypes.RKE2, nil)
 			if err != nil {
-				return err
+				return nil, err
 			}
 
 			defaultVersion = defaultVersions[0]
 		} else if strings.Contains(terraform.Module, clustertypes.K3S) {
 			defaultVersions, err := kubernetesversions.Default(client, clustertypes.K3S, nil)
 			if err != nil {
-				return err
+				return nil, err
 			}
 
 			defaultVersion = defaultVersions[0]
 		}
 	}
 
-	operations.ReplaceValue([]string{"terratest", "kubernetesVersion"}, defaultVersion, cattleConfig)
-	return nil
+	terratest.KubernetesVersion = defaultVersion
+	return terratest, nil
 }

--- a/tests/extensions/provisioning/provision.go
+++ b/tests/extensions/provisioning/provision.go
@@ -19,15 +19,15 @@ import (
 // Provision is a function that will run terraform init and apply Terraform resources to provision a cluster.
 func Provision(t *testing.T, client, standardUserClient *rancher.Client, rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig,
 	terratestConfig *config.TerratestConfig, testUser, testPassword string, terraformOptions *terraform.Options,
-	configMap []map[string]any, newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File, isWindows, persistClusters,
-	containsCustomModule bool, clusterIDs, customClusterNames []string, nestedRancherModuleDir string) ([]*steveV1.SteveAPIObject, []string) {
+	newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File, isWindows, persistClusters,
+	containsCustomModule bool, customClusterName string, nestedRancherModuleDir string) ([]*steveV1.SteveAPIObject, string) {
 	var err error
 	var clusterNames []string
 
-	isSupported := SupportedModules(terraformOptions, configMap)
+	isSupported := SupportedModules(terraformConfig)
 	require.True(t, isSupported)
 
-	clusterNames, customClusterNames, err = framework.ConfigTF(standardUserClient, rancherConfig, terratestConfig, testUser, testPassword, "", configMap, newFile, rootBody, file, isWindows, persistClusters, containsCustomModule, customClusterNames, nestedRancherModuleDir)
+	clusterNames, customClusterName, err = framework.ConfigTF(standardUserClient, rancherConfig, terratestConfig, testUser, testPassword, "", terraformConfig, newFile, rootBody, file, isWindows, persistClusters, containsCustomModule, customClusterName, nestedRancherModuleDir)
 	require.NoError(t, err)
 
 	// If the provisioner is GKE, we need to run terraform import for the Google driver before applying the Terraform configuration.
@@ -47,5 +47,5 @@ func Provision(t *testing.T, client, standardUserClient *rancher.Client, rancher
 		clusterObjects = append(clusterObjects, createdCluster)
 	}
 
-	return clusterObjects, customClusterNames
+	return clusterObjects, customClusterName
 }

--- a/tests/extensions/provisioning/supportedModules.go
+++ b/tests/extensions/provisioning/supportedModules.go
@@ -4,8 +4,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/gruntwork-io/terratest/modules/terraform"
-	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/defaults/modules"
 	"github.com/rancher/tfp-automation/framework/set/defaults/providers/aws"
@@ -79,16 +77,12 @@ func IsHostedModule(module string) bool {
 }
 
 // SupportedModules is a function that will check if the user-inputted module is supported.
-func SupportedModules(terraformOptions *terraform.Options, configMap []map[string]any) bool {
-	var isSupported bool
-	for _, cattleConfig := range configMap {
-		tfConfig := new(config.TerraformConfig)
-		operations.LoadObjectFromMap(config.TerraformConfigurationFileKey, cattleConfig, tfConfig)
-
-		isSupported = verifyModule(tfConfig.Module)
+func SupportedModules(terraformConfig *config.TerraformConfig) bool {
+	if terraformConfig == nil {
+		return false
 	}
 
-	return isSupported
+	return verifyModule(terraformConfig.Module)
 }
 
 func verifyModule(module string) bool {

--- a/tests/extensions/provisioning/uniquify.go
+++ b/tests/extensions/provisioning/uniquify.go
@@ -1,40 +1,12 @@
 package provisioning
 
 import (
-	"os"
-
-	shepherdConfig "github.com/rancher/shepherd/pkg/config"
-	"github.com/rancher/shepherd/pkg/config/operations"
 	namegen "github.com/rancher/shepherd/pkg/namegenerator"
 	"github.com/rancher/tfp-automation/config"
 )
 
-const (
-	resourcePrefixKey = "resourcePrefix"
-)
+func UniquifyTerraform(terraformConfig *config.TerraformConfig) *config.TerraformConfig {
+	terraformConfig.ResourcePrefix = namegen.AppendRandomString(terraformConfig.ResourcePrefix)
 
-func UniquifyTerraform(cattleConfig map[string]any) (map[string]any, error) {
-	resourcePrefix := []string{config.TerraformConfigurationFileKey, resourcePrefixKey}
-	cattleConfig, err := uniquifyField(resourcePrefix, cattleConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	return cattleConfig, nil
-}
-
-func uniquifyField(keyPath []string, cattleConfig map[string]any) (map[string]any, error) {
-	cattleConfig = shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
-	_, terraformConfig, _, _ := config.LoadTFPConfigs(cattleConfig)
-
-	keyPathValue := terraformConfig.ResourcePrefix
-
-	keyPathValue = namegen.AppendRandomString(keyPathValue)
-
-	uniqueCattleConfig, err := operations.ReplaceValue(keyPath, keyPathValue, cattleConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	return uniqueCattleConfig, nil
+	return terraformConfig
 }

--- a/tests/extensions/rbac/rbac.go
+++ b/tests/extensions/rbac/rbac.go
@@ -17,7 +17,7 @@ func RBAC(t *testing.T, client *rancher.Client, rancherConfig *rancher.Config, t
 	terratestConfig *config.TerratestConfig, testUser, testPassword string, terraformOptions *terraform.Options,
 	configMap []map[string]any, rbacRole config.Role, newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File,
 	nestedRancherModuleDir string) {
-	_, _, err := framework.ConfigTF(client, rancherConfig, terratestConfig, testUser, testPassword, rbacRole, configMap, newFile, rootBody, file, false, false, false, nil, nestedRancherModuleDir)
+	_, _, err := framework.ConfigTF(client, rancherConfig, terratestConfig, testUser, testPassword, rbacRole, terraformConfig, newFile, rootBody, file, false, false, false, "", nestedRancherModuleDir)
 	require.NoError(t, err)
 
 	terraform.Apply(t, terraformOptions)

--- a/tests/kdm/kdm_test.go
+++ b/tests/kdm/kdm_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/shepherd/extensions/clusters/kubernetesversions"
-	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
 	clusterActions "github.com/rancher/tests/actions/clusters"
 	provisioningActions "github.com/rancher/tests/actions/provisioning"
@@ -64,9 +63,6 @@ func (k *KDMTestSuite) SetupSuite() {
 func (k *KDMTestSuite) TestKDM() {
 	var err error
 	var testUser, testPassword string
-	var clusterIDs []string
-
-	customClusterNames := []string{}
 
 	rawKdm, err := provisioning.FetchSetting(k.client, "rke-metadata-config")
 	require.NoError(k.T(), err)
@@ -114,43 +110,41 @@ func (k *KDMTestSuite) TestKDM() {
 		k.T().Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			rancher, terraform, terratest, _ := config.LoadTFPConfigs(k.cattleConfig)
+			rancher.AdminToken = standardToken
+			terratest.Nodepools = tt.nodeRoles
+			terraform.Module = tt.module
+
 			nestedRancherModuleDir, perTestTerraformOptions, err := nested.CreateNestedModules(k.terraformConfig, k.terratestConfig, k.terraformOptions, tt.name, configs.NestedRancherModuleDir)
 			require.NoError(t, err)
 			defer os.RemoveAll(nestedRancherModuleDir)
 
 			newFile, rootBody, file := rancher2.InitializeNestedMainTFs(nestedRancherModuleDir)
 			defer file.Close()
-
-			cattleConfig, err := provisioning.UniquifyTerraform(k.cattleConfig)
-			require.NoError(t, err)
-
-			_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, standardToken, cattleConfig)
+			terratest, err = provisioning.GetK8sVersion(k.standardUserClient, terraform, terratest)
 			require.NoError(k.T(), err)
 
-			_, err = operations.ReplaceValue([]string{"terratest", "nodepools"}, tt.nodeRoles, cattleConfig)
-			require.NoError(k.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "module"}, tt.module, cattleConfig)
-			require.NoError(k.T(), err)
-
-			provisioning.GetK8sVersion(k.standardUserClient, cattleConfig)
-
-			rancher, terraform, terratest, _ := config.LoadTFPConfigs(cattleConfig)
+			terraform = provisioning.UniquifyTerraform(terraform)
 
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, k.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(k.T(), perTestTerraformOptions, keyPath)
 
-			clusters, _ := provisioning.Provision(k.T(), k.client, k.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+			logrus.Infof("Provisioning cluster (%s)", terraform.ResourcePrefix)
+			clusters, _ := provisioning.Provision(k.T(), k.client, k.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, newFile, rootBody, file, false, false, true, "", nestedRancherModuleDir)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", clusters[0].Name)
 			err = provisioningActions.VerifyClusterReady(k.client, clusters[0])
 			require.NoError(k.T(), err)
 
+			logrus.Infof("Verifying service account token secret (%s)", clusters[0].Name)
 			err = clusterActions.VerifyServiceAccountTokenSecret(k.client, clusters[0].Name)
 			require.NoError(k.T(), err)
 
+			logrus.Infof("Verifying cluster pods (%s)", clusters[0].Name)
 			err = pods.VerifyClusterPods(k.client, clusters[0])
 			require.NoError(k.T(), err)
 
-			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
+			params := tfpQase.GetProvisioningSchemaParams(k.terraformConfig, k.terratestConfig)
 			err = qase.UpdateSchemaParameters(tt.name, params)
 			if err != nil {
 				logrus.Warningf("Failed to upload schema parameters %s", err)

--- a/tests/postrelease/post_release_test.go
+++ b/tests/postrelease/post_release_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/rancher/tfp-automation/defaults/keypath"
 	"github.com/rancher/tfp-automation/defaults/stevetypes"
 	tfpQase "github.com/rancher/tfp-automation/pipeline/qase"
-	"github.com/rancher/tfp-automation/tests/extensions/provisioning"
 	"github.com/rancher/tfp-automation/tests/infrastructure/ranchers"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
@@ -52,10 +51,7 @@ func (s *TfpPostReleaseTestSuite) TestTfpPostRelease() {
 			err = pods.VerifyClusterPods(s.client, cluster)
 			require.NoError(s.T(), err)
 
-			cattleConfig, err := provisioning.UniquifyTerraform(s.cattleConfig)
-			require.NoError(t, err)
-
-			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
+			params := tfpQase.GetProvisioningSchemaParams(s.terraformConfig, s.terratestConfig)
 			err = qase.UpdateSchemaParameters(tt.name, params)
 			if err != nil {
 				logrus.Warningf("Failed to upload schema parameters %s", err)

--- a/tests/postrelease/post_release_upgrade_test.go
+++ b/tests/postrelease/post_release_upgrade_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/rancher/tfp-automation/defaults/keypath"
 	"github.com/rancher/tfp-automation/defaults/stevetypes"
 	tfpQase "github.com/rancher/tfp-automation/pipeline/qase"
-	"github.com/rancher/tfp-automation/tests/extensions/provisioning"
 	"github.com/rancher/tfp-automation/tests/infrastructure/ranchers"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
@@ -54,10 +53,7 @@ func (s *TfpPostReleaseUpgradeTestSuite) TestTfpPostReleaseUpgrade() {
 			err = pods.VerifyClusterPods(s.client, cluster)
 			require.NoError(s.T(), err)
 
-			cattleConfig, err := provisioning.UniquifyTerraform(s.cattleConfig)
-			require.NoError(t, err)
-
-			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
+			params := tfpQase.GetProvisioningSchemaParams(s.terraformConfig, s.terratestConfig)
 			err = qase.UpdateSchemaParameters(tt.name, params)
 			if err != nil {
 				logrus.Warningf("Failed to upload schema parameters %s", err)

--- a/tests/rancher2/os/os_test.go
+++ b/tests/rancher2/os/os_test.go
@@ -79,7 +79,10 @@ func (o *OSValidationTestSuite) SetupSuite() {
 
 	o.permutedConfigs = make([]map[string]any, 0, len(permutedConfigs))
 	for _, permutedConfig := range permutedConfigs {
-		uniqueConfig, uniqueErr := provisioning.UniquifyTerraform(permutedConfig)
+		_, terraformConfig, _, _ := config.LoadTFPConfigs(permutedConfig)
+		uniqueTerraform := provisioning.UniquifyTerraform(terraformConfig)
+
+		uniqueConfig, uniqueErr := operations.ReplaceValue([]string{"terraform", "resourcePrefix"}, uniqueTerraform.ResourcePrefix, permutedConfig)
 		require.NoError(o.T(), uniqueErr)
 		o.permutedConfigs = append(o.permutedConfigs, uniqueConfig)
 	}
@@ -111,16 +114,12 @@ func (o *OSValidationTestSuite) TestDynamicOSValidation() {
 	newFile, rootBody, file := rancher2.InitializeMainTF(o.terratestConfig)
 	defer file.Close()
 
-	customClusterNames := []string{}
-
 	for ami, batch := range configBatches {
 		_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, o.terratestConfig.PathToRepo, "")
 		defer cleanup.Cleanup(o.T(), o.terraformOptions, keyPath)
 
 		o.standardUserClient, testUser, testPassword, err = standarduser.CreateStandardUser(o.client)
 		require.NoError(o.T(), err)
-
-		var clusterIDs []string
 
 		amiInfo, err := ec2.GetAMI(o.client, &o.awsCredentials, ami)
 		require.NoError(o.T(), err)
@@ -136,11 +135,15 @@ func (o *OSValidationTestSuite) TestDynamicOSValidation() {
 				logrus.Infof("Provisioning Cluster Type: %s, "+"K8s Version: %s, "+"CNI: %s", terraformConfig.Module, terratestConfig.KubernetesVersion, terraformConfig.CNI)
 			}
 
-			clusters, _ := provisioning.Provision(o.T(), o.client, o.standardUserClient, o.rancherConfig, o.terraformConfig, o.terratestConfig, testUser, testPassword, o.terraformOptions, batch, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, "")
+			logrus.Infof("Provisioning cluster (%s)", o.terraformConfig.ResourcePrefix)
+			clusters, _ := provisioning.Provision(o.T(), o.client, o.standardUserClient, o.rancherConfig, o.terraformConfig, o.terratestConfig, testUser, testPassword, o.terraformOptions, newFile, rootBody, file, false, false, true, "", "")
 			time.Sleep(2 * time.Minute)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", clusters[0].Name)
 			err = provisioningActions.VerifyClusterReady(o.client, clusters[0])
 			require.NoError(o.T(), err)
 
+			logrus.Infof("Verifying service account token secret (%s)", clusters[0].Name)
 			err = clusterActions.VerifyServiceAccountTokenSecret(o.client, clusters[0].Name)
 			require.NoError(o.T(), err)
 
@@ -158,8 +161,8 @@ func (o *OSValidationTestSuite) TestDynamicOSValidation() {
 			}
 		})
 
-		for _, cattleConfig := range batch {
-			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
+		for range batch {
+			params := tfpQase.GetProvisioningSchemaParams(o.terraformConfig, o.terratestConfig)
 			err = qase.UpdateSchemaParameters(testName, params)
 			if err != nil {
 				logrus.Warningf("Failed to upload schema parameters %s", err)

--- a/tests/rancher2/provisioning/dynamic_provision_custom_test.go
+++ b/tests/rancher2/provisioning/dynamic_provision_custom_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/rancher/shepherd/clients/rancher"
 	shepherdConfig "github.com/rancher/shepherd/pkg/config"
-	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
 	clusterActions "github.com/rancher/tests/actions/clusters"
 	provisioningActions "github.com/rancher/tests/actions/provisioning"
@@ -67,9 +66,6 @@ func (p *DynamicProvisionCustomTestSuite) SetupSuite() {
 func (p *DynamicProvisionCustomTestSuite) TestTfpProvisionCustomDynamicInput() {
 	var err error
 	var testUser, testPassword string
-	var clusterIDs []string
-
-	customClusterNames := []string{}
 
 	p.standardUserClient, testUser, testPassword, err = standarduser.CreateStandardUser(p.client)
 	require.NoError(p.T(), err)
@@ -89,49 +85,56 @@ func (p *DynamicProvisionCustomTestSuite) TestTfpProvisionCustomDynamicInput() {
 		p.T().Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			rancher, terraform, terratest, _ := config.LoadTFPConfigs(p.cattleConfig)
+			rancher.AdminToken = standardToken
+
 			nestedRancherModuleDir, perTestTerraformOptions, err := nested.CreateNestedModules(p.terraformConfig, p.terratestConfig, p.terraformOptions, tt.name, configs.NestedRancherModuleDir)
 			require.NoError(t, err)
 			defer os.RemoveAll(nestedRancherModuleDir)
 
 			newFile, rootBody, file := rancher2.InitializeNestedMainTFs(nestedRancherModuleDir)
 			defer file.Close()
-
-			cattleConfig, err := provisioning.UniquifyTerraform(p.cattleConfig)
-			require.NoError(t, err)
-
-			_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, standardToken, cattleConfig)
+			terratest, err = provisioning.GetK8sVersion(p.client, terraform, terratest)
 			require.NoError(p.T(), err)
 
-			provisioning.GetK8sVersion(p.client, cattleConfig)
-
-			rancher, terraform, terratest, _ := config.LoadTFPConfigs(cattleConfig)
+			terraform = provisioning.UniquifyTerraform(terraform)
 
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, p.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(p.T(), perTestTerraformOptions, keyPath)
 
-			clusters, customClusterNames := provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+			logrus.Infof("Provisioning cluster (%s)", terraform.ResourcePrefix)
+			clusters, customClusterName := provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, newFile, rootBody, file, false, false, true, "", nestedRancherModuleDir)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", clusters[0].Name)
 			err = provisioningActions.VerifyClusterReady(p.client, clusters[0])
 			require.NoError(p.T(), err)
 
+			logrus.Infof("Verifying service account token secret (%s)", clusters[0].Name)
 			err = clusterActions.VerifyServiceAccountTokenSecret(p.client, clusters[0].Name)
 			require.NoError(p.T(), err)
 
+			logrus.Infof("Verifying cluster pods (%s)", clusters[0].Name)
 			err = pods.VerifyClusterPods(p.client, clusters[0])
 			require.NoError(p.T(), err)
 
 			if strings.Contains(p.terraformConfig.Module, clustertypes.WINDOWS) {
-				clusters, _ = provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, true, true, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+				logrus.Infof("Provisioning cluster (%s)", terraform.ResourcePrefix)
+				clusters, _ = provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, newFile, rootBody, file, true, true, true, customClusterName, nestedRancherModuleDir)
+
+				logrus.Infof("Verifying the cluster is ready (%s)", clusters[0].Name)
 				err = provisioningActions.VerifyClusterReady(p.client, clusters[0])
 				require.NoError(p.T(), err)
 
+				logrus.Infof("Verifying service account token secret (%s)", clusters[0].Name)
 				err = clusterActions.VerifyServiceAccountTokenSecret(p.client, clusters[0].Name)
 				require.NoError(p.T(), err)
 
+				logrus.Infof("Verifying cluster pods (%s)", clusters[0].Name)
 				err = pods.VerifyClusterPods(p.client, clusters[0])
 				require.NoError(p.T(), err)
 			}
 
-			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
+			params := tfpQase.GetProvisioningSchemaParams(p.terraformConfig, p.terratestConfig)
 			err = qase.UpdateSchemaParameters(tt.name, params)
 			if err != nil {
 				logrus.Warningf("Failed to upload schema parameters %s", err)

--- a/tests/rancher2/provisioning/dynamic_provision_import_test.go
+++ b/tests/rancher2/provisioning/dynamic_provision_import_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/rancher/shepherd/clients/rancher"
 	shepherdConfig "github.com/rancher/shepherd/pkg/config"
-	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
 	clusterActions "github.com/rancher/tests/actions/clusters"
 	provisioningActions "github.com/rancher/tests/actions/provisioning"
@@ -66,7 +65,6 @@ func (p *DynamicUpgradeImportedClusterTestSuite) SetupSuite() {
 func (p *DynamicUpgradeImportedClusterTestSuite) TestTfpUpgradeImportedClusterDynamicInput() {
 	var err error
 	var testUser, testPassword string
-	var clusterIDs []string
 
 	p.standardUserClient, testUser, testPassword, err = standarduser.CreateStandardUser(p.client)
 	require.NoError(p.T(), err)
@@ -86,40 +84,42 @@ func (p *DynamicUpgradeImportedClusterTestSuite) TestTfpUpgradeImportedClusterDy
 		p.T().Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			rancher, terraform, terratest, _ := config.LoadTFPConfigs(p.cattleConfig)
+			rancher.AdminToken = standardToken
+
 			nestedRancherModuleDir, perTestTerraformOptions, err := nested.CreateNestedModules(p.terraformConfig, p.terratestConfig, p.terraformOptions, tt.name, configs.NestedRancherModuleDir)
 			require.NoError(t, err)
 			defer os.RemoveAll(nestedRancherModuleDir)
 
 			newFile, rootBody, file := rancher2.InitializeNestedMainTFs(nestedRancherModuleDir)
 			defer file.Close()
-
-			cattleConfig, err := provisioning.UniquifyTerraform(p.cattleConfig)
-			require.NoError(t, err)
-
-			_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, standardToken, cattleConfig)
+			terratest, err = provisioning.GetK8sVersion(p.client, terraform, terratest)
 			require.NoError(p.T(), err)
 
-			provisioning.GetK8sVersion(p.client, cattleConfig)
-
-			rancher, terraform, terratest, _ := config.LoadTFPConfigs(cattleConfig)
+			terraform = provisioning.UniquifyTerraform(terraform)
 
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, p.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(p.T(), perTestTerraformOptions, keyPath)
 
-			clusters, _ := provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, nil, nestedRancherModuleDir)
+			logrus.Infof("Provisioning cluster (%s)", terraform.ResourcePrefix)
+			clusters, _ := provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, newFile, rootBody, file, false, false, true, "", nestedRancherModuleDir)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", clusters[0].Name)
 			err = provisioningActions.VerifyClusterReady(p.client, clusters[0])
 			require.NoError(p.T(), err)
 
+			logrus.Infof("Verifying service account token secret (%s)", clusters[0].Name)
 			err = clusterActions.VerifyServiceAccountTokenSecret(p.client, clusters[0].Name)
 			require.NoError(p.T(), err)
 
+			logrus.Infof("Verifying cluster pods (%s)", clusters[0].Name)
 			err = pods.VerifyClusterPods(p.client, clusters[0])
 			require.NoError(p.T(), err)
 
 			err = imported.SetUpgradeImportedCluster(p.client, terraform)
 			require.NoError(p.T(), err)
 
-			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
+			params := tfpQase.GetProvisioningSchemaParams(p.terraformConfig, p.terratestConfig)
 			err = qase.UpdateSchemaParameters(tt.name, params)
 			if err != nil {
 				logrus.Warningf("Failed to upload schema parameters %s", err)

--- a/tests/rancher2/provisioning/dynamic_provision_test.go
+++ b/tests/rancher2/provisioning/dynamic_provision_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/rancher/shepherd/clients/rancher"
 	shepherdConfig "github.com/rancher/shepherd/pkg/config"
-	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
 	clusterActions "github.com/rancher/tests/actions/clusters"
 	provisioningActions "github.com/rancher/tests/actions/provisioning"
@@ -65,7 +64,6 @@ func (p *DynamicTfpProvisionTestSuite) SetupSuite() {
 func (p *DynamicTfpProvisionTestSuite) TestTfpProvisionDynamicInput() {
 	var err error
 	var testUser, testPassword string
-	var clusterIDs []string
 
 	p.standardUserClient, testUser, testPassword, err = standarduser.CreateStandardUser(p.client)
 	require.NoError(p.T(), err)
@@ -85,39 +83,41 @@ func (p *DynamicTfpProvisionTestSuite) TestTfpProvisionDynamicInput() {
 		p.T().Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			rancher, terraform, terratest, _ := config.LoadTFPConfigs(p.cattleConfig)
+			rancher.AdminToken = standardToken
+
 			nestedRancherModuleDir, perTestTerraformOptions, err := nested.CreateNestedModules(p.terraformConfig, p.terratestConfig, p.terraformOptions, tt.name, configs.NestedRancherModuleDir)
 			require.NoError(t, err)
 			defer os.RemoveAll(nestedRancherModuleDir)
 
 			newFile, rootBody, file := rancher2.InitializeNestedMainTFs(nestedRancherModuleDir)
 			defer file.Close()
-
-			cattleConfig, err := provisioning.UniquifyTerraform(p.cattleConfig)
-			require.NoError(t, err)
-
-			_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, standardToken, cattleConfig)
+			terratest, err = provisioning.GetK8sVersion(p.client, terraform, terratest)
 			require.NoError(p.T(), err)
 
-			provisioning.GetK8sVersion(p.client, cattleConfig)
-
-			rancher, terraform, terratest, _ := config.LoadTFPConfigs(cattleConfig)
+			terraform = provisioning.UniquifyTerraform(terraform)
 
 			tt.name = tt.name + " Module: " + p.terraformConfig.Module + " Kubernetes version: " + terratest.KubernetesVersion
 
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, p.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(p.T(), perTestTerraformOptions, keyPath)
 
-			clusters, _ := provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, false, clusterIDs, nil, nestedRancherModuleDir)
+			logrus.Infof("Provisioning cluster (%s)", terraform.ResourcePrefix)
+			clusters, _ := provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, newFile, rootBody, file, false, false, false, "", nestedRancherModuleDir)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", clusters[0].Name)
 			err = provisioningActions.VerifyClusterReady(p.client, clusters[0])
 			require.NoError(p.T(), err)
 
+			logrus.Infof("Verifying service account token secret (%s)", clusters[0].Name)
 			err = clusterActions.VerifyServiceAccountTokenSecret(p.client, clusters[0].Name)
 			require.NoError(p.T(), err)
 
+			logrus.Infof("Verifying cluster pods (%s)", clusters[0].Name)
 			err = pods.VerifyClusterPods(p.client, clusters[0])
 			require.NoError(p.T(), err)
 
-			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
+			params := tfpQase.GetProvisioningSchemaParams(p.terraformConfig, p.terratestConfig)
 			err = qase.UpdateSchemaParameters(tt.name, params)
 			if err != nil {
 				logrus.Warningf("Failed to upload schema parameters %s", err)

--- a/tests/rancher2/provisioning/provision_ace_test.go
+++ b/tests/rancher2/provisioning/provision_ace_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/rancher/shepherd/clients/rancher"
 	shepherdConfig "github.com/rancher/shepherd/pkg/config"
-	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
 	clusterActions "github.com/rancher/tests/actions/clusters"
 	provisioningActions "github.com/rancher/tests/actions/provisioning"
@@ -65,7 +64,6 @@ func (p *ProvisionACETestSuite) SetupSuite() {
 func (p *ProvisionACETestSuite) TestTfpProvisionACE() {
 	var err error
 	var testUser, testPassword string
-	var clusterIDs []string
 
 	p.standardUserClient, testUser, testPassword, err = standarduser.CreateStandardUser(p.client)
 	require.NoError(p.T(), err)
@@ -96,48 +94,44 @@ func (p *ProvisionACETestSuite) TestTfpProvisionACE() {
 		p.T().Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			rancher, terraform, terratest, _ := config.LoadTFPConfigs(p.cattleConfig)
+			rancher.AdminToken = standardToken
+			terratest.Nodepools = tt.nodeRoles
+			terraform.LocalAuthEndpoint = tt.authEndpoint.LocalAuthEndpoint
+			terraform.Module = tt.module
+
 			nestedRancherModuleDir, perTestTerraformOptions, err := nested.CreateNestedModules(p.terraformConfig, p.terratestConfig, p.terraformOptions, tt.name, configs.NestedRancherModuleDir)
 			require.NoError(t, err)
 			defer os.RemoveAll(nestedRancherModuleDir)
 
 			newFile, rootBody, file := rancher2.InitializeNestedMainTFs(nestedRancherModuleDir)
 			defer file.Close()
-
-			cattleConfig, err := provisioning.UniquifyTerraform(p.cattleConfig)
-			require.NoError(t, err)
-
-			_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, standardToken, cattleConfig)
+			terratest, err = provisioning.GetK8sVersion(p.client, terraform, terratest)
 			require.NoError(p.T(), err)
 
-			_, err = operations.ReplaceValue([]string{"terratest", "nodepools"}, tt.nodeRoles, cattleConfig)
-			require.NoError(p.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "localAuthEndpoint"}, tt.authEndpoint.LocalAuthEndpoint, cattleConfig)
-			require.NoError(p.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "module"}, tt.module, cattleConfig)
-			require.NoError(p.T(), err)
-
-			provisioning.GetK8sVersion(p.client, cattleConfig)
-
-			rancher, terraform, terratest, _ := config.LoadTFPConfigs(cattleConfig)
+			terraform = provisioning.UniquifyTerraform(terraform)
 
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, p.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(p.T(), perTestTerraformOptions, keyPath)
 
-			clusters, _ := provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, nil, nestedRancherModuleDir)
+			logrus.Infof("Provisioning cluster (%s)", terraform.ResourcePrefix)
+			clusters, _ := provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, newFile, rootBody, file, false, false, true, "", nestedRancherModuleDir)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", clusters[0].Name)
 			err = provisioningActions.VerifyClusterReady(p.client, clusters[0])
 			require.NoError(p.T(), err)
 
+			logrus.Infof("Verifying service account token secret (%s)", clusters[0].Name)
 			err = clusterActions.VerifyServiceAccountTokenSecret(p.client, clusters[0].Name)
 			require.NoError(p.T(), err)
 
+			logrus.Infof("Verifying cluster pods (%s)", clusters[0].Name)
 			err = pods.VerifyClusterPods(p.client, clusters[0])
 			require.NoError(p.T(), err)
 
 			provisioningActions.VerifyACE(p.T(), p.client, clusters[0])
 
-			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
+			params := tfpQase.GetProvisioningSchemaParams(p.terraformConfig, p.terratestConfig)
 			err = qase.UpdateSchemaParameters(tt.name, params)
 			if err != nil {
 				logrus.Warningf("Failed to upload schema parameters %s", err)

--- a/tests/rancher2/provisioning/provision_custom_test.go
+++ b/tests/rancher2/provisioning/provision_custom_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/rancher/shepherd/clients/rancher"
 	shepherdConfig "github.com/rancher/shepherd/pkg/config"
-	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
 	clusterActions "github.com/rancher/tests/actions/clusters"
 	provisioningActions "github.com/rancher/tests/actions/provisioning"
@@ -68,9 +67,6 @@ func (p *ProvisionCustomTestSuite) SetupSuite() {
 func (p *ProvisionCustomTestSuite) TestTfpProvisionCustom() {
 	var err error
 	var testUser, testPassword string
-	var clusterIDs []string
-
-	customClusterNames := []string{}
 
 	p.standardUserClient, testUser, testPassword, err = standarduser.CreateStandardUser(p.client)
 	require.NoError(p.T(), err)
@@ -94,6 +90,10 @@ func (p *ProvisionCustomTestSuite) TestTfpProvisionCustom() {
 		p.T().Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			rancher, terraform, terratest, _ := config.LoadTFPConfigs(p.cattleConfig)
+			rancher.AdminToken = standardToken
+			terraform.Module = tt.module
+
 			nestedRancherModuleDir, perTestTerraformOptions, err := nested.CreateNestedModules(p.terraformConfig, p.terratestConfig, p.terraformOptions, tt.name, configs.NestedRancherModuleDir)
 			require.NoError(t, err)
 			defer os.RemoveAll(nestedRancherModuleDir)
@@ -101,45 +101,47 @@ func (p *ProvisionCustomTestSuite) TestTfpProvisionCustom() {
 			newFile, rootBody, file := rancher2.InitializeNestedMainTFs(nestedRancherModuleDir)
 			defer file.Close()
 
-			cattleConfig, err := provisioning.UniquifyTerraform(p.cattleConfig)
-			require.NoError(t, err)
-
-			_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, standardToken, cattleConfig)
+			terratest, err = provisioning.GetK8sVersion(p.client, terraform, terratest)
 			require.NoError(p.T(), err)
 
-			_, err = operations.ReplaceValue([]string{"terraform", "module"}, tt.module, cattleConfig)
-			require.NoError(p.T(), err)
-
-			provisioning.GetK8sVersion(p.client, cattleConfig)
-
-			rancher, terraform, terratest, _ := config.LoadTFPConfigs(cattleConfig)
+			terraform = provisioning.UniquifyTerraform(terraform)
 
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, p.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(p.T(), perTestTerraformOptions, keyPath)
 
-			clusters, customClusterNames := provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+			logrus.Infof("Provisioning cluster (%s)", terraform.ResourcePrefix)
+			clusters, customClusterName := provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, newFile, rootBody, file, false, false, true, "", nestedRancherModuleDir)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", clusters[0].Name)
 			err = provisioningActions.VerifyClusterReady(p.client, clusters[0])
 			require.NoError(p.T(), err)
 
+			logrus.Infof("Verifying service account token secret (%s)", clusters[0].Name)
 			err = clusterActions.VerifyServiceAccountTokenSecret(p.client, clusters[0].Name)
 			require.NoError(p.T(), err)
 
+			logrus.Infof("Verifying cluster pods (%s)", clusters[0].Name)
 			err = pods.VerifyClusterPods(p.client, clusters[0])
 			require.NoError(p.T(), err)
 
 			if strings.Contains(terraform.Module, clustertypes.WINDOWS) {
-				clusters, _ = provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, true, true, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+				logrus.Infof("Provisioning cluster (%s)", terraform.ResourcePrefix)
+				clusters, _ = provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, newFile, rootBody, file, true, true, true, customClusterName, nestedRancherModuleDir)
+
+				logrus.Infof("Verifying the cluster is ready (%s)", clusters[0].Name)
 				err = provisioningActions.VerifyClusterReady(p.client, clusters[0])
 				require.NoError(p.T(), err)
 
+				logrus.Infof("Verifying service account token secret (%s)", clusters[0].Name)
 				err = clusterActions.VerifyServiceAccountTokenSecret(p.client, clusters[0].Name)
 				require.NoError(p.T(), err)
 
+				logrus.Infof("Verifying cluster pods (%s)", clusters[0].Name)
 				err = pods.VerifyClusterPods(p.client, clusters[0])
 				require.NoError(p.T(), err)
 			}
 
-			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
+			params := tfpQase.GetProvisioningSchemaParams(p.terraformConfig, p.terratestConfig)
 			err = qase.UpdateSchemaParameters(tt.name, params)
 			if err != nil {
 				logrus.Warningf("Failed to upload schema parameters %s", err)

--- a/tests/rancher2/provisioning/provision_data_directory_test.go
+++ b/tests/rancher2/provisioning/provision_data_directory_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/rancher/shepherd/clients/rancher"
 	shepherdConfig "github.com/rancher/shepherd/pkg/config"
-	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
 	clusterActions "github.com/rancher/tests/actions/clusters"
 	provisioningActions "github.com/rancher/tests/actions/provisioning"
@@ -65,7 +64,6 @@ func (p *ProvisionDataDirectoryTestSuite) SetupSuite() {
 func (p *ProvisionDataDirectoryTestSuite) TestTfpProvisionDataDirectory() {
 	var err error
 	var testUser, testPassword string
-	var clusterIDs []string
 
 	p.standardUserClient, testUser, testPassword, err = standarduser.CreateStandardUser(p.client)
 	require.NoError(p.T(), err)
@@ -100,46 +98,42 @@ func (p *ProvisionDataDirectoryTestSuite) TestTfpProvisionDataDirectory() {
 		p.T().Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			rancher, terraform, terratest, _ := config.LoadTFPConfigs(p.cattleConfig)
+			rancher.AdminToken = standardToken
+			terratest.Nodepools = tt.nodeRoles
+			terraform.DataDirectories = tt.dataDirectories.DataDirectories
+			terraform.Module = tt.module
+
 			nestedRancherModuleDir, perTestTerraformOptions, err := nested.CreateNestedModules(p.terraformConfig, p.terratestConfig, p.terraformOptions, tt.name, configs.NestedRancherModuleDir)
 			require.NoError(t, err)
 			defer os.RemoveAll(nestedRancherModuleDir)
 
 			newFile, rootBody, file := rancher2.InitializeNestedMainTFs(nestedRancherModuleDir)
 			defer file.Close()
-
-			cattleConfig, err := provisioning.UniquifyTerraform(p.cattleConfig)
-			require.NoError(t, err)
-
-			_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, standardToken, cattleConfig)
+			terratest, err = provisioning.GetK8sVersion(p.client, terraform, terratest)
 			require.NoError(p.T(), err)
 
-			_, err = operations.ReplaceValue([]string{"terratest", "nodepools"}, tt.nodeRoles, cattleConfig)
-			require.NoError(p.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "dataDirectories"}, tt.dataDirectories.DataDirectories, cattleConfig)
-			require.NoError(p.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "module"}, tt.module, cattleConfig)
-			require.NoError(p.T(), err)
-
-			provisioning.GetK8sVersion(p.client, cattleConfig)
-
-			rancher, terraform, terratest, _ := config.LoadTFPConfigs(cattleConfig)
+			terraform = provisioning.UniquifyTerraform(terraform)
 
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, p.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(p.T(), perTestTerraformOptions, keyPath)
 
-			clusters, _ := provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, false, clusterIDs, nil, nestedRancherModuleDir)
+			logrus.Infof("Provisioning cluster (%s)", terraform.ResourcePrefix)
+			clusters, _ := provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, newFile, rootBody, file, false, false, false, "", nestedRancherModuleDir)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", clusters[0].Name)
 			err = provisioningActions.VerifyClusterReady(p.client, clusters[0])
 			require.NoError(p.T(), err)
 
+			logrus.Infof("Verifying service account token secret (%s)", clusters[0].Name)
 			err = clusterActions.VerifyServiceAccountTokenSecret(p.client, clusters[0].Name)
 			require.NoError(p.T(), err)
 
+			logrus.Infof("Verifying cluster pods (%s)", clusters[0].Name)
 			err = pods.VerifyClusterPods(p.client, clusters[0])
 			require.NoError(p.T(), err)
 
-			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
+			params := tfpQase.GetProvisioningSchemaParams(p.terraformConfig, p.terratestConfig)
 			err = qase.UpdateSchemaParameters(tt.name, params)
 			if err != nil {
 				logrus.Warningf("Failed to upload schema parameters %s", err)

--- a/tests/rancher2/provisioning/provision_import_test.go
+++ b/tests/rancher2/provisioning/provision_import_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/rancher/shepherd/clients/rancher"
 	shepherdConfig "github.com/rancher/shepherd/pkg/config"
-	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
 	clusterActions "github.com/rancher/tests/actions/clusters"
 	provisioningActions "github.com/rancher/tests/actions/provisioning"
@@ -68,7 +67,6 @@ func (p *UpgradeImportedClusterTestSuite) SetupSuite() {
 func (p *UpgradeImportedClusterTestSuite) TestTfpUpgradeImportedCluster() {
 	var err error
 	var testUser, testPassword string
-	var clusterIDs []string
 
 	p.standardUserClient, testUser, testPassword, err = standarduser.CreateStandardUser(p.client)
 	require.NoError(p.T(), err)
@@ -98,6 +96,10 @@ func (p *UpgradeImportedClusterTestSuite) TestTfpUpgradeImportedCluster() {
 		p.T().Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			rancher, terraform, terratest, _ := config.LoadTFPConfigs(p.cattleConfig)
+			rancher.AdminToken = standardToken
+			terraform.Module = tt.module
+
 			nestedRancherModuleDir, perTestTerraformOptions, err := nested.CreateNestedModules(p.terraformConfig, p.terratestConfig, p.terraformOptions, tt.name, configs.NestedRancherModuleDir)
 			require.NoError(t, err)
 			defer os.RemoveAll(nestedRancherModuleDir)
@@ -105,34 +107,30 @@ func (p *UpgradeImportedClusterTestSuite) TestTfpUpgradeImportedCluster() {
 			newFile, rootBody, file := rancher2.InitializeNestedMainTFs(nestedRancherModuleDir)
 			defer file.Close()
 
-			cattleConfig, err := provisioning.UniquifyTerraform(p.cattleConfig)
-			require.NoError(t, err)
-
-			_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, standardToken, cattleConfig)
-			require.NoError(p.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "module"}, tt.module, cattleConfig)
-			require.NoError(p.T(), err)
-
-			rancher, terraform, terratest, _ := config.LoadTFPConfigs(cattleConfig)
+			terraform = provisioning.UniquifyTerraform(terraform)
 
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, p.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(p.T(), perTestTerraformOptions, keyPath)
 
-			clusters, _ := provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, nil, nestedRancherModuleDir)
+			logrus.Infof("Provisioning cluster (%s)", terraform.ResourcePrefix)
+			clusters, _ := provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, newFile, rootBody, file, false, false, true, "", nestedRancherModuleDir)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", clusters[0].Name)
 			err = provisioningActions.VerifyClusterReady(p.client, clusters[0])
 			require.NoError(p.T(), err)
 
+			logrus.Infof("Verifying service account token secret (%s)", clusters[0].Name)
 			err = clusterActions.VerifyServiceAccountTokenSecret(p.client, clusters[0].Name)
 			require.NoError(p.T(), err)
 
+			logrus.Infof("Verifying cluster pods (%s)", clusters[0].Name)
 			err = pods.VerifyClusterPods(p.client, clusters[0])
 			require.NoError(p.T(), err)
 
 			err = imported.SetUpgradeImportedCluster(p.client, terraform)
 			require.NoError(p.T(), err)
 
-			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
+			params := tfpQase.GetProvisioningSchemaParams(p.terraformConfig, p.terratestConfig)
 			err = qase.UpdateSchemaParameters(tt.name, params)
 			if err != nil {
 				logrus.Warningf("Failed to upload schema parameters %s", err)

--- a/tests/rancher2/provisioning/provision_test.go
+++ b/tests/rancher2/provisioning/provision_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/rancher/shepherd/clients/rancher"
 	shepherdConfig "github.com/rancher/shepherd/pkg/config"
-	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
 	clusterActions "github.com/rancher/tests/actions/clusters"
 	provisioningActions "github.com/rancher/tests/actions/provisioning"
@@ -65,7 +64,6 @@ func (p *ProvisionTestSuite) SetupSuite() {
 func (p *ProvisionTestSuite) TestTfpProvision() {
 	var err error
 	var testUser, testPassword string
-	var clusterIDs []string
 
 	p.standardUserClient, testUser, testPassword, err = standarduser.CreateStandardUser(p.client)
 	require.NoError(p.T(), err)
@@ -88,6 +86,10 @@ func (p *ProvisionTestSuite) TestTfpProvision() {
 		p.T().Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			rancher, terraform, terratest, _ := config.LoadTFPConfigs(p.cattleConfig)
+			rancher.AdminToken = standardToken
+			terratest.Nodepools = tt.nodeRoles
+
 			nestedRancherModuleDir, perTestTerraformOptions, err := nested.CreateNestedModules(p.terraformConfig, p.terratestConfig, p.terraformOptions, tt.name, configs.NestedRancherModuleDir)
 			require.NoError(t, err)
 			defer os.RemoveAll(nestedRancherModuleDir)
@@ -95,33 +97,30 @@ func (p *ProvisionTestSuite) TestTfpProvision() {
 			newFile, rootBody, file := rancher2.InitializeNestedMainTFs(nestedRancherModuleDir)
 			defer file.Close()
 
-			cattleConfig, err := provisioning.UniquifyTerraform(p.cattleConfig)
-			require.NoError(t, err)
-
-			_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, standardToken, cattleConfig)
+			terratest, err = provisioning.GetK8sVersion(p.client, terraform, terratest)
 			require.NoError(p.T(), err)
 
-			_, err = operations.ReplaceValue([]string{"terratest", "nodepools"}, tt.nodeRoles, cattleConfig)
-			require.NoError(p.T(), err)
-
-			provisioning.GetK8sVersion(p.client, cattleConfig)
-
-			rancher, terraform, terratest, _ := config.LoadTFPConfigs(cattleConfig)
+			terraform = provisioning.UniquifyTerraform(terraform)
 
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, p.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(p.T(), perTestTerraformOptions, keyPath)
 
-			clusters, _ := provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, false, clusterIDs, nil, nestedRancherModuleDir)
+			logrus.Infof("Provisioning cluster (%s)", terraform.ResourcePrefix)
+			clusters, _ := provisioning.Provision(p.T(), p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, newFile, rootBody, file, false, false, false, "", nestedRancherModuleDir)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", clusters[0].Name)
 			err = provisioningActions.VerifyClusterReady(p.client, clusters[0])
 			require.NoError(p.T(), err)
 
+			logrus.Infof("Verifying service account token secret (%s)", clusters[0].Name)
 			err = clusterActions.VerifyServiceAccountTokenSecret(p.client, clusters[0].Name)
 			require.NoError(p.T(), err)
 
+			logrus.Infof("Verifying cluster pods (%s)", clusters[0].Name)
 			err = pods.VerifyClusterPods(p.client, clusters[0])
 			require.NoError(p.T(), err)
 
-			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
+			params := tfpQase.GetProvisioningSchemaParams(p.terraformConfig, p.terratestConfig)
 			err = qase.UpdateSchemaParameters(tt.name, params)
 			if err != nil {
 				logrus.Warningf("Failed to upload schema parameters %s", err)

--- a/tests/rancher2/provisioning/schemas/schemas.yaml
+++ b/tests/rancher2/provisioning/schemas/schemas.yaml
@@ -4,397 +4,704 @@
   suite: Go Automation/TFP/Provisioning
   cases:
   - description: Provisions downstream RKE2/K3S node driver cluster
+    preconditions: null
+    postconditions: null
     title: 8_nodes_3_etcd_2_cp_3_worker
+    severity: null
     priority: 4
+    behavior: null
     type: 8
-    is_flaky: 0
+    layer: null
+    isflaky: null
+    suiteid: null
+    milestoneid: null
     automation: 2
+    status: null
+    attachments: []
     steps:
     - action: Provision downstream RKE2/K3S cluster
       expectedresult: ""
       data: ""
       position: 1
       attachments: []
+      steps: []
     - action: Post cluster creation checks
       expectedresult: ""
       data: ""
       position: 2
       attachments: []
-    custom_field:
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
       "14": Validation
       "18": Hostbusters
-
+    createdat: null
+    updatedat: null
   - description: Provisions downstream RKE2 custom cluster
+    preconditions: null
+    postconditions: null
     title: Custom_TFP_RKE2
+    severity: null
     priority: 4
+    behavior: null
     type: 8
-    is_flaky: 0
+    layer: null
+    isflaky: null
+    suiteid: null
+    milestoneid: null
     automation: 2
+    status: null
+    attachments: []
     steps:
     - action: Provision downstream RKE2 custom cluster
       expectedresult: ""
       data: ""
       position: 1
       attachments: []
+      steps: []
     - action: Post cluster creation checks
       expectedresult: ""
       data: ""
       position: 2
       attachments: []
-    custom_field:
+      steps: []
+    tags: []
+    params: {}
+    parameters:
+    - parametergroup: null
+      parametershared: null
+      parametersingle: null
+    - parametergroup: null
+      parametershared: null
+      parametersingle: null
+    - parametergroup: null
+      parametershared: null
+      parametersingle:
+        title: CNI
+        values:
+        - calico
+    - parametergroup: null
+      parametershared: null
+      parametersingle: null
+    - parametergroup: null
+      parametershared: null
+      parametersingle: null
+    - parametergroup: null
+      parametershared: null
+      parametersingle:
+        title: K8sVersion
+        values:
+        - v1.34.5+k3s1
+    - parametergroup: null
+      parametershared: null
+      parametersingle: null
+    customfield:
       "14": Validation
       "18": Hostbusters
-
+    createdat: null
+    updatedat: null
   - description: Provisions downstream RKE2 Windows 2019 custom cluster
+    preconditions: null
+    postconditions: null
     title: Custom_TFP_RKE2_Windows_2019
+    severity: null
     priority: 4
+    behavior: null
     type: 8
-    is_flaky: 0
+    layer: null
+    isflaky: null
+    suiteid: null
+    milestoneid: null
     automation: 2
+    status: null
+    attachments: []
     steps:
     - action: Provision downstream RKE2 Windows 2019 custom cluster
       expectedresult: ""
       data: ""
       position: 1
       attachments: []
+      steps: []
     - action: Post cluster creation checks
       expectedresult: ""
       data: ""
       position: 2
       attachments: []
-    custom_field:
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
       "14": Validation
       "18": Hostbusters
-
+    createdat: null
+    updatedat: null
   - description: Provisions downstream RKE2 Windows 2022 custom cluster
+    preconditions: null
+    postconditions: null
     title: Custom_TFP_RKE2_Windows_2022
+    severity: null
     priority: 4
+    behavior: null
     type: 8
-    is_flaky: 0
+    layer: null
+    isflaky: null
+    suiteid: null
+    milestoneid: null
     automation: 2
+    status: null
+    attachments: []
     steps:
     - action: Provision downstream RKE2 Windows 2022 custom cluster
       expectedresult: ""
       data: ""
       position: 1
       attachments: []
+      steps: []
     - action: Post cluster creation checks
       expectedresult: ""
       data: ""
       position: 2
       attachments: []
-    custom_field:
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
       "14": Validation
       "18": Hostbusters
-
+    createdat: null
+    updatedat: null
   - description: Provisions downstream K3S custom cluster
+    preconditions: null
+    postconditions: null
     title: Custom_TFP_K3S
+    severity: null
     priority: 4
+    behavior: null
     type: 8
-    is_flaky: 0
+    layer: null
+    isflaky: null
+    suiteid: null
+    milestoneid: null
     automation: 2
+    status: null
+    attachments: []
     steps:
     - action: Provision downstream K3S custom cluster
       expectedresult: ""
       data: ""
       position: 1
       attachments: []
+      steps: []
     - action: Post cluster creation checks
       expectedresult: ""
       data: ""
       position: 2
       attachments: []
-    custom_field:
+      steps: []
+    tags: []
+    params: {}
+    parameters:
+    - parametergroup: null
+      parametershared: null
+      parametersingle: null
+    - parametergroup: null
+      parametershared: null
+      parametersingle: null
+    - parametergroup: null
+      parametershared: null
+      parametersingle:
+        title: CNI
+        values:
+        - calico
+    - parametergroup: null
+      parametershared: null
+      parametersingle: null
+    - parametergroup: null
+      parametershared: null
+      parametersingle: null
+    - parametergroup: null
+      parametershared: null
+      parametersingle:
+        title: K8sVersion
+        values:
+        - v1.34.5+k3s1
+    - parametergroup: null
+      parametershared: null
+      parametersingle: null
+    customfield:
       "14": Validation
       "18": Hostbusters
-
+    createdat: null
+    updatedat: null
   - description: Upgrade imported RKE2 cluster
+    preconditions: null
+    postconditions: null
     title: Upgrade_Imported_RKE2
+    severity: null
     priority: 4
+    behavior: null
     type: 8
-    is_flaky: 0
+    layer: null
+    isflaky: null
+    suiteid: null
+    milestoneid: null
     automation: 2
+    status: null
+    attachments: []
     steps:
     - action: Import RKE2 cluster
       expectedresult: ""
       data: ""
       position: 1
       attachments: []
+      steps: []
     - action: Post imported cluster checks
       expectedresult: ""
       data: ""
       position: 2
       attachments: []
+      steps: []
     - action: Upgrade imported RKE2 cluster
       expectedresult: ""
       data: ""
       position: 3
       attachments: []
+      steps: []
     - action: Post upgrade checks
       expectedresult: ""
       data: ""
       position: 4
       attachments: []
-    custom_field:
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
       "14": Validation
       "18": Hostbusters
-
+    createdat: null
+    updatedat: null
   - description: Upgrade imported RKE2 Windows 2019 cluster
+    preconditions: null
+    postconditions: null
     title: Upgrade_Imported_RKE2_Windows_2019
+    severity: null
     priority: 4
+    behavior: null
     type: 8
-    is_flaky: 0
+    layer: null
+    isflaky: null
+    suiteid: null
+    milestoneid: null
     automation: 2
+    status: null
+    attachments: []
     steps:
     - action: Import RKE2 Windows 2019 cluster
       expectedresult: ""
       data: ""
       position: 1
       attachments: []
+      steps: []
     - action: Post imported cluster checks
       expectedresult: ""
       data: ""
       position: 2
       attachments: []
+      steps: []
     - action: Upgrade imported RKE2 Windows 2019 cluster
       expectedresult: ""
       data: ""
       position: 3
       attachments: []
+      steps: []
     - action: Post upgrade checks
       expectedresult: ""
       data: ""
       position: 4
       attachments: []
-    custom_field:
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
       "14": Validation
       "18": Hostbusters
-
+    createdat: null
+    updatedat: null
   - description: Upgrade imported RKE2 Windows 2022 cluster
+    preconditions: null
+    postconditions: null
     title: Upgrade_Imported_RKE2_Windows_2022
+    severity: null
     priority: 4
+    behavior: null
     type: 8
-    is_flaky: 0
+    layer: null
+    isflaky: null
+    suiteid: null
+    milestoneid: null
     automation: 2
+    status: null
+    attachments: []
     steps:
     - action: Import RKE2 Windows 2022 cluster
       expectedresult: ""
       data: ""
       position: 1
       attachments: []
+      steps: []
     - action: Post imported cluster checks
       expectedresult: ""
       data: ""
       position: 2
       attachments: []
+      steps: []
     - action: Upgrade imported RKE2 Windows 2022 cluster
       expectedresult: ""
       data: ""
       position: 3
       attachments: []
+      steps: []
     - action: Post upgrade checks
       expectedresult: ""
       data: ""
       position: 4
       attachments: []
-    custom_field:
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
       "14": Validation
       "18": Hostbusters
-
+    createdat: null
+    updatedat: null
   - description: Upgrade imported K3S cluster
+    preconditions: null
+    postconditions: null
     title: Upgrade_Imported_K3S
+    severity: null
     priority: 4
+    behavior: null
     type: 8
-    is_flaky: 0
+    layer: null
+    isflaky: null
+    suiteid: null
+    milestoneid: null
     automation: 2
+    status: null
+    attachments: []
     steps:
     - action: Import K3S cluster
       expectedresult: ""
       data: ""
       position: 1
       attachments: []
+      steps: []
     - action: Post imported cluster checks
       expectedresult: ""
       data: ""
       position: 2
       attachments: []
+      steps: []
     - action: Upgrade imported K3S cluster
       expectedresult: ""
       data: ""
       position: 3
       attachments: []
+      steps: []
     - action: Post upgrade checks
       expectedresult: ""
       data: ""
       position: 4
       attachments: []
-    custom_field:
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
       "14": Validation
       "18": Hostbusters
-
+    createdat: null
+    updatedat: null
   - description: Provision AKS hosted cluster
+    preconditions: null
+    postconditions: null
     title: Provision_AKS_Cluster
+    severity: null
     priority: 4
+    behavior: null
     type: 8
-    is_flaky: 0
+    layer: null
+    isflaky: null
+    suiteid: null
+    milestoneid: null
     automation: 2
+    status: null
+    attachments: []
     steps:
     - action: Provision AKS hosted cluster
       expectedresult: ""
       data: ""
       position: 1
       attachments: []
+      steps: []
     - action: Post cluster creation checks
       expectedresult: ""
       data: ""
       position: 2
       attachments: []
-    custom_field:
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
       "14": Validation
       "18": Hostbusters
-
+    createdat: null
+    updatedat: null
   - description: Provision EKS hosted cluster
+    preconditions: null
+    postconditions: null
     title: Provision_EKS_Cluster
+    severity: null
     priority: 4
+    behavior: null
     type: 8
-    is_flaky: 0
+    layer: null
+    isflaky: null
+    suiteid: null
+    milestoneid: null
     automation: 2
+    status: null
+    attachments: []
     steps:
     - action: Provision EKS hosted cluster
       expectedresult: ""
       data: ""
       position: 1
       attachments: []
+      steps: []
     - action: Post cluster creation checks
       expectedresult: ""
       data: ""
       position: 2
       attachments: []
-    custom_field:
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
       "14": Validation
       "18": Hostbusters
-
+    createdat: null
+    updatedat: null
   - description: Provision GKE hosted cluster
+    preconditions: null
+    postconditions: null
     title: Provision_GKE_Cluster
+    severity: null
     priority: 4
+    behavior: null
     type: 8
-    is_flaky: 0
+    layer: null
+    isflaky: null
+    suiteid: null
+    milestoneid: null
     automation: 2
+    status: null
+    attachments: []
     steps:
     - action: Provision GKE hosted cluster
       expectedresult: ""
       data: ""
       position: 1
       attachments: []
+      steps: []
     - action: Post cluster creation checks
       expectedresult: ""
       data: ""
       position: 2
       attachments: []
-    custom_field:
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
       "14": Validation
       "18": Hostbusters
-
+    createdat: null
+    updatedat: null
   - description: Provisions downstream RKE2 cluster with custom data directory
+    preconditions: null
+    postconditions: null
     title: RKE2_Data_Directory
+    severity: null
     priority: 4
+    behavior: null
     type: 8
-    is_flaky: 0
+    layer: null
+    isflaky: null
+    suiteid: null
+    milestoneid: null
     automation: 2
+    status: null
+    attachments: []
     steps:
     - action: Provision downstream RKE2 node driver cluster
       expectedresult: ""
       data: ""
       position: 1
       attachments: []
+      steps: []
     - action: Post cluster creation checks
       expectedresult: ""
       data: ""
       position: 2
       attachments: []
+      steps: []
     - action: Verify data directories
       expectedresult: ""
       data: ""
       position: 2
       attachments: []
-    custom_field:
-        "14": Validation
-        "18": Hostbusters
-
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
+      "14": Validation
+      "18": Hostbusters
+    createdat: null
+    updatedat: null
   - description: Provisions downstream K3S cluster with custom data directory
+    preconditions: null
+    postconditions: null
     title: K3S_Data_Directory
+    severity: null
     priority: 4
+    behavior: null
     type: 8
-    is_flaky: 0
+    layer: null
+    isflaky: null
+    suiteid: null
+    milestoneid: null
     automation: 2
+    status: null
+    attachments: []
     steps:
     - action: Provision downstream K3S node driver cluster
       expectedresult: ""
       data: ""
       position: 1
       attachments: []
+      steps: []
     - action: Post cluster creation checks
       expectedresult: ""
       data: ""
       position: 2
       attachments: []
+      steps: []
     - action: Verify data directories
       expectedresult: ""
       data: ""
       position: 2
       attachments: []
-    custom_field:
-        "14": Validation
-        "18": Hostbusters
-
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
+      "14": Validation
+      "18": Hostbusters
+    createdat: null
+    updatedat: null
   - description: Provisions downstream RKE2 cluster with ACE enabled
+    preconditions: null
+    postconditions: null
     title: RKE2_ACE
+    severity: null
     priority: 4
+    behavior: null
     type: 8
-    is_flaky: 0
+    layer: null
+    isflaky: null
+    suiteid: null
+    milestoneid: null
     automation: 2
+    status: null
+    attachments: []
     steps:
     - action: Provision downstream RKE2 node driver cluster
       expectedresult: ""
       data: ""
       position: 1
       attachments: []
+      steps: []
     - action: Post cluster creation checks
       expectedresult: ""
       data: ""
       position: 2
       attachments: []
+      steps: []
     - action: Verify ACE functionality
       expectedresult: ""
       data: ""
       position: 2
       attachments: []
-    custom_field:
-        "14": Validation
-        "18": Hostbusters
-
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
+      "14": Validation
+      "18": Hostbusters
+    createdat: null
+    updatedat: null
   - description: Provisions downstream K3S cluster with ACE enabled
+    preconditions: null
+    postconditions: null
     title: K3S_ACE
+    severity: null
     priority: 4
+    behavior: null
     type: 8
-    is_flaky: 0
+    layer: null
+    isflaky: null
+    suiteid: null
+    milestoneid: null
     automation: 2
+    status: null
+    attachments: []
     steps:
     - action: Provision downstream K3S node driver cluster
       expectedresult: ""
       data: ""
       position: 1
       attachments: []
+      steps: []
     - action: Post cluster creation checks
       expectedresult: ""
       data: ""
       position: 2
       attachments: []
+      steps: []
     - action: Verify ACE functionality
       expectedresult: ""
       data: ""
       position: 2
       attachments: []
-    custom_field:
-        "14": Validation
-        "18": Hostbusters
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
+      "14": Validation
+      "18": Hostbusters
+    createdat: null
+    updatedat: null

--- a/tests/rancher2/psact/psact_test.go
+++ b/tests/rancher2/psact/psact_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/rancher/shepherd/clients/rancher"
 	shepherdConfig "github.com/rancher/shepherd/pkg/config"
-	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
 	clusterActions "github.com/rancher/tests/actions/clusters"
 	provisioningActions "github.com/rancher/tests/actions/provisioning"
@@ -65,7 +64,6 @@ func (p *PSACTTestSuite) SetupSuite() {
 func (p *PSACTTestSuite) TestTfpPSACT() {
 	var err error
 	var testUser, testPassword string
-	var clusterIDs []string
 
 	p.standardUserClient, testUser, testPassword, err = standarduser.CreateStandardUser(p.client)
 	require.NoError(p.T(), err)
@@ -96,48 +94,44 @@ func (p *PSACTTestSuite) TestTfpPSACT() {
 		p.T().Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			rancher, terraform, terratest, _ := config.LoadTFPConfigs(p.cattleConfig)
+			rancher.AdminToken = standardToken
+			terraform.Module = tt.module
+			terratest.Nodepools = tt.nodeRoles
+			terratest.PSACT = string(tt.psact)
+
 			nestedRancherModuleDir, perTestTerraformOptions, err := nested.CreateNestedModules(p.terraformConfig, p.terratestConfig, p.terraformOptions, tt.name, configs.NestedRancherModuleDir)
 			require.NoError(t, err)
 			defer os.RemoveAll(nestedRancherModuleDir)
 
 			newFile, rootBody, file := rancher2.InitializeNestedMainTFs(nestedRancherModuleDir)
 			defer file.Close()
-
-			cattleConfig, err := provisioning.UniquifyTerraform(p.cattleConfig)
+			terratest, err = provisioning.GetK8sVersion(p.client, terraform, terratest)
 			require.NoError(t, err)
 
-			_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, standardToken, cattleConfig)
-			require.NoError(t, err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "module"}, tt.module, cattleConfig)
-			require.NoError(t, err)
-
-			_, err = operations.ReplaceValue([]string{"terratest", "nodepools"}, tt.nodeRoles, cattleConfig)
-			require.NoError(t, err)
-
-			_, err = operations.ReplaceValue([]string{"terratest", "psact"}, tt.psact, cattleConfig)
-			require.NoError(t, err)
-
-			provisioning.GetK8sVersion(p.client, cattleConfig)
-
-			rancher, terraform, terratest, _ := config.LoadTFPConfigs(cattleConfig)
+			terraform = provisioning.UniquifyTerraform(terraform)
 
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, p.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(p.T(), perTestTerraformOptions, keyPath)
 
-			clusters, _ := provisioning.Provision(t, p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, false, clusterIDs, nil, nestedRancherModuleDir)
+			logrus.Infof("Provisioning cluster (%s)", terraform.ResourcePrefix)
+			clusters, _ := provisioning.Provision(t, p.client, p.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, newFile, rootBody, file, false, false, false, "", nestedRancherModuleDir)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", clusters[0].Name)
 			err = provisioningActions.VerifyClusterReady(p.client, clusters[0])
 			require.NoError(t, err)
 
+			logrus.Infof("Verifying service account token secret (%s)", clusters[0].Name)
 			err = clusterActions.VerifyServiceAccountTokenSecret(p.client, clusters[0].Name)
 			require.NoError(t, err)
 
+			logrus.Infof("Verifying cluster pods (%s)", clusters[0].Name)
 			err = pods.VerifyClusterPods(p.client, clusters[0])
 			require.NoError(t, err)
 
 			provisioningActions.VerifyPSACT(t, p.client, clusters[0])
 
-			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
+			params := tfpQase.GetProvisioningSchemaParams(p.terraformConfig, p.terratestConfig)
 			err = qase.UpdateSchemaParameters(tt.name, params)
 			if err != nil {
 				logrus.Warningf("Failed to upload schema parameters %s", err)

--- a/tests/rancher2/rbac/auth_test.go
+++ b/tests/rancher2/rbac/auth_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/rancher/shepherd/clients/rancher"
 	shepherdConfig "github.com/rancher/shepherd/pkg/config"
-	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tfp-automation/config"
@@ -75,26 +74,21 @@ func (r *AuthConfigTestSuite) TestTfpAuthConfig() {
 		newFile, rootBody, file := rancher2.InitializeMainTF(r.terratestConfig)
 		defer file.Close()
 
-		cattleConfig, err := provisioning.UniquifyTerraform(r.cattleConfig)
-		require.NoError(r.T(), err)
+		rancher, terraform, _, _ := config.LoadTFPConfigs(r.cattleConfig)
+		rancher.AdminToken = r.client.RancherConfig.AdminToken
+		terraform.AuthProvider = tt.authProvider
 
-		_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, r.client.RancherConfig.AdminToken, cattleConfig)
-		require.NoError(r.T(), err)
-
-		_, err = operations.ReplaceValue([]string{"terraform", "authProvider"}, tt.authProvider, cattleConfig)
-		require.NoError(r.T(), err)
-
-		rancher, terraform, _, _ := config.LoadTFPConfigs(cattleConfig)
+		terraform = provisioning.UniquifyTerraform(terraform)
 
 		r.Run((tt.name), func() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, r.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(r.T(), r.terraformOptions, keyPath)
 
-			rbac.AuthConfig(r.T(), rancher, terraform, r.terraformOptions, testUser, testPassword, []map[string]any{cattleConfig}, newFile, rootBody, file)
+			rbac.AuthConfig(r.T(), rancher, terraform, r.terraformOptions, testUser, testPassword, []map[string]any{r.cattleConfig}, newFile, rootBody, file)
 		})
 
-		params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
-		err = qase.UpdateSchemaParameters(tt.name, params)
+		params := tfpQase.GetProvisioningSchemaParams(r.terraformConfig, r.terratestConfig)
+		err := qase.UpdateSchemaParameters(tt.name, params)
 		if err != nil {
 			logrus.Warningf("Failed to upload schema parameters %s", err)
 		}
@@ -122,26 +116,21 @@ func (r *AuthConfigTestSuite) TestTfpAuthConfigDynamicInput() {
 		newFile, rootBody, file := rancher2.InitializeMainTF(r.terratestConfig)
 		defer file.Close()
 
-		cattleConfig, err := provisioning.UniquifyTerraform(r.cattleConfig)
-		require.NoError(r.T(), err)
+		rancher, terraform, _, _ := config.LoadTFPConfigs(r.cattleConfig)
+		rancher.AdminToken = r.client.RancherConfig.AdminToken
+		terraform.AuthProvider = r.terraformConfig.AuthProvider
 
-		_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, r.client.RancherConfig.AdminToken, cattleConfig)
-		require.NoError(r.T(), err)
-
-		_, err = operations.ReplaceValue([]string{"terraform", "authProvider"}, r.terraformConfig.AuthProvider, cattleConfig)
-		require.NoError(r.T(), err)
-
-		rancher, terraform, _, _ := config.LoadTFPConfigs(cattleConfig)
+		terraform = provisioning.UniquifyTerraform(terraform)
 
 		r.Run((tt.name), func() {
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, r.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(r.T(), r.terraformOptions, keyPath)
 
-			rbac.AuthConfig(r.T(), rancher, terraform, r.terraformOptions, testUser, testPassword, []map[string]any{cattleConfig}, newFile, rootBody, file)
+			rbac.AuthConfig(r.T(), rancher, terraform, r.terraformOptions, testUser, testPassword, []map[string]any{r.cattleConfig}, newFile, rootBody, file)
 		})
 
-		params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
-		err = qase.UpdateSchemaParameters(tt.name, params)
+		params := tfpQase.GetProvisioningSchemaParams(r.terraformConfig, r.terratestConfig)
+		err := qase.UpdateSchemaParameters(tt.name, params)
 		if err != nil {
 			logrus.Warningf("Failed to upload schema parameters %s", err)
 		}

--- a/tests/rancher2/rbac/rbac_test.go
+++ b/tests/rancher2/rbac/rbac_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/rancher/shepherd/clients/rancher"
 	shepherdConfig "github.com/rancher/shepherd/pkg/config"
-	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
 	clusterActions "github.com/rancher/tests/actions/clusters"
 	provisioningActions "github.com/rancher/tests/actions/provisioning"
@@ -65,7 +64,6 @@ func (r *RBACTestSuite) SetupSuite() {
 func (r *RBACTestSuite) TestTfpRBAC() {
 	var err error
 	var testUser, testPassword string
-	var clusterIDs []string
 
 	r.standardUserClient, testUser, testPassword, err = standarduser.CreateStandardUser(r.client)
 	require.NoError(r.T(), err)
@@ -93,45 +91,43 @@ func (r *RBACTestSuite) TestTfpRBAC() {
 		r.T().Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			rancher, terraform, terratest, _ := config.LoadTFPConfigs(r.cattleConfig)
+			rancher.AdminToken = standardToken
+			terraform.Module = tt.module
+			terratest.Nodepools = nodeRolesDedicated
+
 			nestedRancherModuleDir, perTestTerraformOptions, err := nested.CreateNestedModules(r.terraformConfig, r.terratestConfig, r.terraformOptions, tt.name, "/modules/rancher2")
 			require.NoError(t, err)
 			defer os.RemoveAll(nestedRancherModuleDir)
 
 			newFile, rootBody, file := rancher2.InitializeNestedMainTFs(nestedRancherModuleDir)
 			defer file.Close()
-
-			cattleConfig, err := provisioning.UniquifyTerraform(r.cattleConfig)
-			require.NoError(t, err)
-
-			_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, standardToken, cattleConfig)
+			terratest, err = provisioning.GetK8sVersion(r.client, terraform, terratest)
 			require.NoError(r.T(), err)
 
-			_, err = operations.ReplaceValue([]string{"terraform", "module"}, tt.module, cattleConfig)
-			require.NoError(r.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terratest", "nodepools"}, nodeRolesDedicated, cattleConfig)
-			require.NoError(r.T(), err)
-
-			provisioning.GetK8sVersion(r.client, cattleConfig)
-
-			rancher, terraform, terratest, _ := config.LoadTFPConfigs(cattleConfig)
+			terraform = provisioning.UniquifyTerraform(terraform)
 
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, r.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(r.T(), perTestTerraformOptions, keyPath)
 
-			clusters, _ := provisioning.Provision(r.T(), r.client, r.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, false, clusterIDs, nil, nestedRancherModuleDir)
+			logrus.Infof("Provisioning cluster (%s)", terraform.ResourcePrefix)
+			clusters, _ := provisioning.Provision(r.T(), r.client, r.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, newFile, rootBody, file, false, false, false, "", nestedRancherModuleDir)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", clusters[0].Name)
 			err = provisioningActions.VerifyClusterReady(r.client, clusters[0])
 			require.NoError(r.T(), err)
 
+			logrus.Infof("Verifying service account token secret (%s)", clusters[0].Name)
 			err = clusterActions.VerifyServiceAccountTokenSecret(r.client, clusters[0].Name)
 			require.NoError(r.T(), err)
 
+			logrus.Infof("Verifying cluster pods (%s)", clusters[0].Name)
 			err = pods.VerifyClusterPods(r.client, clusters[0])
 			require.NoError(r.T(), err)
 
-			rb.RBAC(r.T(), r.client, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, tt.rbacRole, newFile, rootBody, file, nestedRancherModuleDir)
+			rb.RBAC(r.T(), r.client, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{r.cattleConfig}, tt.rbacRole, newFile, rootBody, file, nestedRancherModuleDir)
 
-			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
+			params := tfpQase.GetProvisioningSchemaParams(r.terraformConfig, r.terratestConfig)
 			err = qase.UpdateSchemaParameters(tt.name, params)
 			if err != nil {
 				logrus.Warningf("Failed to upload schema parameters %s", err)

--- a/tests/rancher2/resources/build_module_test.go
+++ b/tests/rancher2/resources/build_module_test.go
@@ -30,9 +30,7 @@ func (r *BuildModuleTestSuite) TestBuildModule() {
 	r.cattleConfig = shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
 	r.rancherConfig, r.terraformConfig, r.terratestConfig, _ = config.LoadTFPConfigs(r.cattleConfig)
 
-	configMap := []map[string]any{r.cattleConfig}
-
-	err := provisioning.BuildModule(r.T(), r.rancherConfig, r.terraformConfig, r.terratestConfig, configMap)
+	err := provisioning.BuildModule(r.T(), r.rancherConfig, r.terraformConfig, r.terratestConfig)
 	require.NoError(r.T(), err)
 }
 

--- a/tests/rancher2/snapshot/snapshot.go
+++ b/tests/rancher2/snapshot/snapshot.go
@@ -16,7 +16,6 @@ import (
 	"github.com/rancher/shepherd/extensions/defaults/namespaces"
 	"github.com/rancher/shepherd/extensions/workloads"
 	"github.com/rancher/shepherd/extensions/workloads/pods"
-	"github.com/rancher/shepherd/pkg/config/operations"
 	namegen "github.com/rancher/shepherd/pkg/namegenerator"
 	provisioningActions "github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/services"
@@ -58,7 +57,7 @@ const (
 // RestoreSnapshot creates workloads, takes a snapshot of the cluster, restores the cluster and verifies the workloads created after
 // a snapshot no longer are present in the cluster
 func RestoreSnapshot(t *testing.T, client *rancher.Client, rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig,
-	terratestConfig *config.TerratestConfig, testUser, testPassword string, terraformOptions *terraform.Options, cattleConfig map[string]any,
+	terratestConfig *config.TerratestConfig, testUser, testPassword string, terraformOptions *terraform.Options,
 	newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File, nestedRancherModuleDir string) {
 	initialWorkloadName := namegen.AppendRandomString(initialWorkload)
 
@@ -73,10 +72,10 @@ func RestoreSnapshot(t *testing.T, client *rancher.Client, rancherConfig *ranche
 
 	deploymentResp, serviceResp := createWorkloads(t, client, clusterID, podTemplate, initialWorkloadName, isCattleLabeled, DeploymentSteveType)
 
-	snapshotName, postDeploymentResp, postServiceResp, err := snapshotV2Prov(t, client, rancherConfig, terraformConfig, terratestConfig, podTemplate, testUser, testPassword, clusterID, terraformOptions, cattleConfig, newFile, rootBody, file, nestedRancherModuleDir)
+	snapshotName, postDeploymentResp, postServiceResp, err := snapshotV2Prov(t, client, rancherConfig, terraformConfig, terratestConfig, podTemplate, testUser, testPassword, clusterID, terraformOptions, newFile, rootBody, file, nestedRancherModuleDir)
 	require.NoError(t, err)
 
-	restoreV2Prov(t, client, rancherConfig, terraformConfig, terratestConfig, snapshotName, testUser, testPassword, clusterID, terraformOptions, cattleConfig, newFile, rootBody, file, nestedRancherModuleDir)
+	restoreV2Prov(t, client, rancherConfig, terraformConfig, terratestConfig, snapshotName, testUser, testPassword, clusterID, terraformOptions, newFile, rootBody, file, nestedRancherModuleDir)
 
 	_, err = steveclient.SteveType(DeploymentSteveType).ByID(postDeploymentResp.ID)
 	require.Error(t, err)
@@ -95,12 +94,11 @@ func RestoreSnapshot(t *testing.T, client *rancher.Client, rancherConfig *ranche
 // snapshotV2Prov takes a snapshot of the cluster and creates a deployment and service in the cluster.
 func snapshotV2Prov(t *testing.T, client *rancher.Client, rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig,
 	terratestConfig *config.TerratestConfig, podTemplate corev1.PodTemplateSpec, testUser, testPassword, clusterID string,
-	terraformOptions *terraform.Options, cattleConfig map[string]any, newFile *hclwrite.File, rootBody *hclwrite.Body,
+	terraformOptions *terraform.Options, newFile *hclwrite.File, rootBody *hclwrite.Body,
 	file *os.File, nestedRancherModuleDir string) (string, *steveV1.SteveAPIObject, *steveV1.SteveAPIObject, error) {
-	_, err := operations.ReplaceValue([]string{"terratest", "snapshotInput", "createSnapshot"}, true, cattleConfig)
-	require.NoError(t, err)
+	terratestConfig.SnapshotInput.CreateSnapshot = true
 
-	_, _, err = framework.ConfigTF(client, rancherConfig, terratestConfig, testUser, testPassword, "", []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, false, nil, nestedRancherModuleDir)
+	_, _, err := framework.ConfigTF(client, rancherConfig, terratestConfig, testUser, testPassword, "", terraformConfig, newFile, rootBody, file, false, false, false, "", nestedRancherModuleDir)
 	require.NoError(t, err)
 
 	terraform.Apply(t, terraformOptions)
@@ -123,17 +121,12 @@ func snapshotV2Prov(t *testing.T, client *rancher.Client, rancherConfig *rancher
 // restoreV2Prov restores the cluster to the previous state after a snapshot is taken.
 func restoreV2Prov(t *testing.T, client *rancher.Client, rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig,
 	terratestConfig *config.TerratestConfig, snapshotName, testUser, testPassword string, clusterID string, terraformOptions *terraform.Options,
-	cattleConfig map[string]any, newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File, nestedRancherModuleDir string) {
-	_, err := operations.ReplaceValue([]string{"terratest", "snapshotInput", "createSnapshot"}, false, cattleConfig)
-	require.NoError(t, err)
+	newFile *hclwrite.File, rootBody *hclwrite.Body, file *os.File, nestedRancherModuleDir string) {
+	terratestConfig.SnapshotInput.CreateSnapshot = false
+	terratestConfig.SnapshotInput.RestoreSnapshot = true
+	terratestConfig.SnapshotInput.SnapshotName = snapshotName
 
-	_, err = operations.ReplaceValue([]string{"terratest", "snapshotInput", "restoreSnapshot"}, true, cattleConfig)
-	require.NoError(t, err)
-
-	_, err = operations.ReplaceValue([]string{"terratest", "snapshotInput", "snapshotName"}, snapshotName, cattleConfig)
-	require.NoError(t, err)
-
-	_, _, err = framework.ConfigTF(client, rancherConfig, terratestConfig, testUser, testPassword, "", []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, false, nil, nestedRancherModuleDir)
+	_, _, err := framework.ConfigTF(client, rancherConfig, terratestConfig, testUser, testPassword, "", terraformConfig, newFile, rootBody, file, false, false, false, "", nestedRancherModuleDir)
 	require.NoError(t, err)
 
 	terraform.Apply(t, terraformOptions)

--- a/tests/rancher2/snapshot/snapshot_restore_test.go
+++ b/tests/rancher2/snapshot/snapshot_restore_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/rancher/shepherd/clients/rancher"
 	shepherdConfig "github.com/rancher/shepherd/pkg/config"
-	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
 	clusterActions "github.com/rancher/tests/actions/clusters"
 	provisioningActions "github.com/rancher/tests/actions/provisioning"
@@ -65,7 +64,6 @@ func (s *SnapshotRestoreTestSuite) SetupSuite() {
 func (s *SnapshotRestoreTestSuite) TestTfpSnapshotRestore() {
 	var err error
 	var testUser, testPassword string
-	var clusterIDs []string
 
 	s.standardUserClient, testUser, testPassword, err = standarduser.CreateStandardUser(s.client)
 	require.NoError(s.T(), err)
@@ -98,48 +96,44 @@ func (s *SnapshotRestoreTestSuite) TestTfpSnapshotRestore() {
 		s.T().Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			rancher, terraform, terratest, _ := config.LoadTFPConfigs(s.cattleConfig)
+			rancher.AdminToken = standardToken
+			terraform.Module = tt.module
+			terratest.Nodepools = tt.nodeRoles
+			terratest.SnapshotInput.SnapshotRestore = tt.etcdSnapshot.SnapshotInput.SnapshotRestore
+
 			nestedRancherModuleDir, perTestTerraformOptions, err := nested.CreateNestedModules(s.terraformConfig, s.terratestConfig, s.terraformOptions, tt.name, configs.NestedRancherModuleDir)
 			require.NoError(t, err)
 			defer os.RemoveAll(nestedRancherModuleDir)
 
 			newFile, rootBody, file := rancher2.InitializeNestedMainTFs(nestedRancherModuleDir)
 			defer file.Close()
-
-			cattleConfig, err := provisioning.UniquifyTerraform(s.cattleConfig)
-			require.NoError(t, err)
-
-			_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, standardToken, cattleConfig)
+			terratest, err = provisioning.GetK8sVersion(s.client, terraform, terratest)
 			require.NoError(s.T(), err)
 
-			_, err = operations.ReplaceValue([]string{"terraform", "module"}, tt.module, cattleConfig)
-			require.NoError(s.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terratest", "nodepools"}, tt.nodeRoles, cattleConfig)
-			require.NoError(s.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terratest", "snapshotInput", "snapshotRestore"}, tt.etcdSnapshot.SnapshotInput.SnapshotRestore, cattleConfig)
-			require.NoError(s.T(), err)
-
-			provisioning.GetK8sVersion(s.client, cattleConfig)
-
-			rancher, terraform, terratest, _ := config.LoadTFPConfigs(cattleConfig)
+			terraform = provisioning.UniquifyTerraform(terraform)
 
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, s.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(s.T(), perTestTerraformOptions, keyPath)
 
-			clusters, _ := provisioning.Provision(s.T(), s.client, s.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, false, clusterIDs, nil, nestedRancherModuleDir)
+			logrus.Infof("Provisioning cluster (%s)", terraform.ResourcePrefix)
+			clusters, _ := provisioning.Provision(s.T(), s.client, s.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, newFile, rootBody, file, false, false, false, "", nestedRancherModuleDir)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", clusters[0].Name)
 			err = provisioningActions.VerifyClusterReady(s.client, clusters[0])
 			require.NoError(s.T(), err)
 
+			logrus.Infof("Verifying service account token secret (%s)", clusters[0].Name)
 			err = clusterActions.VerifyServiceAccountTokenSecret(s.client, clusters[0].Name)
 			require.NoError(s.T(), err)
 
+			logrus.Infof("Verifying cluster pods (%s)", clusters[0].Name)
 			err = pods.VerifyClusterPods(s.client, clusters[0])
 			require.NoError(s.T(), err)
 
-			RestoreSnapshot(s.T(), s.client, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, cattleConfig, newFile, rootBody, file, nestedRancherModuleDir)
+			RestoreSnapshot(s.T(), s.client, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, newFile, rootBody, file, nestedRancherModuleDir)
 
-			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
+			params := tfpQase.GetProvisioningSchemaParams(s.terraformConfig, s.terratestConfig)
 			err = qase.UpdateSchemaParameters(tt.name, params)
 			if err != nil {
 				logrus.Warningf("Failed to upload schema parameters %s", err)

--- a/tests/registries/registries_test.go
+++ b/tests/registries/registries_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/rancher/shepherd/clients/rancher"
-	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
 	clusterActions "github.com/rancher/tests/actions/clusters"
 	provisioningActions "github.com/rancher/tests/actions/provisioning"
@@ -65,7 +64,6 @@ func (r *TfpRegistriesTestSuite) SetupSuite() {
 func (r *TfpRegistriesTestSuite) TestTfpAuthenticatedRegistry() {
 	var err error
 	var testUser, testPassword string
-	var clusterIDs []string
 
 	r.standardUserClient, testUser, testPassword, err = standarduser.CreateStandardUser(r.client)
 	require.NoError(r.T(), err)
@@ -91,54 +89,46 @@ func (r *TfpRegistriesTestSuite) TestTfpAuthenticatedRegistry() {
 		r.T().Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			rancher, terraform, terratest, _ := config.LoadTFPConfigs(r.cattleConfig)
+			rancher.AdminToken = standardToken
+			terratest.Nodepools = tt.nodeRoles
+			terraform.Module = tt.module
+			terraform.PrivateRegistries.SystemDefaultRegistry = r.authRegistry
+			terraform.PrivateRegistries.URL = r.authRegistry
+			terraform.StandaloneRegistry.Authenticated = true
+
 			nestedRancherModuleDir, perTestTerraformOptions, err := nested.CreateNestedModules(r.terraformConfig, r.terratestConfig, r.terraformOptions, tt.name, configs.NestedRancherModuleDir)
 			require.NoError(t, err)
 			defer os.RemoveAll(nestedRancherModuleDir)
 
 			newFile, rootBody, file := rancher2.InitializeNestedMainTFs(nestedRancherModuleDir)
 			defer file.Close()
-
-			cattleConfig, err := provisioning.UniquifyTerraform(r.cattleConfig)
-			require.NoError(t, err)
-
-			_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, standardToken, cattleConfig)
+			terratest, err = provisioning.GetK8sVersion(r.standardUserClient, terraform, terratest)
 			require.NoError(r.T(), err)
 
-			_, err = operations.ReplaceValue([]string{"terratest", "nodepools"}, tt.nodeRoles, cattleConfig)
-			require.NoError(r.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "module"}, tt.module, cattleConfig)
-			require.NoError(r.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "privateRegistries", "systemDefaultRegistry"}, r.authRegistry, cattleConfig)
-			require.NoError(r.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "privateRegistries", "url"}, r.authRegistry, cattleConfig)
-			require.NoError(r.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "standaloneRegistry", "authenticated"}, true, cattleConfig)
-			require.NoError(r.T(), err)
-
-			provisioning.GetK8sVersion(r.standardUserClient, cattleConfig)
-
-			rancher, terraform, terratest, _ := config.LoadTFPConfigs(cattleConfig)
+			terraform = provisioning.UniquifyTerraform(terraform)
 
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, r.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(r.T(), perTestTerraformOptions, keyPath)
 
-			clusters, _ := provisioning.Provision(r.T(), r.client, r.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, nil, nestedRancherModuleDir)
+			logrus.Infof("Provisioning cluster (%s)", terraform.ResourcePrefix)
+			clusters, _ := provisioning.Provision(r.T(), r.client, r.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, newFile, rootBody, file, false, false, true, "", nestedRancherModuleDir)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", clusters[0].Name)
 			err = provisioningActions.VerifyClusterReady(r.client, clusters[0])
 			require.NoError(r.T(), err)
 
+			logrus.Infof("Verifying service account token secret (%s)", clusters[0].Name)
 			err = clusterActions.VerifyServiceAccountTokenSecret(r.client, clusters[0].Name)
 			require.NoError(r.T(), err)
 
+			logrus.Infof("Verifying cluster pods (%s)", clusters[0].Name)
 			err = pods.VerifyClusterPods(r.client, clusters[0])
 			require.NoError(r.T(), err)
 
 			provisioning.VerifyRegistry(r.T(), r.client, clusters[0].ID, terraform)
 
-			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
+			params := tfpQase.GetProvisioningSchemaParams(r.terraformConfig, r.terratestConfig)
 			err = qase.UpdateSchemaParameters(tt.name, params)
 			if err != nil {
 				logrus.Warningf("Failed to upload schema parameters %s", err)
@@ -154,7 +144,6 @@ func (r *TfpRegistriesTestSuite) TestTfpAuthenticatedRegistry() {
 func (r *TfpRegistriesTestSuite) TestTfpECRRegistry() {
 	var err error
 	var testUser, testPassword string
-	var clusterIDs []string
 
 	r.standardUserClient, testUser, testPassword, err = standarduser.CreateStandardUser(r.client)
 	require.NoError(r.T(), err)
@@ -180,63 +169,49 @@ func (r *TfpRegistriesTestSuite) TestTfpECRRegistry() {
 		r.T().Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			rancher, terraform, terratest, _ := config.LoadTFPConfigs(r.cattleConfig)
+			rancher.AdminToken = standardToken
+			terratest.Nodepools = tt.nodeRoles
+			terraform.Module = tt.module
+			terraform.PrivateRegistries.SystemDefaultRegistry = r.terraformConfig.StandaloneRegistry.ECRURI
+			terraform.PrivateRegistries.URL = r.terraformConfig.StandaloneRegistry.ECRURI
+			terraform.PrivateRegistries.Username = r.terraformConfig.StandaloneRegistry.ECRUsername
+			terraform.PrivateRegistries.Password = r.terraformConfig.StandaloneRegistry.ECRPassword
+			terraform.StandaloneRegistry.Authenticated = true
+			terraform.PrivateRegistries.AuthConfigSecretName = r.terraformConfig.PrivateRegistries.AuthConfigSecretName + "-ecr"
+
 			nestedRancherModuleDir, perTestTerraformOptions, err := nested.CreateNestedModules(r.terraformConfig, r.terratestConfig, r.terraformOptions, tt.name, configs.NestedRancherModuleDir)
 			require.NoError(t, err)
 			defer os.RemoveAll(nestedRancherModuleDir)
 
 			newFile, rootBody, file := rancher2.InitializeNestedMainTFs(nestedRancherModuleDir)
 			defer file.Close()
-
-			cattleConfig, err := provisioning.UniquifyTerraform(r.cattleConfig)
-			require.NoError(t, err)
-
-			_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, standardToken, cattleConfig)
+			terratest, err = provisioning.GetK8sVersion(r.standardUserClient, terraform, terratest)
 			require.NoError(r.T(), err)
 
-			_, err = operations.ReplaceValue([]string{"terratest", "nodepools"}, tt.nodeRoles, cattleConfig)
-			require.NoError(r.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "module"}, tt.module, cattleConfig)
-			require.NoError(r.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "privateRegistries", "systemDefaultRegistry"}, r.terraformConfig.StandaloneRegistry.ECRURI, cattleConfig)
-			require.NoError(r.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "privateRegistries", "url"}, r.terraformConfig.StandaloneRegistry.ECRURI, cattleConfig)
-			require.NoError(r.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "privateRegistries", "username"}, r.terraformConfig.StandaloneRegistry.ECRUsername, cattleConfig)
-			require.NoError(r.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "privateRegistries", "password"}, r.terraformConfig.StandaloneRegistry.ECRPassword, cattleConfig)
-			require.NoError(r.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "standaloneRegistry", "authenticated"}, true, cattleConfig)
-			require.NoError(r.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "privateRegistries", "authConfigSecretName"}, r.terraformConfig.PrivateRegistries.AuthConfigSecretName+"-ecr", cattleConfig)
-			require.NoError(r.T(), err)
-
-			provisioning.GetK8sVersion(r.standardUserClient, cattleConfig)
-
-			rancher, terraform, terratest, _ := config.LoadTFPConfigs(cattleConfig)
+			terraform = provisioning.UniquifyTerraform(terraform)
 
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, r.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(r.T(), perTestTerraformOptions, keyPath)
 
-			clusters, _ := provisioning.Provision(r.T(), r.client, r.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, nil, nestedRancherModuleDir)
+			logrus.Infof("Provisioning cluster (%s)", terraform.ResourcePrefix)
+			clusters, _ := provisioning.Provision(r.T(), r.client, r.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, newFile, rootBody, file, false, false, true, "", nestedRancherModuleDir)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", clusters[0].Name)
 			err = provisioningActions.VerifyClusterReady(r.client, clusters[0])
 			require.NoError(r.T(), err)
 
+			logrus.Infof("Verifying service account token secret (%s)", clusters[0].Name)
 			err = clusterActions.VerifyServiceAccountTokenSecret(r.client, clusters[0].Name)
 			require.NoError(r.T(), err)
 
+			logrus.Infof("Verifying cluster pods (%s)", clusters[0].Name)
 			err = pods.VerifyClusterPods(r.client, clusters[0])
 			require.NoError(r.T(), err)
 
 			provisioning.VerifyRegistry(r.T(), r.client, clusters[0].ID, terraform)
 
-			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
+			params := tfpQase.GetProvisioningSchemaParams(r.terraformConfig, r.terratestConfig)
 			err = qase.UpdateSchemaParameters(tt.name, params)
 			if err != nil {
 				logrus.Warningf("Failed to upload schema parameters %s", err)
@@ -252,11 +227,9 @@ func (r *TfpRegistriesTestSuite) TestTfpECRRegistry() {
 func (r *TfpRegistriesTestSuite) TestTfpGlobalRegistry() {
 	var err error
 	var testUser, testPassword string
-	var clusterIDs []string
 
 	nodeRolesAll := []config.Nodepool{config.AllRolesNodePool}
 	nodeRolesDedicated := []config.Nodepool{config.EtcdNodePool, config.ControlPlaneNodePool, config.WorkerNodePool}
-	customClusterNames := []string{}
 
 	r.standardUserClient, testUser, testPassword, err = standarduser.CreateStandardUser(r.client)
 	require.NoError(r.T(), err)
@@ -282,74 +255,67 @@ func (r *TfpRegistriesTestSuite) TestTfpGlobalRegistry() {
 		r.T().Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			rancher, terraform, terratest, _ := config.LoadTFPConfigs(r.cattleConfig)
+			rancher.AdminToken = standardToken
+			terratest.Nodepools = tt.nodeRoles
+			terraform.Module = tt.module
+			terraform.PrivateRegistries.SystemDefaultRegistry = r.globalRegistry
+			terraform.PrivateRegistries.URL = r.globalRegistry
+			terraform.PrivateRegistries.Password = ""
+			terraform.PrivateRegistries.Username = ""
+			terraform.StandaloneRegistry.Authenticated = false
+
 			nestedRancherModuleDir, perTestTerraformOptions, err := nested.CreateNestedModules(r.terraformConfig, r.terratestConfig, r.terraformOptions, tt.name, configs.NestedRancherModuleDir)
 			require.NoError(t, err)
 			defer os.RemoveAll(nestedRancherModuleDir)
 
 			newFile, rootBody, file := rancher2.InitializeNestedMainTFs(nestedRancherModuleDir)
 			defer file.Close()
-
-			cattleConfig, err := provisioning.UniquifyTerraform(r.cattleConfig)
-			require.NoError(t, err)
-
-			_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, standardToken, cattleConfig)
+			terratest, err = provisioning.GetK8sVersion(r.standardUserClient, terraform, terratest)
 			require.NoError(r.T(), err)
 
-			_, err = operations.ReplaceValue([]string{"terratest", "nodepools"}, tt.nodeRoles, cattleConfig)
-			require.NoError(r.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "module"}, tt.module, cattleConfig)
-			require.NoError(r.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "privateRegistries", "systemDefaultRegistry"}, r.globalRegistry, cattleConfig)
-			require.NoError(r.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "privateRegistries", "url"}, r.globalRegistry, cattleConfig)
-			require.NoError(r.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "privateRegistries", "password"}, "", cattleConfig)
-			require.NoError(r.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "privateRegistries", "username"}, "", cattleConfig)
-			require.NoError(r.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "standaloneRegistry", "authenticated"}, false, cattleConfig)
-			require.NoError(r.T(), err)
-
-			provisioning.GetK8sVersion(r.standardUserClient, cattleConfig)
-
-			rancher, terraform, terratest, _ := config.LoadTFPConfigs(cattleConfig)
+			terraform = provisioning.UniquifyTerraform(terraform)
 
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, r.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(r.T(), perTestTerraformOptions, keyPath)
 
-			clusters, customClusterNames := provisioning.Provision(r.T(), r.client, r.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+			logrus.Infof("Provisioning cluster (%s)", terraform.ResourcePrefix)
+			clusters, customClusterName := provisioning.Provision(r.T(), r.client, r.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, newFile, rootBody, file, false, false, true, "", nestedRancherModuleDir)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", clusters[0].Name)
 			err = provisioningActions.VerifyClusterReady(r.client, clusters[0])
 			require.NoError(r.T(), err)
 
+			logrus.Infof("Verifying service account token secret (%s)", clusters[0].Name)
 			err = clusterActions.VerifyServiceAccountTokenSecret(r.client, clusters[0].Name)
 			require.NoError(r.T(), err)
 
+			logrus.Infof("Verifying cluster pods (%s)", clusters[0].Name)
 			err = pods.VerifyClusterPods(r.client, clusters[0])
 			require.NoError(r.T(), err)
 
 			provisioning.VerifyRegistry(r.T(), r.client, clusters[0].ID, terraform)
 
 			if strings.Contains(terraform.Module, clustertypes.WINDOWS) {
-				clusters, _ = provisioning.Provision(r.T(), r.client, r.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, true, true, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+				logrus.Infof("Provisioning cluster (%s)", terraform.ResourcePrefix)
+				clusters, _ = provisioning.Provision(r.T(), r.client, r.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, newFile, rootBody, file, true, true, true, customClusterName, nestedRancherModuleDir)
+
+				logrus.Infof("Verifying the cluster is ready (%s)", clusters[0].Name)
 				err = provisioningActions.VerifyClusterReady(r.client, clusters[0])
 				require.NoError(r.T(), err)
 
+				logrus.Infof("Verifying service account token secret (%s)", clusters[0].Name)
 				err = clusterActions.VerifyServiceAccountTokenSecret(r.client, clusters[0].Name)
 				require.NoError(r.T(), err)
 
+				logrus.Infof("Verifying cluster pods (%s)", clusters[0].Name)
 				err = pods.VerifyClusterPods(r.client, clusters[0])
 				require.NoError(r.T(), err)
 
 				provisioning.VerifyRegistry(r.T(), r.client, clusters[0].ID, terraform)
 			}
 
-			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
+			params := tfpQase.GetProvisioningSchemaParams(r.terraformConfig, r.terratestConfig)
 			err = qase.UpdateSchemaParameters(tt.name, params)
 			if err != nil {
 				logrus.Warningf("Failed to upload schema parameters %s", err)
@@ -365,7 +331,6 @@ func (r *TfpRegistriesTestSuite) TestTfpGlobalRegistry() {
 func (r *TfpRegistriesTestSuite) TestTfpNonAuthenticatedRegistry() {
 	var err error
 	var testUser, testPassword string
-	var clusterIDs []string
 
 	r.standardUserClient, testUser, testPassword, err = standarduser.CreateStandardUser(r.client)
 	require.NoError(r.T(), err)
@@ -378,7 +343,6 @@ func (r *TfpRegistriesTestSuite) TestTfpNonAuthenticatedRegistry() {
 	nodeRolesAll := []config.Nodepool{config.AllRolesNodePool}
 	nodeRolesDedicated := []config.Nodepool{config.EtcdNodePool, config.ControlPlaneNodePool, config.WorkerNodePool}
 	nodeRolesWindows := []config.Nodepool{config.EtcdNodePool, config.ControlPlaneNodePool, config.WorkerNodePool, config.WindowsNodePool}
-	customClusterNames := []string{}
 
 	tests := []struct {
 		name      string
@@ -395,74 +359,67 @@ func (r *TfpRegistriesTestSuite) TestTfpNonAuthenticatedRegistry() {
 		r.T().Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			rancher, terraform, terratest, _ := config.LoadTFPConfigs(r.cattleConfig)
+			rancher.AdminToken = standardToken
+			terratest.Nodepools = tt.nodeRoles
+			terraform.Module = tt.module
+			terraform.PrivateRegistries.SystemDefaultRegistry = r.nonAuthRegistry
+			terraform.PrivateRegistries.URL = r.nonAuthRegistry
+			terraform.PrivateRegistries.Password = ""
+			terraform.PrivateRegistries.Username = ""
+			terraform.StandaloneRegistry.Authenticated = false
+
 			nestedRancherModuleDir, perTestTerraformOptions, err := nested.CreateNestedModules(r.terraformConfig, r.terratestConfig, r.terraformOptions, tt.name, configs.NestedRancherModuleDir)
 			require.NoError(t, err)
 			defer os.RemoveAll(nestedRancherModuleDir)
 
 			newFile, rootBody, file := rancher2.InitializeNestedMainTFs(nestedRancherModuleDir)
 			defer file.Close()
-
-			cattleConfig, err := provisioning.UniquifyTerraform(r.cattleConfig)
-			require.NoError(t, err)
-
-			_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, standardToken, cattleConfig)
+			terratest, err = provisioning.GetK8sVersion(r.standardUserClient, terraform, terratest)
 			require.NoError(r.T(), err)
 
-			_, err = operations.ReplaceValue([]string{"terratest", "nodepools"}, tt.nodeRoles, cattleConfig)
-			require.NoError(r.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "module"}, tt.module, cattleConfig)
-			require.NoError(r.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "privateRegistries", "systemDefaultRegistry"}, r.nonAuthRegistry, cattleConfig)
-			require.NoError(r.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "privateRegistries", "url"}, r.nonAuthRegistry, cattleConfig)
-			require.NoError(r.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "privateRegistries", "password"}, "", cattleConfig)
-			require.NoError(r.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "privateRegistries", "username"}, "", cattleConfig)
-			require.NoError(r.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "standaloneRegistry", "authenticated"}, false, cattleConfig)
-			require.NoError(r.T(), err)
-
-			provisioning.GetK8sVersion(r.standardUserClient, cattleConfig)
-
-			rancher, terraform, terratest, _ := config.LoadTFPConfigs(cattleConfig)
+			terraform = provisioning.UniquifyTerraform(terraform)
 
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, r.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(r.T(), perTestTerraformOptions, keyPath)
 
-			clusters, customClusterNames := provisioning.Provision(r.T(), r.client, r.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+			logrus.Infof("Provisioning cluster (%s)", terraform.ResourcePrefix)
+			clusters, customClusterName := provisioning.Provision(r.T(), r.client, r.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, newFile, rootBody, file, false, false, true, "", nestedRancherModuleDir)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", clusters[0].Name)
 			err = provisioningActions.VerifyClusterReady(r.client, clusters[0])
 			require.NoError(r.T(), err)
 
+			logrus.Infof("Verifying service account token secret (%s)", clusters[0].Name)
 			err = clusterActions.VerifyServiceAccountTokenSecret(r.client, clusters[0].Name)
 			require.NoError(r.T(), err)
 
+			logrus.Infof("Verifying cluster pods (%s)", clusters[0].Name)
 			err = pods.VerifyClusterPods(r.client, clusters[0])
 			require.NoError(r.T(), err)
 
 			provisioning.VerifyRegistry(r.T(), r.client, clusters[0].ID, terraform)
 
 			if strings.Contains(terraform.Module, clustertypes.WINDOWS) {
-				clusters, _ = provisioning.Provision(r.T(), r.client, r.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, true, true, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+				logrus.Infof("Provisioning cluster (%s)", terraform.ResourcePrefix)
+				clusters, _ = provisioning.Provision(r.T(), r.client, r.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, newFile, rootBody, file, true, true, true, customClusterName, nestedRancherModuleDir)
+
+				logrus.Infof("Verifying the cluster is ready (%s)", clusters[0].Name)
 				err = provisioningActions.VerifyClusterReady(r.client, clusters[0])
 				require.NoError(r.T(), err)
 
+				logrus.Infof("Verifying service account token secret (%s)", clusters[0].Name)
 				err = clusterActions.VerifyServiceAccountTokenSecret(r.client, clusters[0].Name)
 				require.NoError(r.T(), err)
 
+				logrus.Infof("Verifying cluster pods (%s)", clusters[0].Name)
 				err = pods.VerifyClusterPods(r.client, clusters[0])
 				require.NoError(r.T(), err)
 
 				provisioning.VerifyRegistry(r.T(), r.client, clusters[0].ID, terraform)
 			}
 
-			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
+			params := tfpQase.GetProvisioningSchemaParams(r.terraformConfig, r.terratestConfig)
 			err = qase.UpdateSchemaParameters(tt.name, params)
 			if err != nil {
 				logrus.Warningf("Failed to upload schema parameters %s", err)

--- a/tests/sanity/sanity_aks_provisioning_test.go
+++ b/tests/sanity/sanity_aks_provisioning_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/rancher/shepherd/clients/rancher"
-	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
 	clusterActions "github.com/rancher/tests/actions/clusters"
 	provisioningActions "github.com/rancher/tests/actions/provisioning"
@@ -54,9 +53,6 @@ func (s *TfpSanityAKSProvisioningTestSuite) SetupSuite() {
 func (s *TfpSanityAKSProvisioningTestSuite) TestTfpProvisioningAKSSanity() {
 	var err error
 	var testUser, testPassword string
-	var clusterIDs []string
-
-	customClusterNames := []string{}
 
 	s.standardUserClient, testUser, testPassword, err = standarduser.CreateStandardUser(s.client)
 	require.NoError(s.T(), err)
@@ -81,46 +77,42 @@ func (s *TfpSanityAKSProvisioningTestSuite) TestTfpProvisioningAKSSanity() {
 		s.T().Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			rancher, terraform, terratest, _ := config.LoadTFPConfigs(s.cattleConfig)
+			rancher.AdminToken = standardToken
+			terraform.Module = tt.module
+			terratest.Nodepools = tt.nodePools
+			terratest.KubernetesVersion = tt.kubernetesVersion
+
 			nestedRancherModuleDir, perTestTerraformOptions, err := nested.CreateNestedModules(s.terraformConfig, s.terratestConfig, s.terraformOptions, tt.name, configs.NestedRancherModuleDir)
 			require.NoError(t, err)
 			defer os.RemoveAll(nestedRancherModuleDir)
 
 			newFile, rootBody, file := rancher2.InitializeNestedMainTFs(nestedRancherModuleDir)
 			defer file.Close()
-
-			cattleConfig, err := provisioning.UniquifyTerraform(s.cattleConfig)
-			require.NoError(t, err)
-
-			_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, standardToken, cattleConfig)
+			terratest, err = provisioning.GetK8sVersion(s.standardUserClient, terraform, terratest)
 			require.NoError(s.T(), err)
 
-			_, err = operations.ReplaceValue([]string{"terraform", "module"}, tt.module, cattleConfig)
-			require.NoError(s.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terratest", "nodepools"}, tt.nodePools, cattleConfig)
-			require.NoError(s.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terratest", "kubernetesVersion"}, tt.kubernetesVersion, cattleConfig)
-			require.NoError(s.T(), err)
-
-			provisioning.GetK8sVersion(s.standardUserClient, cattleConfig)
-
-			rancher, terraform, terratest, _ := config.LoadTFPConfigs(cattleConfig)
+			terraform = provisioning.UniquifyTerraform(terraform)
 
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, s.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(s.T(), perTestTerraformOptions, keyPath)
 
-			clusters, _ := provisioning.Provision(s.T(), s.client, s.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+			logrus.Infof("Provisioning cluster (%s)", terraform.ResourcePrefix)
+			clusters, _ := provisioning.Provision(s.T(), s.client, s.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, newFile, rootBody, file, false, false, true, "", nestedRancherModuleDir)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", clusters[0].Name)
 			err = provisioningActions.VerifyClusterReady(s.client, clusters[0])
 			require.NoError(s.T(), err)
 
+			logrus.Infof("Verifying service account token secret (%s)", clusters[0].Name)
 			err = clusterActions.VerifyServiceAccountTokenSecret(s.client, clusters[0].Name)
 			require.NoError(s.T(), err)
 
+			logrus.Infof("Verifying cluster pods (%s)", clusters[0].Name)
 			err = pods.VerifyClusterPods(s.client, clusters[0])
 			require.NoError(s.T(), err)
 
-			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
+			params := tfpQase.GetProvisioningSchemaParams(s.terraformConfig, s.terratestConfig)
 			err = qase.UpdateSchemaParameters(tt.name, params)
 			if err != nil {
 				logrus.Warningf("Failed to upload schema parameters %s", err)

--- a/tests/sanity/sanity_dual_stack_provisioning_test.go
+++ b/tests/sanity/sanity_dual_stack_provisioning_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/rancher/shepherd/clients/rancher"
-	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
 	clusterActions "github.com/rancher/tests/actions/clusters"
 	provisioningActions "github.com/rancher/tests/actions/provisioning"
@@ -59,9 +58,6 @@ func (s *TfpSanityDualStackProvisioningTestSuite) SetupSuite() {
 func (s *TfpSanityDualStackProvisioningTestSuite) TestTfpProvisioningSanityDualStack() {
 	var err error
 	var testUser, testPassword string
-	var clusterIDs []string
-
-	customClusterNames := []string{}
 
 	s.standardUserClient, testUser, testPassword, err = standarduser.CreateStandardUser(s.client)
 	require.NoError(s.T(), err)
@@ -86,43 +82,41 @@ func (s *TfpSanityDualStackProvisioningTestSuite) TestTfpProvisioningSanityDualS
 		s.T().Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			rancher, terraform, terratest, _ := config.LoadTFPConfigs(s.cattleConfig)
+			rancher.AdminToken = standardToken
+			terratest.Nodepools = tt.nodeRoles
+			terraform.Module = tt.module
+
 			nestedRancherModuleDir, perTestTerraformOptions, err := nested.CreateNestedModules(s.terraformConfig, s.terratestConfig, s.terraformOptions, tt.name, configs.NestedRancherModuleDir)
 			require.NoError(t, err)
 			defer os.RemoveAll(nestedRancherModuleDir)
 
 			newFile, rootBody, file := rancher2.InitializeNestedMainTFs(nestedRancherModuleDir)
 			defer file.Close()
-
-			cattleConfig, err := provisioning.UniquifyTerraform(s.cattleConfig)
-			require.NoError(t, err)
-
-			_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, standardToken, cattleConfig)
+			terratest, err = provisioning.GetK8sVersion(s.standardUserClient, terraform, terratest)
 			require.NoError(s.T(), err)
 
-			_, err = operations.ReplaceValue([]string{"terratest", "nodepools"}, tt.nodeRoles, cattleConfig)
-			require.NoError(s.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "module"}, tt.module, cattleConfig)
-			require.NoError(s.T(), err)
-
-			provisioning.GetK8sVersion(s.standardUserClient, cattleConfig)
-
-			rancher, terraform, terratest, _ := config.LoadTFPConfigs(cattleConfig)
+			terraform = provisioning.UniquifyTerraform(terraform)
 
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, s.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(s.T(), perTestTerraformOptions, keyPath)
 
-			clusters, _ := provisioning.Provision(s.T(), s.client, s.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+			logrus.Infof("Provisioning cluster (%s)", terraform.ResourcePrefix)
+			clusters, _ := provisioning.Provision(s.T(), s.client, s.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, newFile, rootBody, file, false, false, true, "", nestedRancherModuleDir)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", clusters[0].Name)
 			err = provisioningActions.VerifyClusterReady(s.client, clusters[0])
 			require.NoError(s.T(), err)
 
+			logrus.Infof("Verifying service account token secret (%s)", clusters[0].Name)
 			err = clusterActions.VerifyServiceAccountTokenSecret(s.client, clusters[0].Name)
 			require.NoError(s.T(), err)
 
+			logrus.Infof("Verifying cluster pods (%s)", clusters[0].Name)
 			err = pods.VerifyClusterPods(s.client, clusters[0])
 			require.NoError(s.T(), err)
 
-			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
+			params := tfpQase.GetProvisioningSchemaParams(s.terraformConfig, s.terratestConfig)
 			err = qase.UpdateSchemaParameters(tt.name, params)
 			if err != nil {
 				logrus.Warningf("Failed to upload schema parameters %s", err)

--- a/tests/sanity/sanity_eks_provisioning_test.go
+++ b/tests/sanity/sanity_eks_provisioning_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/rancher/shepherd/clients/rancher"
-	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
 	clusterActions "github.com/rancher/tests/actions/clusters"
 	provisioningActions "github.com/rancher/tests/actions/provisioning"
@@ -54,9 +53,6 @@ func (s *TfpSanityEKSProvisioningTestSuite) SetupSuite() {
 func (s *TfpSanityEKSProvisioningTestSuite) TestTfpProvisioningEKSSanity() {
 	var err error
 	var testUser, testPassword string
-	var clusterIDs []string
-
-	customClusterNames := []string{}
 
 	s.standardUserClient, testUser, testPassword, err = standarduser.CreateStandardUser(s.client)
 	require.NoError(s.T(), err)
@@ -81,46 +77,42 @@ func (s *TfpSanityEKSProvisioningTestSuite) TestTfpProvisioningEKSSanity() {
 		s.T().Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			rancher, terraform, terratest, _ := config.LoadTFPConfigs(s.cattleConfig)
+			rancher.AdminToken = standardToken
+			terraform.Module = tt.module
+			terratest.Nodepools = tt.nodePools
+			terratest.KubernetesVersion = tt.kubernetesVersion
+
 			nestedRancherModuleDir, perTestTerraformOptions, err := nested.CreateNestedModules(s.terraformConfig, s.terratestConfig, s.terraformOptions, tt.name, configs.NestedRancherModuleDir)
 			require.NoError(t, err)
 			defer os.RemoveAll(nestedRancherModuleDir)
 
 			newFile, rootBody, file := rancher2.InitializeNestedMainTFs(nestedRancherModuleDir)
 			defer file.Close()
-
-			cattleConfig, err := provisioning.UniquifyTerraform(s.cattleConfig)
-			require.NoError(t, err)
-
-			_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, standardToken, cattleConfig)
+			terratest, err = provisioning.GetK8sVersion(s.standardUserClient, terraform, terratest)
 			require.NoError(s.T(), err)
 
-			_, err = operations.ReplaceValue([]string{"terraform", "module"}, tt.module, cattleConfig)
-			require.NoError(s.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terratest", "nodepools"}, tt.nodePools, cattleConfig)
-			require.NoError(s.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terratest", "kubernetesVersion"}, tt.kubernetesVersion, cattleConfig)
-			require.NoError(s.T(), err)
-
-			provisioning.GetK8sVersion(s.standardUserClient, cattleConfig)
-
-			rancher, terraform, terratest, _ := config.LoadTFPConfigs(cattleConfig)
+			terraform = provisioning.UniquifyTerraform(terraform)
 
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, s.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(s.T(), perTestTerraformOptions, keyPath)
 
-			clusters, _ := provisioning.Provision(s.T(), s.client, s.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+			logrus.Infof("Provisioning cluster (%s)", terraform.ResourcePrefix)
+			clusters, _ := provisioning.Provision(s.T(), s.client, s.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, newFile, rootBody, file, false, false, true, "", nestedRancherModuleDir)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", clusters[0].Name)
 			err = provisioningActions.VerifyClusterReady(s.client, clusters[0])
 			require.NoError(s.T(), err)
 
+			logrus.Infof("Verifying service account token secret (%s)", clusters[0].Name)
 			err = clusterActions.VerifyServiceAccountTokenSecret(s.client, clusters[0].Name)
 			require.NoError(s.T(), err)
 
+			logrus.Infof("Verifying cluster pods (%s)", clusters[0].Name)
 			err = pods.VerifyClusterPods(s.client, clusters[0])
 			require.NoError(s.T(), err)
 
-			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
+			params := tfpQase.GetProvisioningSchemaParams(s.terraformConfig, s.terratestConfig)
 			err = qase.UpdateSchemaParameters(tt.name, params)
 			if err != nil {
 				logrus.Warningf("Failed to upload schema parameters %s", err)

--- a/tests/sanity/sanity_gke_provisioning_test.go
+++ b/tests/sanity/sanity_gke_provisioning_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/rancher/shepherd/clients/rancher"
-	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
 	clusterActions "github.com/rancher/tests/actions/clusters"
 	provisioningActions "github.com/rancher/tests/actions/provisioning"
@@ -54,9 +53,6 @@ func (s *TfpSanityGKEProvisioningTestSuite) SetupSuite() {
 func (s *TfpSanityGKEProvisioningTestSuite) TestTfpProvisioningGKESanity() {
 	var err error
 	var testUser, testPassword string
-	var clusterIDs []string
-
-	customClusterNames := []string{}
 
 	s.standardUserClient, testUser, testPassword, err = standarduser.CreateStandardUser(s.client)
 	require.NoError(s.T(), err)
@@ -81,46 +77,42 @@ func (s *TfpSanityGKEProvisioningTestSuite) TestTfpProvisioningGKESanity() {
 		s.T().Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			rancher, terraform, terratest, _ := config.LoadTFPConfigs(s.cattleConfig)
+			rancher.AdminToken = standardToken
+			terraform.Module = tt.module
+			terratest.Nodepools = tt.nodePools
+			terratest.KubernetesVersion = tt.kubernetesVersion
+
 			nestedRancherModuleDir, perTestTerraformOptions, err := nested.CreateNestedModules(s.terraformConfig, s.terratestConfig, s.terraformOptions, tt.name, configs.NestedRancherModuleDir)
 			require.NoError(t, err)
 			defer os.RemoveAll(nestedRancherModuleDir)
 
 			newFile, rootBody, file := rancher2.InitializeNestedMainTFs(nestedRancherModuleDir)
 			defer file.Close()
-
-			cattleConfig, err := provisioning.UniquifyTerraform(s.cattleConfig)
-			require.NoError(t, err)
-
-			_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, standardToken, cattleConfig)
+			terratest, err = provisioning.GetK8sVersion(s.standardUserClient, terraform, terratest)
 			require.NoError(s.T(), err)
 
-			_, err = operations.ReplaceValue([]string{"terraform", "module"}, tt.module, cattleConfig)
-			require.NoError(s.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terratest", "nodepools"}, tt.nodePools, cattleConfig)
-			require.NoError(s.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terratest", "kubernetesVersion"}, tt.kubernetesVersion, cattleConfig)
-			require.NoError(s.T(), err)
-
-			provisioning.GetK8sVersion(s.standardUserClient, cattleConfig)
-
-			rancher, terraform, terratest, _ := config.LoadTFPConfigs(cattleConfig)
+			terraform = provisioning.UniquifyTerraform(terraform)
 
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, s.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(s.T(), perTestTerraformOptions, keyPath)
 
-			clusters, _ := provisioning.Provision(s.T(), s.client, s.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+			logrus.Infof("Provisioning cluster (%s)", terraform.ResourcePrefix)
+			clusters, _ := provisioning.Provision(s.T(), s.client, s.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, newFile, rootBody, file, false, false, true, "", nestedRancherModuleDir)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", clusters[0].Name)
 			err = provisioningActions.VerifyClusterReady(s.client, clusters[0])
 			require.NoError(s.T(), err)
 
+			logrus.Infof("Verifying service account token secret (%s)", clusters[0].Name)
 			err = clusterActions.VerifyServiceAccountTokenSecret(s.client, clusters[0].Name)
 			require.NoError(s.T(), err)
 
+			logrus.Infof("Verifying cluster pods (%s)", clusters[0].Name)
 			err = pods.VerifyClusterPods(s.client, clusters[0])
 			require.NoError(s.T(), err)
 
-			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
+			params := tfpQase.GetProvisioningSchemaParams(s.terraformConfig, s.terratestConfig)
 			err = qase.UpdateSchemaParameters(tt.name, params)
 			if err != nil {
 				logrus.Warningf("Failed to upload schema parameters %s", err)

--- a/tests/sanity/sanity_ipv6_hosted_provisioning_test.go
+++ b/tests/sanity/sanity_ipv6_hosted_provisioning_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/rancher/shepherd/clients/rancher"
-	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
 	clusterActions "github.com/rancher/tests/actions/clusters"
 	provisioningActions "github.com/rancher/tests/actions/provisioning"
@@ -60,9 +59,6 @@ func (s *TfpSanityIPv6HostedProvisioningTestSuite) SetupSuite() {
 func (s *TfpSanityIPv6HostedProvisioningTestSuite) TestTfpProvisioningSanityIPv6Hosted() {
 	var err error
 	var testUser, testPassword string
-	var clusterIDs []string
-
-	customClusterNames := []string{}
 
 	s.standardUserClient, testUser, testPassword, err = standarduser.CreateStandardUser(s.client)
 	require.NoError(s.T(), err)
@@ -91,6 +87,12 @@ func (s *TfpSanityIPv6HostedProvisioningTestSuite) TestTfpProvisioningSanityIPv6
 		s.T().Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			rancher, terraform, terratest, _ := config.LoadTFPConfigs(s.cattleConfig)
+			rancher.AdminToken = standardToken
+			terratest.Nodepools = tt.nodeRoles
+			terraform.Module = tt.module
+			terratest.KubernetesVersion = tt.kubernetesVersion
+
 			nestedRancherModuleDir, perTestTerraformOptions, err := nested.CreateNestedModules(s.terraformConfig, s.terratestConfig, s.terraformOptions, tt.name, configs.NestedRancherModuleDir)
 			require.NoError(t, err)
 			defer os.RemoveAll(nestedRancherModuleDir)
@@ -98,37 +100,30 @@ func (s *TfpSanityIPv6HostedProvisioningTestSuite) TestTfpProvisioningSanityIPv6
 			newFile, rootBody, file := rancher2.InitializeNestedMainTFs(nestedRancherModuleDir)
 			defer file.Close()
 
-			cattleConfig, err := provisioning.UniquifyTerraform(s.cattleConfig)
+			terratest, err = provisioning.GetK8sVersion(s.standardUserClient, terraform, terratest)
 			require.NoError(t, err)
 
-			_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, standardToken, cattleConfig)
-			require.NoError(s.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terratest", "nodepools"}, tt.nodeRoles, cattleConfig)
-			require.NoError(s.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "module"}, tt.module, cattleConfig)
-			require.NoError(s.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terratest", "kubernetesVersion"}, tt.kubernetesVersion, cattleConfig)
-			require.NoError(s.T(), err)
-
-			rancher, terraform, terratest, _ := config.LoadTFPConfigs(cattleConfig)
+			terraform = provisioning.UniquifyTerraform(terraform)
 
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, s.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(s.T(), perTestTerraformOptions, keyPath)
 
-			clusters, _ := provisioning.Provision(s.T(), s.client, s.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+			logrus.Infof("Provisioning cluster (%s)", terraform.ResourcePrefix)
+			clusters, _ := provisioning.Provision(s.T(), s.client, s.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, newFile, rootBody, file, false, false, true, "", nestedRancherModuleDir)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", clusters[0].Name)
 			err = provisioningActions.VerifyClusterReady(s.client, clusters[0])
 			require.NoError(s.T(), err)
 
+			logrus.Infof("Verifying service account token secret (%s)", clusters[0].Name)
 			err = clusterActions.VerifyServiceAccountTokenSecret(s.client, clusters[0].Name)
 			require.NoError(s.T(), err)
 
+			logrus.Infof("Verifying cluster pods (%s)", clusters[0].Name)
 			err = pods.VerifyClusterPods(s.client, clusters[0])
 			require.NoError(s.T(), err)
 
-			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
+			params := tfpQase.GetProvisioningSchemaParams(s.terraformConfig, s.terratestConfig)
 			err = qase.UpdateSchemaParameters(tt.name, params)
 			if err != nil {
 				logrus.Warningf("Failed to upload schema parameters %s", err)

--- a/tests/sanity/sanity_ipv6_provisioning_test.go
+++ b/tests/sanity/sanity_ipv6_provisioning_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/rancher/shepherd/clients/rancher"
-	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
 	clusterActions "github.com/rancher/tests/actions/clusters"
 	provisioningActions "github.com/rancher/tests/actions/provisioning"
@@ -59,9 +58,6 @@ func (s *TfpSanityIPv6ProvisioningTestSuite) SetupSuite() {
 func (s *TfpSanityIPv6ProvisioningTestSuite) TestTfpProvisioningSanityIPv6() {
 	var err error
 	var testUser, testPassword string
-	var clusterIDs []string
-
-	customClusterNames := []string{}
 
 	s.standardUserClient, testUser, testPassword, err = standarduser.CreateStandardUser(s.client)
 	require.NoError(s.T(), err)
@@ -86,43 +82,41 @@ func (s *TfpSanityIPv6ProvisioningTestSuite) TestTfpProvisioningSanityIPv6() {
 		s.T().Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			rancher, terraform, terratest, _ := config.LoadTFPConfigs(s.cattleConfig)
+			rancher.AdminToken = standardToken
+			terratest.Nodepools = tt.nodeRoles
+			terraform.Module = tt.module
+
 			nestedRancherModuleDir, perTestTerraformOptions, err := nested.CreateNestedModules(s.terraformConfig, s.terratestConfig, s.terraformOptions, tt.name, configs.NestedRancherModuleDir)
 			require.NoError(t, err)
 			defer os.RemoveAll(nestedRancherModuleDir)
 
 			newFile, rootBody, file := rancher2.InitializeNestedMainTFs(nestedRancherModuleDir)
 			defer file.Close()
-
-			cattleConfig, err := provisioning.UniquifyTerraform(s.cattleConfig)
-			require.NoError(t, err)
-
-			_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, standardToken, cattleConfig)
+			terratest, err = provisioning.GetK8sVersion(s.standardUserClient, terraform, terratest)
 			require.NoError(s.T(), err)
 
-			_, err = operations.ReplaceValue([]string{"terratest", "nodepools"}, tt.nodeRoles, cattleConfig)
-			require.NoError(s.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "module"}, tt.module, cattleConfig)
-			require.NoError(s.T(), err)
-
-			provisioning.GetK8sVersion(s.standardUserClient, cattleConfig)
-
-			rancher, terraform, terratest, _ := config.LoadTFPConfigs(cattleConfig)
+			terraform = provisioning.UniquifyTerraform(terraform)
 
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, s.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(s.T(), perTestTerraformOptions, keyPath)
 
-			clusters, _ := provisioning.Provision(s.T(), s.client, s.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+			logrus.Infof("Provisioning cluster (%s)", terraform.ResourcePrefix)
+			clusters, _ := provisioning.Provision(s.T(), s.client, s.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, newFile, rootBody, file, false, false, true, "", nestedRancherModuleDir)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", clusters[0].Name)
 			err = provisioningActions.VerifyClusterReady(s.client, clusters[0])
 			require.NoError(s.T(), err)
 
+			logrus.Infof("Verifying service account token secret (%s)", clusters[0].Name)
 			err = clusterActions.VerifyServiceAccountTokenSecret(s.client, clusters[0].Name)
 			require.NoError(s.T(), err)
 
+			logrus.Infof("Verifying cluster pods (%s)", clusters[0].Name)
 			err = pods.VerifyClusterPods(s.client, clusters[0])
 			require.NoError(s.T(), err)
 
-			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
+			params := tfpQase.GetProvisioningSchemaParams(s.terraformConfig, s.terratestConfig)
 			err = qase.UpdateSchemaParameters(tt.name, params)
 			if err != nil {
 				logrus.Warningf("Failed to upload schema parameters %s", err)

--- a/tests/sanity/sanity_provisioning_test.go
+++ b/tests/sanity/sanity_provisioning_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/rancher/shepherd/clients/rancher"
-	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
 	clusterActions "github.com/rancher/tests/actions/clusters"
 	provisioningActions "github.com/rancher/tests/actions/provisioning"
@@ -61,9 +60,6 @@ func (s *TfpSanityProvisioningTestSuite) SetupSuite() {
 func (s *TfpSanityProvisioningTestSuite) TestTfpProvisioningSanity() {
 	var err error
 	var testUser, testPassword string
-	var clusterIDs []string
-
-	customClusterNames := []string{}
 
 	s.standardUserClient, testUser, testPassword, err = standarduser.CreateStandardUser(s.client)
 	require.NoError(s.T(), err)
@@ -96,6 +92,11 @@ func (s *TfpSanityProvisioningTestSuite) TestTfpProvisioningSanity() {
 		s.T().Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			rancher, terraform, terratest, _ := config.LoadTFPConfigs(s.cattleConfig)
+			rancher.AdminToken = standardToken
+			terratest.Nodepools = tt.nodeRoles
+			terraform.Module = tt.module
+
 			nestedRancherModuleDir, perTestTerraformOptions, err := nested.CreateNestedModules(s.terraformConfig, s.terratestConfig, s.terraformOptions, tt.name, configs.NestedRancherModuleDir)
 			require.NoError(t, err)
 			defer os.RemoveAll(nestedRancherModuleDir)
@@ -103,49 +104,47 @@ func (s *TfpSanityProvisioningTestSuite) TestTfpProvisioningSanity() {
 			newFile, rootBody, file := rancher2.InitializeNestedMainTFs(nestedRancherModuleDir)
 			defer file.Close()
 
-			cattleConfig, err := provisioning.UniquifyTerraform(s.cattleConfig)
+			terratest, err = provisioning.GetK8sVersion(s.standardUserClient, terraform, terratest)
 			require.NoError(t, err)
 
-			_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, standardToken, cattleConfig)
-			require.NoError(s.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terratest", "nodepools"}, tt.nodeRoles, cattleConfig)
-			require.NoError(s.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "module"}, tt.module, cattleConfig)
-			require.NoError(s.T(), err)
-
-			err = provisioning.GetK8sVersion(s.standardUserClient, cattleConfig)
-			require.NoError(t, err)
-
-			rancher, terraform, terratest, _ := config.LoadTFPConfigs(cattleConfig)
+			terraform = provisioning.UniquifyTerraform(terraform)
 
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, s.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(s.T(), perTestTerraformOptions, keyPath)
 
-			clusters, customClusterNames := provisioning.Provision(s.T(), s.client, s.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+			logrus.Infof("Provisioning cluster (%s)", terraform.ResourcePrefix)
+			clusters, customClusterName := provisioning.Provision(s.T(), s.client, s.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, newFile, rootBody, file, false, false, true, "", nestedRancherModuleDir)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", clusters[0].Name)
 			err = provisioningActions.VerifyClusterReady(s.client, clusters[0])
 			require.NoError(s.T(), err)
 
+			logrus.Infof("Verifying service account token secret (%s)", clusters[0].Name)
 			err = clusterActions.VerifyServiceAccountTokenSecret(s.client, clusters[0].Name)
 			require.NoError(s.T(), err)
 
+			logrus.Infof("Verifying cluster pods (%s)", clusters[0].Name)
 			err = pods.VerifyClusterPods(s.client, clusters[0])
 			require.NoError(s.T(), err)
 
 			if strings.Contains(terraform.Module, clustertypes.WINDOWS) {
-				clusters, customClusterNames = provisioning.Provision(s.T(), s.client, s.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, true, true, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+				logrus.Infof("Provisioning cluster (%s)", terraform.ResourcePrefix)
+				clusters, _ = provisioning.Provision(s.T(), s.client, s.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, newFile, rootBody, file, true, true, true, customClusterName, nestedRancherModuleDir)
+
+				logrus.Infof("Verifying the cluster is ready (%s)", clusters[0].Name)
 				err = provisioningActions.VerifyClusterReady(s.client, clusters[0])
 				require.NoError(s.T(), err)
 
+				logrus.Infof("Verifying service account token secret (%s)", clusters[0].Name)
 				err = clusterActions.VerifyServiceAccountTokenSecret(s.client, clusters[0].Name)
 				require.NoError(s.T(), err)
 
+				logrus.Infof("Verifying cluster pods (%s)", clusters[0].Name)
 				err = pods.VerifyClusterPods(s.client, clusters[0])
 				require.NoError(s.T(), err)
 			}
 
-			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
+			params := tfpQase.GetProvisioningSchemaParams(s.terraformConfig, s.terratestConfig)
 			err = qase.UpdateSchemaParameters(tt.name, params)
 			if err != nil {
 				logrus.Warningf("Failed to upload schema parameters %s", err)
@@ -161,7 +160,6 @@ func (s *TfpSanityProvisioningTestSuite) TestTfpProvisioningSanity() {
 func (s *TfpSanityProvisioningTestSuite) TestTfpProvisioningSanityImported() {
 	var err error
 	var testUser, testPassword string
-	var clusterIDs []string
 
 	s.standardUserClient, testUser, testPassword, err = standarduser.CreateStandardUser(s.client)
 	require.NoError(s.T(), err)
@@ -189,6 +187,8 @@ func (s *TfpSanityProvisioningTestSuite) TestTfpProvisioningSanityImported() {
 		s.T().Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			rancher, terraform, terratest, _ := config.LoadTFPConfigs(s.cattleConfig)
+
 			nestedRancherModuleDir, perTestTerraformOptions, err := nested.CreateNestedModules(s.terraformConfig, s.terratestConfig, s.terraformOptions, tt.name, configs.NestedRancherModuleDir)
 			require.NoError(t, err)
 			defer os.RemoveAll(nestedRancherModuleDir)
@@ -196,34 +196,33 @@ func (s *TfpSanityProvisioningTestSuite) TestTfpProvisioningSanityImported() {
 			newFile, rootBody, file := rancher2.InitializeNestedMainTFs(nestedRancherModuleDir)
 			defer file.Close()
 
-			cattleConfig, err := provisioning.UniquifyTerraform(s.cattleConfig)
+			rancher.AdminToken = standardToken
+			terraform.Module = tt.module
+
+			terratest, err = provisioning.GetK8sVersion(s.standardUserClient, terraform, terratest)
 			require.NoError(t, err)
 
-			_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, standardToken, cattleConfig)
-			require.NoError(s.T(), err)
-
-			_, err = operations.ReplaceValue([]string{"terraform", "module"}, tt.module, cattleConfig)
-			require.NoError(s.T(), err)
-
-			err = provisioning.GetK8sVersion(s.standardUserClient, cattleConfig)
-			require.NoError(t, err)
-
-			rancher, terraform, terratest, _ := config.LoadTFPConfigs(cattleConfig)
+			terraform = provisioning.UniquifyTerraform(terraform)
 
 			_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, s.terratestConfig.PathToRepo, "")
 			defer cleanup.Cleanup(s.T(), perTestTerraformOptions, keyPath)
 
-			clusters, _ := provisioning.Provision(s.T(), s.client, s.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, false, true, clusterIDs, nil, nestedRancherModuleDir)
+			logrus.Infof("Provisioning cluster (%s)", terraform.ResourcePrefix)
+			clusters, _ := provisioning.Provision(s.T(), s.client, s.standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, newFile, rootBody, file, false, false, true, "", nestedRancherModuleDir)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", clusters[0].Name)
 			err = provisioningActions.VerifyClusterReady(s.client, clusters[0])
 			require.NoError(s.T(), err)
 
+			logrus.Infof("Verifying service account token secret (%s)", clusters[0].Name)
 			err = clusterActions.VerifyServiceAccountTokenSecret(s.client, clusters[0].Name)
 			require.NoError(s.T(), err)
 
+			logrus.Infof("Verifying cluster pods (%s)", clusters[0].Name)
 			err = pods.VerifyClusterPods(s.client, clusters[0])
 			require.NoError(s.T(), err)
 
-			params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
+			params := tfpQase.GetProvisioningSchemaParams(s.terraformConfig, s.terratestConfig)
 			err = qase.UpdateSchemaParameters(tt.name, params)
 			if err != nil {
 				logrus.Warningf("Failed to upload schema parameters %s", err)

--- a/tests/sanity/sanity_upgrade_dual_stack_rancher_test.go
+++ b/tests/sanity/sanity_upgrade_dual_stack_rancher_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/rancher/shepherd/clients/rancher"
-	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
 	clusterActions "github.com/rancher/tests/actions/clusters"
 	provisioningActions "github.com/rancher/tests/actions/provisioning"
@@ -84,7 +83,6 @@ func (s *TfpSanityDualStackUpgradeRancherTestSuite) TestTfpUpgradeDualStackRanch
 
 func (s *TfpSanityDualStackUpgradeRancherTestSuite) provisionAndVerifyCluster(name string, standardUserClient *rancher.Client, standardToken,
 	testUser, testPassword string) string {
-	var clusterIDs []string
 	var nestedRancherModuleDir string
 
 	nodeRolesDedicated := []config.Nodepool{config.EtcdNodePool, config.ControlPlaneNodePool, config.WorkerNodePool}
@@ -104,39 +102,38 @@ func (s *TfpSanityDualStackUpgradeRancherTestSuite) provisionAndVerifyCluster(na
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
 
+				rancher, terraform, terratest, _ := config.LoadTFPConfigs(s.cattleConfig)
+				rancher.AdminToken = standardToken
+				terratest.Nodepools = tt.nodeRoles
+				terraform.Module = tt.module
+
 				nestedRancherModuleDir, perTestTerraformOptions, err := nested.CreateNestedModules(s.terraformConfig, s.terratestConfig, s.terraformOptions, tt.name, configs.NestedRancherModuleDir)
 				require.NoError(t, err)
 
 				newFile, rootBody, file := rancher2.InitializeNestedMainTFs(nestedRancherModuleDir)
 				defer file.Close()
 
-				cattleConfig, err := provisioning.UniquifyTerraform(s.cattleConfig)
+				terratest, err = provisioning.GetK8sVersion(standardUserClient, terraform, terratest)
 				require.NoError(t, err)
 
-				_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, standardToken, cattleConfig)
-				require.NoError(t, err)
+				terraform = provisioning.UniquifyTerraform(terraform)
 
-				_, err = operations.ReplaceValue([]string{"terratest", "nodepools"}, tt.nodeRoles, cattleConfig)
-				require.NoError(t, err)
+				logrus.Infof("Provisioning cluster (%s)", terraform.ResourcePrefix)
+				clusters, _ := provisioning.Provision(t, s.client, standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, newFile, rootBody, file, false, true, true, "", nestedRancherModuleDir)
 
-				_, err = operations.ReplaceValue([]string{"terraform", "module"}, tt.module, cattleConfig)
-				require.NoError(t, err)
-
-				provisioning.GetK8sVersion(standardUserClient, cattleConfig)
-
-				rancher, terraform, terratest, _ := config.LoadTFPConfigs(cattleConfig)
-
-				clusters, _ := provisioning.Provision(t, s.client, standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, true, true, clusterIDs, nil, nestedRancherModuleDir)
+				logrus.Infof("Verifying the cluster is ready (%s)", clusters[0].Name)
 				err = provisioningActions.VerifyClusterReady(s.client, clusters[0])
 				require.NoError(t, err)
 
+				logrus.Infof("Verifying service account token secret (%s)", clusters[0].Name)
 				err = clusterActions.VerifyServiceAccountTokenSecret(s.client, clusters[0].Name)
 				require.NoError(t, err)
 
+				logrus.Infof("Verifying cluster pods (%s)", clusters[0].Name)
 				err = pods.VerifyClusterPods(s.client, clusters[0])
 				require.NoError(t, err)
 
-				params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
+				params := tfpQase.GetProvisioningSchemaParams(s.terraformConfig, s.terratestConfig)
 				err = qase.UpdateSchemaParameters(tt.name, params)
 				if err != nil {
 					logrus.Warningf("Failed to upload schema parameters %s", err)

--- a/tests/sanity/sanity_upgrade_ipv6_rancher_test.go
+++ b/tests/sanity/sanity_upgrade_ipv6_rancher_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/rancher/shepherd/clients/rancher"
-	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
 	clusterActions "github.com/rancher/tests/actions/clusters"
 	provisioningActions "github.com/rancher/tests/actions/provisioning"
@@ -84,7 +83,6 @@ func (s *TfpSanityIPv6UpgradeRancherTestSuite) TestTfpUpgradeIPv6Rancher() {
 
 func (s *TfpSanityIPv6UpgradeRancherTestSuite) provisionAndVerifyCluster(name string, standardUserClient *rancher.Client, standardToken,
 	testUser, testPassword string) string {
-	var clusterIDs []string
 	var nestedRancherModuleDir string
 
 	nodeRolesDedicated := []config.Nodepool{config.EtcdNodePool, config.ControlPlaneNodePool, config.WorkerNodePool}
@@ -104,39 +102,38 @@ func (s *TfpSanityIPv6UpgradeRancherTestSuite) provisionAndVerifyCluster(name st
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
 
+				rancher, terraform, terratest, _ := config.LoadTFPConfigs(s.cattleConfig)
+				rancher.AdminToken = standardToken
+				terratest.Nodepools = tt.nodeRoles
+				terraform.Module = tt.module
+
 				nestedRancherModuleDir, perTestTerraformOptions, err := nested.CreateNestedModules(s.terraformConfig, s.terratestConfig, s.terraformOptions, tt.name, configs.NestedRancherModuleDir)
 				require.NoError(t, err)
 
 				newFile, rootBody, file := rancher2.InitializeNestedMainTFs(nestedRancherModuleDir)
 				defer file.Close()
 
-				cattleConfig, err := provisioning.UniquifyTerraform(s.cattleConfig)
+				terratest, err = provisioning.GetK8sVersion(standardUserClient, terraform, terratest)
 				require.NoError(t, err)
 
-				_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, standardToken, cattleConfig)
-				require.NoError(t, err)
+				terraform = provisioning.UniquifyTerraform(terraform)
 
-				_, err = operations.ReplaceValue([]string{"terratest", "nodepools"}, tt.nodeRoles, cattleConfig)
-				require.NoError(t, err)
+				logrus.Infof("Provisioning cluster (%s)", terraform.ResourcePrefix)
+				clusters, _ := provisioning.Provision(t, s.client, standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, newFile, rootBody, file, false, true, true, "", nestedRancherModuleDir)
 
-				_, err = operations.ReplaceValue([]string{"terraform", "module"}, tt.module, cattleConfig)
-				require.NoError(t, err)
-
-				provisioning.GetK8sVersion(standardUserClient, cattleConfig)
-
-				rancher, terraform, terratest, _ := config.LoadTFPConfigs(cattleConfig)
-
-				clusters, _ := provisioning.Provision(t, s.client, standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, true, true, clusterIDs, nil, nestedRancherModuleDir)
+				logrus.Infof("Verifying the cluster is ready (%s)", clusters[0].Name)
 				err = provisioningActions.VerifyClusterReady(s.client, clusters[0])
 				require.NoError(t, err)
 
+				logrus.Infof("Verifying service account token secret (%s)", clusters[0].Name)
 				err = clusterActions.VerifyServiceAccountTokenSecret(s.client, clusters[0].Name)
 				require.NoError(t, err)
 
+				logrus.Infof("Verifying cluster pods (%s)", clusters[0].Name)
 				err = pods.VerifyClusterPods(s.client, clusters[0])
 				require.NoError(t, err)
 
-				params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
+				params := tfpQase.GetProvisioningSchemaParams(s.terraformConfig, s.terratestConfig)
 				err = qase.UpdateSchemaParameters(tt.name, params)
 				if err != nil {
 					logrus.Warningf("Failed to upload schema parameters %s", err)

--- a/tests/sanity/sanity_upgrade_rancher_test.go
+++ b/tests/sanity/sanity_upgrade_rancher_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/rancher/shepherd/clients/rancher"
-	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
 	clusterActions "github.com/rancher/tests/actions/clusters"
 	provisioningActions "github.com/rancher/tests/actions/provisioning"
@@ -88,10 +87,7 @@ func (s *TfpSanityUpgradeRancherTestSuite) TestTfpUpgradeRancher() {
 
 func (s *TfpSanityUpgradeRancherTestSuite) provisionAndVerifyCluster(name string, standardUserClient *rancher.Client, standardToken,
 	testUser, testPassword string) string {
-	var clusterIDs []string
 	var nestedRancherModuleDir string
-
-	customClusterNames := []string{}
 	nodeRolesDedicated := []config.Nodepool{config.EtcdNodePool, config.ControlPlaneNodePool, config.WorkerNodePool}
 	nodeRolesWindows := []config.Nodepool{config.EtcdNodePool, config.ControlPlaneNodePool, config.WorkerNodePool, config.WindowsNodePool}
 	rke2Module, rke2Windows2019, rke2Windows2022, k3sModule := provisioning.DownstreamClusterModules(s.terraformConfig)
@@ -115,52 +111,55 @@ func (s *TfpSanityUpgradeRancherTestSuite) provisionAndVerifyCluster(name string
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
 
+				rancher, terraform, terratest, _ := config.LoadTFPConfigs(s.cattleConfig)
+				rancher.AdminToken = standardToken
+				terratest.Nodepools = tt.nodeRoles
+				terraform.Module = tt.module
+
 				nestedRancherModuleDir, perTestTerraformOptions, err := nested.CreateNestedModules(s.terraformConfig, s.terratestConfig, s.terraformOptions, tt.name, configs.NestedRancherModuleDir)
 				require.NoError(t, err)
 
 				newFile, rootBody, file := rancher2.InitializeNestedMainTFs(nestedRancherModuleDir)
 				defer file.Close()
 
-				cattleConfig, err := provisioning.UniquifyTerraform(s.cattleConfig)
+				terratest, err = provisioning.GetK8sVersion(standardUserClient, terraform, terratest)
 				require.NoError(t, err)
 
-				_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, standardToken, cattleConfig)
-				require.NoError(t, err)
+				terraform = provisioning.UniquifyTerraform(terraform)
 
-				_, err = operations.ReplaceValue([]string{"terratest", "nodepools"}, tt.nodeRoles, cattleConfig)
-				require.NoError(t, err)
+				logrus.Infof("Provisioning cluster (%s)", terraform.ResourcePrefix)
+				clusters, customClusterName := provisioning.Provision(t, s.client, standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, newFile, rootBody, file, false, true, true, "", nestedRancherModuleDir)
 
-				_, err = operations.ReplaceValue([]string{"terraform", "module"}, tt.module, cattleConfig)
-				require.NoError(t, err)
-
-				err = provisioning.GetK8sVersion(standardUserClient, cattleConfig)
-				require.NoError(t, err)
-
-				rancher, terraform, terratest, _ := config.LoadTFPConfigs(cattleConfig)
-
-				clusters, customClusterNames := provisioning.Provision(t, s.client, standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, false, true, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+				logrus.Infof("Verifying the cluster is ready (%s)", clusters[0].Name)
 				err = provisioningActions.VerifyClusterReady(s.client, clusters[0])
 				require.NoError(t, err)
 
+				logrus.Infof("Verifying service account token secret (%s)", clusters[0].Name)
 				err = clusterActions.VerifyServiceAccountTokenSecret(s.client, clusters[0].Name)
 				require.NoError(t, err)
 
+				logrus.Infof("Verifying cluster pods (%s)", clusters[0].Name)
 				err = pods.VerifyClusterPods(s.client, clusters[0])
 				require.NoError(t, err)
 
 				if strings.Contains(terraform.Module, clustertypes.WINDOWS) {
-					clusters, customClusterNames = provisioning.Provision(t, s.client, standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, []map[string]any{cattleConfig}, newFile, rootBody, file, true, true, true, clusterIDs, customClusterNames, nestedRancherModuleDir)
+					logrus.Infof("Provisioning cluster (%s)", terraform.ResourcePrefix)
+					clusters, _ = provisioning.Provision(t, s.client, standardUserClient, rancher, terraform, terratest, testUser, testPassword, perTestTerraformOptions, newFile, rootBody, file, true, true, true, customClusterName, nestedRancherModuleDir)
+
+					logrus.Infof("Verifying the cluster is ready (%s)", clusters[0].Name)
 					err = provisioningActions.VerifyClusterReady(s.client, clusters[0])
 					require.NoError(t, err)
 
+					logrus.Infof("Verifying service account token secret (%s)", clusters[0].Name)
 					err = clusterActions.VerifyServiceAccountTokenSecret(s.client, clusters[0].Name)
 					require.NoError(t, err)
 
+					logrus.Infof("Verifying cluster pods (%s)", clusters[0].Name)
 					err = pods.VerifyClusterPods(s.client, clusters[0])
 					require.NoError(t, err)
 				}
 
-				params := tfpQase.GetProvisioningSchemaParams(cattleConfig)
+				params := tfpQase.GetProvisioningSchemaParams(s.terraformConfig, s.terratestConfig)
 				err = qase.UpdateSchemaParameters(tt.name, params)
 				if err != nil {
 					logrus.Warningf("Failed to upload schema parameters %s", err)


### PR DESCRIPTION
Changes:
* removed old config map logic for our old parallelism approach.
* removed config maps from all functions and updated them with appropriate terraform/terratest vars
* Added better logging to all tests
* Updated uniquify to not override things 😓 . (its a 1 liner now so maybe we scrap it altogether?) 