### PR TITLE
Update rancher verifications

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,8 +53,8 @@ require (
 	github.com/rancher/norman v0.8.1
 	github.com/rancher/rancher/pkg/apis v0.0.0
 	github.com/rancher/shepherd v0.0.0-20260417171403-fce40497b62e
-	github.com/rancher/tests v0.0.0-20260421170401-642ea66e1af4
-	github.com/rancher/tests/actions v0.0.0-20260421170401-642ea66e1af4
+	github.com/rancher/tests v0.0.0-20260427222935-93821bd449b4
+	github.com/rancher/tests/actions v0.0.0-20260427222935-93821bd449b4
 	github.com/sirupsen/logrus v1.9.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -305,10 +305,10 @@ github.com/rancher/shepherd v0.0.0-20260417171403-fce40497b62e h1:Ebfatf9cHp8JME
 github.com/rancher/shepherd v0.0.0-20260417171403-fce40497b62e/go.mod h1:SJtW8Jqv0rphZzsGnvB965YdyR2FqFtB+TbbzVLt8F4=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250930163923-f2c9e60b1078 h1:1MJSgYkgXhr/Zc5idJkKa10SiBQd0HVtbxVOBoghlzY=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250930163923-f2c9e60b1078/go.mod h1:CV2Soy/Skw8/SA9dDJVgpeHxoEdtjYkNpNy6xvvC5kA=
-github.com/rancher/tests v0.0.0-20260421170401-642ea66e1af4 h1:e2wUDu2XKf0SJyyMQAVJj2TiifeUp3+xARLglX0CVEQ=
-github.com/rancher/tests v0.0.0-20260421170401-642ea66e1af4/go.mod h1:3ACLZPIUuW9M+geuMhNKRrKKDXtmJqYO3ZTaBa2kFec=
-github.com/rancher/tests/actions v0.0.0-20260421170401-642ea66e1af4 h1:8KdE/AJ9FP786WfcGwwOeWeJOV2+XV+hXyMOr2u/CWU=
-github.com/rancher/tests/actions v0.0.0-20260421170401-642ea66e1af4/go.mod h1:0M87e2iNZwCSxhCU7v6JGblt1CaWHtt7QJgIOAC6jNE=
+github.com/rancher/tests v0.0.0-20260427222935-93821bd449b4 h1:XwRw0SwH3/Z3nYlHBT3AyNrWG/Uf15n7KJCu5fV2GAA=
+github.com/rancher/tests v0.0.0-20260427222935-93821bd449b4/go.mod h1:dMkkEN20zukthsWSPZFaALwNLgfoWNrfFRdDY4l4930=
+github.com/rancher/tests/actions v0.0.0-20260427222935-93821bd449b4 h1:PzCVdumk6cq0cbfMoDc7Z5pO2jd3SD+HlQkXkuExSCc=
+github.com/rancher/tests/actions v0.0.0-20260427222935-93821bd449b4/go.mod h1:Hk9ext9wkgum3cjkmVg9+NA92r5KbOuEfQlhcgI+Dis=
 github.com/rancher/wrangler v1.1.2 h1:oXbXo9k7y/H4drUpb4RM1c++vT9O3rpoNEfyusGykiU=
 github.com/rancher/wrangler v1.1.2/go.mod h1:2k9MyhlBdjcutcBGoOJSUAz0HgDAXnMjv81d3n/AaQc=
 github.com/rancher/wrangler/v3 v3.3.1 h1:YFqRfhxjuLNudUrvWrn+64wUPZ8pnn2KWbTsha75JLg=

--- a/tests/infrastructure/ranchers/create_rancher.go
+++ b/tests/infrastructure/ranchers/create_rancher.go
@@ -6,15 +6,19 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/defaults/namespaces"
 	shepherdConfig "github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/tests/actions/features"
 	reg "github.com/rancher/tests/actions/registries"
+	"github.com/rancher/tests/actions/workloads/deployment"
+	"github.com/rancher/tests/actions/workloads/pods"
 	infraConfig "github.com/rancher/tests/validation/recurring/infrastructure/config"
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/defaults/keypath"
 	"github.com/rancher/tfp-automation/defaults/providers"
+	"github.com/rancher/tfp-automation/defaults/stevetypes"
 	"github.com/rancher/tfp-automation/framework"
 	featureDefaults "github.com/rancher/tfp-automation/framework/set/defaults/features"
 	"github.com/rancher/tfp-automation/framework/set/resources/airgap"
@@ -27,6 +31,7 @@ import (
 	"github.com/rancher/tfp-automation/framework/set/resources/sanity"
 	"github.com/rancher/tfp-automation/tests/extensions/provisioning"
 	"github.com/rancher/tfp-automation/tests/extensions/ssh"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -67,6 +72,17 @@ func SetupAirgapRancher(t *testing.T, session *session.Session, moduleKeyPath st
 		t.Fatalf("ERROR: not all of the local cluster pods are using the private registry")
 	}
 
+	cluster, err := client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetLocal + "/local")
+	require.NoError(t, err)
+
+	logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+	err = deployment.VerifyClusterDeployments(client, cluster)
+	require.NoError(t, err)
+
+	logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+	err = pods.VerifyClusterPods(client, cluster)
+	require.NoError(t, err)
+
 	return client, registry, bastion, standaloneTerraformOptions, terraformOptions, cattleConfig, tunnel
 }
 
@@ -92,6 +108,17 @@ func SetupDualStackRancher(t *testing.T, session *session.Session, moduleKeyPath
 	_, keyPath = rancher2.SetKeyPath(keypath.RancherKeyPath, terratestConfig.PathToRepo, "")
 	terraformOptions := framework.Setup(t, terraformConfig, terratestConfig, keyPath)
 
+	cluster, err := client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetLocal + "/local")
+	require.NoError(t, err)
+
+	logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+	err = deployment.VerifyClusterDeployments(client, cluster)
+	require.NoError(t, err)
+
+	logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+	err = pods.VerifyClusterPods(client, cluster)
+	require.NoError(t, err)
+
 	return client, serverNodeOne, standaloneTerraformOptions, terraformOptions, cattleConfig
 }
 
@@ -116,6 +143,17 @@ func SetupIPv6Rancher(t *testing.T, session *session.Session, moduleKeyPath stri
 
 	_, keyPath = rancher2.SetKeyPath(keypath.RancherKeyPath, terratestConfig.PathToRepo, "")
 	terraformOptions := framework.Setup(t, terraformConfig, terratestConfig, keyPath)
+
+	cluster, err := client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetLocal + "/local")
+	require.NoError(t, err)
+
+	logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+	err = deployment.VerifyClusterDeployments(client, cluster)
+	require.NoError(t, err)
+
+	logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+	err = pods.VerifyClusterPods(client, cluster)
+	require.NoError(t, err)
 
 	return client, bastionNode, standaloneTerraformOptions, terraformOptions, cattleConfig
 }
@@ -150,6 +188,17 @@ func SetupProxyRancher(t *testing.T, session *session.Session, moduleKeyPath str
 
 	_, keyPath = rancher2.SetKeyPath(keypath.RancherKeyPath, terratestConfig.PathToRepo, "")
 	terraformOptions := framework.Setup(t, terraformConfig, terratestConfig, keyPath)
+
+	cluster, err := client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetLocal + "/local")
+	require.NoError(t, err)
+
+	logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+	err = deployment.VerifyClusterDeployments(client, cluster)
+	require.NoError(t, err)
+
+	logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+	err = pods.VerifyClusterPods(client, cluster)
+	require.NoError(t, err)
 
 	return client, proxyBastion, proxyPrivateIP, standaloneTerraformOptions, terraformOptions, cattleConfig
 }
@@ -206,6 +255,17 @@ func SetupRancher(t *testing.T, session *session.Session, moduleKeyPath string) 
 	_, keyPath = rancher2.SetKeyPath(keypath.RancherKeyPath, terratestConfig.PathToRepo, "")
 	terraformOptions := framework.Setup(t, terraformConfig, terratestConfig, keyPath)
 
+	cluster, err := client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetLocal + "/local")
+	require.NoError(t, err)
+
+	logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+	err = deployment.VerifyClusterDeployments(client, cluster)
+	require.NoError(t, err)
+
+	logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+	err = pods.VerifyClusterPods(client, cluster)
+	require.NoError(t, err)
+
 	return client, serverNodeOne, standaloneTerraformOptions, terraformOptions, cattleConfig
 }
 
@@ -236,6 +296,17 @@ func SetupRegistryRancher(t *testing.T, session *session.Session, moduleKeyPath 
 	if !usesRegistryPrefix {
 		t.Fatalf("ERROR: not all of the local cluster pods are using the global registry")
 	}
+
+	cluster, err := client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetLocal + "/local")
+	require.NoError(t, err)
+
+	logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+	err = deployment.VerifyClusterDeployments(client, cluster)
+	require.NoError(t, err)
+
+	logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+	err = pods.VerifyClusterPods(client, cluster)
+	require.NoError(t, err)
 
 	return client, authRegistry, nonAuthRegistry, globalRegistry, standaloneTerraformOptions, terraformOptions, cattleConfig
 }

--- a/tests/infrastructure/ranchers/upgrade_rancher.go
+++ b/tests/infrastructure/ranchers/upgrade_rancher.go
@@ -6,15 +6,20 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/defaults/namespaces"
 	"github.com/rancher/shepherd/pkg/session"
 	reg "github.com/rancher/tests/actions/registries"
+	"github.com/rancher/tests/actions/workloads/deployment"
+	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/defaults/keypath"
+	"github.com/rancher/tfp-automation/defaults/stevetypes"
 	"github.com/rancher/tfp-automation/framework"
 	"github.com/rancher/tfp-automation/framework/set/resources/rancher2"
 	"github.com/rancher/tfp-automation/framework/set/resources/upgrade"
 	"github.com/rancher/tfp-automation/tests/extensions/provisioning"
 	"github.com/rancher/tfp-automation/tests/extensions/ssh"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -67,6 +72,17 @@ func UpgradeAirgapRancher(t *testing.T, client *rancher.Client, bastion, registr
 		t.Fatalf("ERROR: not all of the local cluster pods are using the private registry")
 	}
 
+	cluster, err := client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetLocal + "/local")
+	require.NoError(t, err)
+
+	logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+	err = deployment.VerifyClusterDeployments(client, cluster)
+	require.NoError(t, err)
+
+	logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+	err = pods.VerifyClusterPods(client, cluster)
+	require.NoError(t, err)
+
 	return client, updatedCattleConfig, terraformOptions, upgradeTerraformOptions
 }
 
@@ -104,6 +120,17 @@ func UpgradeDualStackRancher(t *testing.T, client *rancher.Client, serverNodeOne
 	_, keyPath = rancher2.SetKeyPath(keypath.RancherKeyPath, terratestConfig.PathToRepo, "")
 	terraformOptions := framework.Setup(t, terraformConfig, terratestConfig, keyPath)
 
+	cluster, err := client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetLocal + "/local")
+	require.NoError(t, err)
+
+	logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+	err = deployment.VerifyClusterDeployments(client, cluster)
+	require.NoError(t, err)
+
+	logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+	err = pods.VerifyClusterPods(client, cluster)
+	require.NoError(t, err)
+
 	return client, updatedCattleConfig, terraformOptions, upgradeTerraformOptions
 }
 
@@ -140,6 +167,17 @@ func UpgradeIPv6Rancher(t *testing.T, client *rancher.Client, serverNodeOne stri
 
 	_, keyPath = rancher2.SetKeyPath(keypath.RancherKeyPath, terratestConfig.PathToRepo, "")
 	terraformOptions := framework.Setup(t, terraformConfig, terratestConfig, keyPath)
+
+	cluster, err := client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetLocal + "/local")
+	require.NoError(t, err)
+
+	logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+	err = deployment.VerifyClusterDeployments(client, cluster)
+	require.NoError(t, err)
+
+	logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+	err = pods.VerifyClusterPods(client, cluster)
+	require.NoError(t, err)
 
 	return client, updatedCattleConfig, terraformOptions, upgradeTerraformOptions
 }
@@ -179,6 +217,17 @@ func UpgradeProxyRancher(t *testing.T, client *rancher.Client, proxyPrivateIP, p
 	_, keyPath = rancher2.SetKeyPath(keypath.RancherKeyPath, terratestConfig.PathToRepo, "")
 	terraformOptions := framework.Setup(t, terraformConfig, terratestConfig, keyPath)
 
+	cluster, err := client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetLocal + "/local")
+	require.NoError(t, err)
+
+	logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+	err = deployment.VerifyClusterDeployments(client, cluster)
+	require.NoError(t, err)
+
+	logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+	err = pods.VerifyClusterPods(client, cluster)
+	require.NoError(t, err)
+
 	return client, updatedCattleConfig, terraformOptions, upgradeTerraformOptions
 }
 
@@ -215,6 +264,17 @@ func UpgradeRancher(t *testing.T, client *rancher.Client, serverNodeOne string, 
 
 	_, keyPath = rancher2.SetKeyPath(keypath.RancherKeyPath, terratestConfig.PathToRepo, "")
 	terraformOptions := framework.Setup(t, terraformConfig, terratestConfig, keyPath)
+
+	cluster, err := client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetLocal + "/local")
+	require.NoError(t, err)
+
+	logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+	err = deployment.VerifyClusterDeployments(client, cluster)
+	require.NoError(t, err)
+
+	logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+	err = pods.VerifyClusterPods(client, cluster)
+	require.NoError(t, err)
 
 	return client, updatedCattleConfig, terraformOptions, upgradeTerraformOptions
 }


### PR DESCRIPTION
Changes:
* Added logic to verify cluster deployments/pods after a rancher is provisioned via tfp-automation.