### PR TITLE
Update registries to run in serialization

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -160,15 +160,19 @@ type Standalone struct {
 }
 
 type StandaloneRegistry struct {
-	AssetsPath         string `json:"assetsPath,omitempty" yaml:"assetsPath,omitempty"`
-	Authenticated      bool   `json:"authenticated,omitempty" yaml:"authenticated,omitempty"`
-	ECRURI             string `json:"ecrURI,omitempty" yaml:"ecrURI,omitempty"`
-	ECRUsername        string `json:"ecrUsername,omitempty" yaml:"ecrUsername,omitempty"`
-	ECRPassword        string `json:"ecrPassword,omitempty" yaml:"ecrPassword,omitempty"`
-	RegistryName       string `json:"registryName,omitempty" yaml:"registryName,omitempty"`
-	RegistryPassword   string `json:"registryPassword,omitempty" yaml:"registryPassword,omitempty"`
-	RegistryUsername   string `json:"registryUsername,omitempty" yaml:"registryUsername,omitempty"`
-	UpgradedAssetsPath string `json:"upgradedAssetsPath,omitempty" yaml:"upgradedAssetsPath,omitempty"`
+	AssetsPath          string `json:"assetsPath,omitempty" yaml:"assetsPath,omitempty"`
+	Authenticated       bool   `json:"authenticated,omitempty" yaml:"authenticated,omitempty"`
+	AuthRegistryFQDN    string `json:"authRegistryFQDN,omitempty" yaml:"authRegistryFQDN,omitempty"`
+	ECRFQDN             string `json:"ecrFQDN,omitempty" yaml:"ecrFQDN,omitempty"`
+	ECRURI              string `json:"ecrURI,omitempty" yaml:"ecrURI,omitempty"`
+	ECRUsername         string `json:"ecrUsername,omitempty" yaml:"ecrUsername,omitempty"`
+	ECRPassword         string `json:"ecrPassword,omitempty" yaml:"ecrPassword,omitempty"`
+	GlobalRegistryFQDN  string `json:"globalRegistryFQDN,omitempty" yaml:"globalRegistryFQDN,omitempty"`
+	NonAuthRegistryFQDN string `json:"nonAuthRegistryFQDN,omitempty" yaml:"nonAuthRegistryFQDN,omitempty"`
+	RegistryName        string `json:"registryName,omitempty" yaml:"registryName,omitempty"`
+	RegistryPassword    string `json:"registryPassword,omitempty" yaml:"registryPassword,omitempty"`
+	RegistryUsername    string `json:"registryUsername,omitempty" yaml:"registryUsername,omitempty"`
+	UpgradedAssetsPath  string `json:"upgradedAssetsPath,omitempty" yaml:"upgradedAssetsPath,omitempty"`
 }
 
 type TerraformConfig struct {

--- a/framework/set/resources/registries/createMainTF.go
+++ b/framework/set/resources/registries/createMainTF.go
@@ -2,7 +2,6 @@ package registries
 
 import (
 	"os"
-	"sync"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
@@ -77,62 +76,12 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 	serverTwoPublicDNS := terraform.Output(t, terraformOptions, serverTwoPublicDNS)
 	serverThreePublicDNS := terraform.Output(t, terraformOptions, serverThreePublicDNS)
 
-	// Will create the authenticated registry, unauthenticated registry, and global registry in parallel using goroutines.
-	var wg sync.WaitGroup
-	var mutex sync.Mutex
-	wg.Add(4)
-
-	go func() {
-		defer wg.Done()
-		mutex.Lock()
-		defer mutex.Unlock()
-
-		file = sanity.OpenFile(file, keyPath)
-		logrus.Infof("Creating authenticated registry...")
-		file, err = registry.CreateAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, authRegistryPublicDNS)
-		if err != nil {
-			logrus.Fatalf("Error creating authenticated registry: %v", err)
-		}
-	}()
-
-	go func() {
-		defer wg.Done()
-		mutex.Lock()
-		defer mutex.Unlock()
-
-		file = sanity.OpenFile(file, keyPath)
-		logrus.Infof("Creating non-authenticated registry...")
-		file, err = registry.CreateNonAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, nonAuthRegistryPublicDNS, nonAuthRegistry)
-		if err != nil {
-			logrus.Fatalf("Error creating unauthenticated registry: %v", err)
-		}
-	}()
-
-	go func() {
-		defer wg.Done()
-		mutex.Lock()
-		defer mutex.Unlock()
-
-		file = sanity.OpenFile(file, keyPath)
-		logrus.Infof("Creating global registry...")
-		file, err = registry.CreateNonAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, globalRegistryPublicDNS, globalRegistry)
-		if err != nil {
-			logrus.Fatalf("Error creating global registry: %v", err)
-		}
-	}()
-
-	go func() {
-		defer wg.Done()
-		mutex.Lock()
-		defer mutex.Unlock()
-
-		file = sanity.OpenFile(file, keyPath)
-		logrus.Infof("Creating ecr registry...")
-		file, err = registry.CreateECRRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, ecrRegistryPublicDNS)
-		if err != nil {
-			logrus.Fatalf("Error creating ecr registry: %v", err)
-		}
-	}()
+	file = sanity.OpenFile(file, keyPath)
+	logrus.Infof("Creating non-authenticated registry...")
+	file, err = registry.CreateNonAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, nonAuthRegistryPublicDNS, nonAuthRegistry)
+	if err != nil {
+		logrus.Fatalf("Error creating unauthenticated registry: %v", err)
+	}
 
 	_, err = terraform.InitAndApplyE(t, terraformOptions)
 	if err != nil && *rancherConfig.Cleanup {
@@ -141,7 +90,47 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 		return "", "", "", err
 	}
 
-	wg.Wait()
+	file = sanity.OpenFile(file, keyPath)
+	logrus.Infof("Creating global registry...")
+	file, err = registry.CreateNonAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, globalRegistryPublicDNS, globalRegistry)
+	if err != nil {
+		logrus.Fatalf("Error creating global registry: %v", err)
+	}
+
+	_, err = terraform.InitAndApplyE(t, terraformOptions)
+	if err != nil && *rancherConfig.Cleanup {
+		logrus.Infof("Error while creating registries. Cleaning up...")
+		cleanup.Cleanup(t, terraformOptions, keyPath)
+		return "", "", "", err
+	}
+
+	file = sanity.OpenFile(file, keyPath)
+	logrus.Infof("Creating authenticated registry...")
+	file, err = registry.CreateAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, authRegistryPublicDNS)
+	if err != nil {
+		logrus.Fatalf("Error creating authenticated registry: %v", err)
+	}
+
+	_, err = terraform.InitAndApplyE(t, terraformOptions)
+	if err != nil && *rancherConfig.Cleanup {
+		logrus.Infof("Error while creating registries. Cleaning up...")
+		cleanup.Cleanup(t, terraformOptions, keyPath)
+		return "", "", "", err
+	}
+
+	file = sanity.OpenFile(file, keyPath)
+	logrus.Infof("Creating ecr registry...")
+	file, err = registry.CreateECRRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, ecrRegistryPublicDNS)
+	if err != nil {
+		logrus.Fatalf("Error creating ecr registry: %v", err)
+	}
+
+	_, err = terraform.InitAndApplyE(t, terraformOptions)
+	if err != nil && *rancherConfig.Cleanup {
+		logrus.Infof("Error while creating registries. Cleaning up...")
+		cleanup.Cleanup(t, terraformOptions, keyPath)
+		return "", "", "", err
+	}
 
 	file = sanity.OpenFile(file, keyPath)
 	logrus.Infof("Creating RKE2 cluster...")


### PR DESCRIPTION
### Description
To ensure stability with building out the registries, this PR shifts away from parallelism and goes back to serialization. While this is taking a hit on time it takes, it is much more important to ensure we do not hit Docker rate limits when building these out.