### PR TITLE
Remove quotes around the parameterized logging

### DIFF
--- a/.github/workflows/community-prime-upgrade-test.yaml
+++ b/.github/workflows/community-prime-upgrade-test.yaml
@@ -207,8 +207,8 @@ jobs:
               upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true

--- a/.github/workflows/kdm-test.yaml
+++ b/.github/workflows/kdm-test.yaml
@@ -215,8 +215,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -488,8 +488,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_14 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -763,8 +763,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_13 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
           EOF
 
       - name: Export CATTLE_TEST_CONFIG

--- a/.github/workflows/mcm-test.yaml
+++ b/.github/workflows/mcm-test.yaml
@@ -203,7 +203,7 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -449,7 +449,7 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_14 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -696,7 +696,7 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_13 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
           EOF
 
       - name: Export CATTLE_TEST_CONFIG

--- a/.github/workflows/post-release-sanity-upgrade.yaml
+++ b/.github/workflows/post-release-sanity-upgrade.yaml
@@ -243,8 +243,8 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -523,8 +523,8 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -803,8 +803,8 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true

--- a/.github/workflows/post-release-sanity.yaml
+++ b/.github/workflows/post-release-sanity.yaml
@@ -229,8 +229,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_14 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -495,8 +495,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_14 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -761,8 +761,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_13 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true

--- a/.github/workflows/prime-community-upgrade-test.yaml
+++ b/.github/workflows/prime-community-upgrade-test.yaml
@@ -219,8 +219,8 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true

--- a/.github/workflows/rancher2-recurring-test.yaml
+++ b/.github/workflows/rancher2-recurring-test.yaml
@@ -231,8 +231,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -539,8 +539,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_14 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -840,8 +840,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_13 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true

--- a/.github/workflows/registry-test.yaml
+++ b/.github/workflows/registry-test.yaml
@@ -226,8 +226,8 @@ jobs:
               ecrURI: "${{ secrets.ECR_URI }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -514,8 +514,8 @@ jobs:
               ecrURI: "${{ secrets.ECR_URI }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -814,8 +814,8 @@ jobs:
               ecrURI: "${{ secrets.ECR_URI }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true

--- a/.github/workflows/sanity-aks-test.yaml
+++ b/.github/workflows/sanity-aks-test.yaml
@@ -229,8 +229,8 @@ jobs:
               repo: "${{ env.RANCHER_REPO }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             aksKubernetesVersion: "${{ vars.AKS_KUBERNETES_VERSION_2_15 }}"
           EOF
 
@@ -491,8 +491,8 @@ jobs:
               repo: "${{ env.RANCHER_REPO }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             aksKubernetesVersion: "${{ vars.AKS_KUBERNETES_VERSION_2_14 }}"
           EOF
 
@@ -755,8 +755,8 @@ jobs:
               repo: "${{ env.RANCHER_REPO }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             aksKubernetesVersion: "${{ vars.AKS_KUBERNETES_VERSION_2_13 }}"
           EOF
 

--- a/.github/workflows/sanity-arm64-test.yaml
+++ b/.github/workflows/sanity-arm64-test.yaml
@@ -222,8 +222,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -514,8 +514,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_14 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -808,8 +808,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_13 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true

--- a/.github/workflows/sanity-dualstack-test.yaml
+++ b/.github/workflows/sanity-dualstack-test.yaml
@@ -233,8 +233,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -517,8 +517,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_14 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -802,8 +802,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_13 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
           EOF
 
       - name: Export CATTLE_TEST_CONFIG

--- a/.github/workflows/sanity-dualstack-upgrade-test.yaml
+++ b/.github/workflows/sanity-dualstack-upgrade-test.yaml
@@ -240,8 +240,8 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -541,8 +541,8 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -843,8 +843,8 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true

--- a/.github/workflows/sanity-eks-test.yaml
+++ b/.github/workflows/sanity-eks-test.yaml
@@ -229,8 +229,8 @@ jobs:
               repo: "${{ env.RANCHER_REPO }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             eksKubernetesVersion: "${{ vars.EKS_KUBERNETES_VERSION_2_14 }}"
           EOF
 
@@ -498,8 +498,8 @@ jobs:
               repo: "${{ env.RANCHER_REPO }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             eksKubernetesVersion: "${{ vars.EKS_KUBERNETES_VERSION_2_14 }}"
           EOF
 
@@ -769,8 +769,8 @@ jobs:
               repo: "${{ env.RANCHER_REPO }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             eksKubernetesVersion: "${{ vars.EKS_KUBERNETES_VERSION_2_13 }}"
           EOF
 

--- a/.github/workflows/sanity-gke-test.yaml
+++ b/.github/workflows/sanity-gke-test.yaml
@@ -218,8 +218,8 @@ jobs:
               repo: "${{ env.RANCHER_REPO }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             gkeKubernetesVersion: "${{ vars.GKE_KUBERNETES_VERSION_2_15 }}"
           EOF
 
@@ -469,8 +469,8 @@ jobs:
               repo: "${{ env.RANCHER_REPO }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             gkeKubernetesVersion: "${{ vars.GKE_KUBERNETES_VERSION_2_14 }}"
           EOF
 
@@ -722,8 +722,8 @@ jobs:
               repo: "${{ env.RANCHER_REPO }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             gkeKubernetesVersion: "${{ vars.GKE_KUBERNETES_VERSION_2_13 }}"
           EOF
 

--- a/.github/workflows/sanity-ipv6-hosted-cluster-test.yaml
+++ b/.github/workflows/sanity-ipv6-hosted-cluster-test.yaml
@@ -235,8 +235,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             eksKubernetesVersion: "${{ vars.EKS_KUBERNETES_VERSION_2_15 }}"
           EOF
 
@@ -522,8 +522,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_14 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             eksKubernetesVersion: "${{ vars.EKS_KUBERNETES_VERSION_2_14 }}"
           EOF
 

--- a/.github/workflows/sanity-ipv6-test.yaml
+++ b/.github/workflows/sanity-ipv6-test.yaml
@@ -233,8 +233,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -517,8 +517,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_14 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -802,8 +802,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_13 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
           EOF
 
       - name: Export CATTLE_TEST_CONFIG

--- a/.github/workflows/sanity-ipv6-upgrade-test.yaml
+++ b/.github/workflows/sanity-ipv6-upgrade-test.yaml
@@ -240,8 +240,8 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -541,8 +541,8 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -843,8 +843,8 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true

--- a/.github/workflows/sanity-mixed-arch-test.yaml
+++ b/.github/workflows/sanity-mixed-arch-test.yaml
@@ -225,8 +225,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -520,8 +520,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_14 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true

--- a/.github/workflows/sanity-test.yaml
+++ b/.github/workflows/sanity-test.yaml
@@ -341,8 +341,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -734,8 +734,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_14 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -1129,8 +1129,8 @@ jobs:
               rke2Version: "${{ vars.RKE2_VERSION_2_13 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true

--- a/.github/workflows/sanity-turtles-off-test.yaml
+++ b/.github/workflows/sanity-turtles-off-test.yaml
@@ -238,8 +238,8 @@ jobs:
                 turtles: "false"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true

--- a/.github/workflows/sanity-upgrade-arm64-test.yaml
+++ b/.github/workflows/sanity-upgrade-arm64-test.yaml
@@ -229,8 +229,8 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -528,8 +528,8 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -829,8 +829,8 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true

--- a/.github/workflows/sanity-upgrade-test.yaml
+++ b/.github/workflows/sanity-upgrade-test.yaml
@@ -348,8 +348,8 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -747,8 +747,8 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true
@@ -1149,8 +1149,8 @@ jobs:
               upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: "${{ vars.TERRAFORM_STANDALONE_LOGGING }}"
-            tfLogging: "${{ vars.TERRAFORM_LOGGING }}"
+            standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
+            tfLogging: ${{ vars.TERRAFORM_LOGGING }}
             nodepools:
               - quantity: ${{ vars.ETCD_COUNT }}
                 etcd: true


### PR DESCRIPTION
### Description
The last PR put quotes around the logging by mistake. This is a bool, but is being interpreted as a string.