### PR TITLE
Allow parameterized logging in GHA workflows

### DIFF
--- a/.github/workflows/community-prime-upgrade-test.yaml
+++ b/.github/workflows/community-prime-upgrade-test.yaml
@@ -207,6 +207,8 @@ jobs:
               upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true

--- a/.github/workflows/kdm-test.yaml
+++ b/.github/workflows/kdm-test.yaml
@@ -215,6 +215,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -486,6 +488,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_14 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -759,6 +763,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_13 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG

--- a/.github/workflows/mcm-test.yaml
+++ b/.github/workflows/mcm-test.yaml
@@ -203,6 +203,7 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -448,6 +449,7 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_14 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -694,6 +696,7 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_13 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG

--- a/.github/workflows/post-release-sanity-upgrade.yaml
+++ b/.github/workflows/post-release-sanity-upgrade.yaml
@@ -243,6 +243,8 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -521,6 +523,8 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -799,6 +803,8 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true

--- a/.github/workflows/post-release-sanity.yaml
+++ b/.github/workflows/post-release-sanity.yaml
@@ -229,6 +229,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_14 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -493,6 +495,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_14 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -757,6 +761,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_13 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true

--- a/.github/workflows/prime-community-upgrade-test.yaml
+++ b/.github/workflows/prime-community-upgrade-test.yaml
@@ -219,6 +219,8 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true

--- a/.github/workflows/rancher2-recurring-test.yaml
+++ b/.github/workflows/rancher2-recurring-test.yaml
@@ -231,6 +231,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -241,9 +243,6 @@ jobs:
               - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
                 windows: true
             snapshotInput: {}
-            aksKubernetesVersion: "${{ vars.AKS_KUBERNETES_VERSION_2_15 }}"
-            eksKubernetesVersion: "${{ vars.EKS_KUBERNETES_VERSION_2_15 }}"
-            gkeKubernetesVersion: "${{ vars.GKE_KUBERNETES_VERSION_2_15 }}"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -540,6 +539,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_14 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -550,9 +551,6 @@ jobs:
               - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
                 windows: true
             snapshotInput: {}
-            aksKubernetesVersion: "${{ vars.AKS_KUBERNETES_VERSION_2_14 }}"
-            eksKubernetesVersion: "${{ vars.EKS_KUBERNETES_VERSION_2_14 }}"
-            gkeKubernetesVersion: "${{ vars.GKE_KUBERNETES_VERSION_2_14 }}"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -842,6 +840,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_13 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -852,9 +852,6 @@ jobs:
               - quantity: ${{ vars.WINDOWS_NODE_COUNT }}
                 windows: true
             snapshotInput: {}
-            aksKubernetesVersion: "${{ vars.AKS_KUBERNETES_VERSION_2_13 }}"
-            eksKubernetesVersion: "${{ vars.EKS_KUBERNETES_VERSION_2_13 }}"
-            gkeKubernetesVersion: "${{ vars.GKE_KUBERNETES_VERSION_2_13 }}"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG

--- a/.github/workflows/registry-test.yaml
+++ b/.github/workflows/registry-test.yaml
@@ -226,6 +226,8 @@ jobs:
               ecrURI: "${{ secrets.ECR_URI }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -512,6 +514,8 @@ jobs:
               ecrURI: "${{ secrets.ECR_URI }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -810,6 +814,8 @@ jobs:
               ecrURI: "${{ secrets.ECR_URI }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true

--- a/.github/workflows/sanity-aks-test.yaml
+++ b/.github/workflows/sanity-aks-test.yaml
@@ -229,6 +229,8 @@ jobs:
               repo: "${{ env.RANCHER_REPO }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             aksKubernetesVersion: "${{ vars.AKS_KUBERNETES_VERSION_2_15 }}"
           EOF
 
@@ -489,6 +491,8 @@ jobs:
               repo: "${{ env.RANCHER_REPO }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             aksKubernetesVersion: "${{ vars.AKS_KUBERNETES_VERSION_2_14 }}"
           EOF
 
@@ -751,6 +755,8 @@ jobs:
               repo: "${{ env.RANCHER_REPO }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             aksKubernetesVersion: "${{ vars.AKS_KUBERNETES_VERSION_2_13 }}"
           EOF
 

--- a/.github/workflows/sanity-arm64-test.yaml
+++ b/.github/workflows/sanity-arm64-test.yaml
@@ -222,6 +222,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -512,6 +514,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_14 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -804,6 +808,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_13 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true

--- a/.github/workflows/sanity-dualstack-test.yaml
+++ b/.github/workflows/sanity-dualstack-test.yaml
@@ -233,6 +233,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -515,6 +517,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_14 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -798,6 +802,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_13 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG

--- a/.github/workflows/sanity-dualstack-upgrade-test.yaml
+++ b/.github/workflows/sanity-dualstack-upgrade-test.yaml
@@ -240,6 +240,8 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -539,6 +541,8 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -839,6 +843,8 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true

--- a/.github/workflows/sanity-eks-test.yaml
+++ b/.github/workflows/sanity-eks-test.yaml
@@ -229,6 +229,8 @@ jobs:
               repo: "${{ env.RANCHER_REPO }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             eksKubernetesVersion: "${{ vars.EKS_KUBERNETES_VERSION_2_14 }}"
           EOF
 
@@ -496,6 +498,8 @@ jobs:
               repo: "${{ env.RANCHER_REPO }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             eksKubernetesVersion: "${{ vars.EKS_KUBERNETES_VERSION_2_14 }}"
           EOF
 
@@ -765,6 +769,8 @@ jobs:
               repo: "${{ env.RANCHER_REPO }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             eksKubernetesVersion: "${{ vars.EKS_KUBERNETES_VERSION_2_13 }}"
           EOF
 

--- a/.github/workflows/sanity-gke-test.yaml
+++ b/.github/workflows/sanity-gke-test.yaml
@@ -218,6 +218,8 @@ jobs:
               repo: "${{ env.RANCHER_REPO }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             gkeKubernetesVersion: "${{ vars.GKE_KUBERNETES_VERSION_2_15 }}"
           EOF
 
@@ -467,6 +469,8 @@ jobs:
               repo: "${{ env.RANCHER_REPO }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             gkeKubernetesVersion: "${{ vars.GKE_KUBERNETES_VERSION_2_14 }}"
           EOF
 
@@ -718,6 +722,8 @@ jobs:
               repo: "${{ env.RANCHER_REPO }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             gkeKubernetesVersion: "${{ vars.GKE_KUBERNETES_VERSION_2_13 }}"
           EOF
 

--- a/.github/workflows/sanity-ipv6-hosted-cluster-test.yaml
+++ b/.github/workflows/sanity-ipv6-hosted-cluster-test.yaml
@@ -235,6 +235,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             eksKubernetesVersion: "${{ vars.EKS_KUBERNETES_VERSION_2_15 }}"
           EOF
 
@@ -520,6 +522,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_14 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             eksKubernetesVersion: "${{ vars.EKS_KUBERNETES_VERSION_2_14 }}"
           EOF
 

--- a/.github/workflows/sanity-ipv6-test.yaml
+++ b/.github/workflows/sanity-ipv6-test.yaml
@@ -233,6 +233,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -515,6 +517,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_14 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -798,6 +802,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_13 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG

--- a/.github/workflows/sanity-ipv6-upgrade-test.yaml
+++ b/.github/workflows/sanity-ipv6-upgrade-test.yaml
@@ -240,6 +240,8 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -539,6 +541,8 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -839,6 +843,8 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true

--- a/.github/workflows/sanity-mixed-arch-test.yaml
+++ b/.github/workflows/sanity-mixed-arch-test.yaml
@@ -225,6 +225,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -518,6 +520,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_14 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true

--- a/.github/workflows/sanity-test.yaml
+++ b/.github/workflows/sanity-test.yaml
@@ -341,6 +341,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -732,6 +734,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_14 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -1125,6 +1129,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_13 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true

--- a/.github/workflows/sanity-turtles-off-test.yaml
+++ b/.github/workflows/sanity-turtles-off-test.yaml
@@ -238,6 +238,8 @@ jobs:
                 turtles: "false"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true

--- a/.github/workflows/sanity-upgrade-arm64-test.yaml
+++ b/.github/workflows/sanity-upgrade-arm64-test.yaml
@@ -229,6 +229,8 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -526,6 +528,8 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -825,6 +829,8 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true

--- a/.github/workflows/sanity-upgrade-test.yaml
+++ b/.github/workflows/sanity-upgrade-test.yaml
@@ -348,6 +348,8 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -745,6 +747,8 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -1145,6 +1149,8 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true


### PR DESCRIPTION
### Description
One enhancement that we should add to our GHA workflows is to ensure that we parameterize our logging level. Right now, it defaults to `info` in our `defaults.yaml` files. However, it would be better to parameterize in GHA and to be able to edit the logging level in Github directly.

This allows much more flexibility and will help when troubleshooting various issues.