### PR TITLE
Remove v2.14 Prime schedule in sanity workflows

### DIFF
--- a/.github/workflows/sanity-test.yaml
+++ b/.github/workflows/sanity-test.yaml
@@ -845,8 +845,6 @@ jobs:
   
   v2-14-prime:
     if: |
-      github.event_name == 'schedule' ||
-      github.event.inputs.run_all_versions == 'true' ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14')) && (contains(github.event.inputs.rancher_version, '-alpha') || contains(github.event.inputs.rancher_version, '-rc')) ||
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.14')) && (contains(inputs.rancher_version, '-alpha') || contains(inputs.rancher_version, '-rc'))
     name: ${{ github.event.inputs.rancher_version }}

--- a/.github/workflows/sanity-upgrade-test.yaml
+++ b/.github/workflows/sanity-upgrade-test.yaml
@@ -858,8 +858,6 @@ jobs:
 
   v2-14-prime:
     if: |
-      github.event_name == 'schedule' ||
-      github.event.inputs.run_all_versions == 'true' ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14')) && (contains(github.event.inputs.rancher_version, '-alpha') || contains(github.event.inputs.rancher_version, '-rc')) ||
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.14')) && (contains(inputs.rancher_version, '-alpha') || contains(inputs.rancher_version, '-rc'))
     name: ${{ vars.RELEASED_RANCHER_VERSION_2_14 }} -> ${{ github.event.inputs.rancher_version }}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-# Hostbusters QA
-* @markusewalker @Josh-Diamond
+* @markusewalker


### PR DESCRIPTION
### Description
Small PR to update `CODEOWNERS` file and to remove the schedule for v2.14 Prime. Until `v2.15.0` is released, there will not be head images pushed to v2.14 prime.