### PR TITLE
Add support for creating standalone private registries

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -167,6 +167,7 @@ type StandaloneRegistry struct {
 	ECRURI              string `json:"ecrURI,omitempty" yaml:"ecrURI,omitempty"`
 	ECRUsername         string `json:"ecrUsername,omitempty" yaml:"ecrUsername,omitempty"`
 	ECRPassword         string `json:"ecrPassword,omitempty" yaml:"ecrPassword,omitempty"`
+	Enabled             bool   `json:"enabled,omitempty" yaml:"enabled,omitempty" default:"false"`
 	GlobalRegistryFQDN  string `json:"globalRegistryFQDN,omitempty" yaml:"globalRegistryFQDN,omitempty"`
 	NonAuthRegistryFQDN string `json:"nonAuthRegistryFQDN,omitempty" yaml:"nonAuthRegistryFQDN,omitempty"`
 	RegistryName        string `json:"registryName,omitempty" yaml:"registryName,omitempty"`

--- a/framework/set/resources/dualstack/k3s/add-servers.sh
+++ b/framework/set/resources/dualstack/k3s/add-servers.sh
@@ -32,6 +32,4 @@ configs:
       username: "${REGISTRY_USERNAME}"
       password: "${REGISTRY_PASSWORD}"" | sudo tee -a /etc/rancher/k3s/registries.yaml > /dev/null
 
-curl -fsSL --max-time 30 -o install.sh https://get.k3s.io
-chmod +x install.sh
-sudo INSTALL_K3S_VERSION=${K8S_VERSION} K3S_TOKEN=${K3S_TOKEN} sh install.sh - server --server https://${K3S_SERVER_IP}:6443 --cluster-cidr=${CLUSTER_CIDR} --service-cidr=${SERVICE_CIDR}
+curl -fsSL --max-time 30 https://get.k3s.io | INSTALL_K3S_VERSION=${K8S_VERSION} K3S_TOKEN=${K3S_TOKEN} sh -s - server --server https://${K3S_SERVER_IP}:6443 --cluster-cidr=${CLUSTER_CIDR} --service-cidr=${SERVICE_CIDR}

--- a/framework/set/resources/dualstack/k3s/init-server.sh
+++ b/framework/set/resources/dualstack/k3s/init-server.sh
@@ -45,9 +45,7 @@ configs:
       username: "${REGISTRY_USERNAME}"
       password: "${REGISTRY_PASSWORD}"" | sudo tee -a /etc/rancher/k3s/registries.yaml > /dev/null
 
-curl -fsSL --max-time 30 -o install.sh https://get.k3s.io
-chmod +x install.sh
-sudo INSTALL_K3S_VERSION=${K8S_VERSION} K3S_TOKEN=${K3S_TOKEN} sh install.sh - server --cluster-init --cluster-cidr=${CLUSTER_CIDR} --service-cidr=${SERVICE_CIDR}
+curl -fsSL --max-time 30 https://get.k3s.io | INSTALL_K3S_VERSION=${K8S_VERSION} K3S_TOKEN=${K3S_TOKEN} sh -s - server --cluster-init --cluster-cidr=${CLUSTER_CIDR} --service-cidr=${SERVICE_CIDR}
 
 sudo mkdir -p /home/${USER}/.kube
 sudo chown ${USER}:${GROUP} /etc/rancher/k3s/k3s.yaml

--- a/framework/set/resources/providers/aws/createResources.go
+++ b/framework/set/resources/providers/aws/createResources.go
@@ -32,7 +32,7 @@ func CreateAWSResources(file *os.File, newFile *hclwrite.File, tfBlockBody, root
 		}
 	}
 
-	if terraformConfig.Standalone.CertManagerVersion != "" && terraformConfig.Provider != providers.EKS {
+	if terraformConfig.Standalone.RancherHostname != "" && terraformConfig.Provider != providers.EKS {
 		ports := []int64{80, 443, 6443, 9345}
 		for _, port := range ports {
 			CreateTargetGroupAttachments(rootBody, terraformConfig, aws.LoadBalancerTargetGroupAttachment, getTargetGroupAttachment(port, false), port)
@@ -54,13 +54,24 @@ func CreateAWSResources(file *os.File, newFile *hclwrite.File, tfBlockBody, root
 		rootBody.AppendNewline()
 	}
 
-	CreateAWSLocalBlock(rootBody, terraformConfig)
-	rootBody.AppendNewline()
+	var err error
 
-	_, err := file.Write(newFile.Bytes())
-	if err != nil {
-		logrus.Infof("Failed to write configurations to main.tf file. Error: %v", err)
-		return nil, err
+	// This is for the case where you are standing up a standalone private registry.
+	if terraformConfig.StandaloneRegistry != nil && terraformConfig.StandaloneRegistry.Enabled {
+		_, err = file.Write(newFile.Bytes())
+		if err != nil {
+			logrus.Infof("Failed to write configurations to main.tf file. Error: %v", err)
+			return nil, err
+		}
+	} else {
+		CreateAWSLocalBlock(rootBody, terraformConfig)
+		rootBody.AppendNewline()
+
+		_, err = file.Write(newFile.Bytes())
+		if err != nil {
+			logrus.Infof("Failed to write configurations to main.tf file. Error: %v", err)
+			return nil, err
+		}
 	}
 
 	return file, err
@@ -89,7 +100,7 @@ func CreateAirgappedAWSResources(file *os.File, newFile *hclwrite.File, tfBlockB
 	CreateAWSLocalBlock(rootBody, terraformConfig)
 	rootBody.AppendNewline()
 
-	if terraformConfig.Standalone.CertManagerVersion != "" {
+	if terraformConfig.Standalone.RancherHostname != "" {
 		ports := []int64{80, 443, 6443, 9345}
 		for _, port := range ports {
 			CreateInternalTargetGroupAttachments(rootBody, terraformConfig, aws.LoadBalancerTargetGroupAttachment, getTargetGroupAttachment(port, true), port)

--- a/modules/registries/all/main.tf
+++ b/modules/registries/all/main.tf
@@ -1,0 +1,1 @@
+// Leave blank - main.tf will be set during testing

--- a/modules/registries/all/outputs.tf
+++ b/modules/registries/all/outputs.tf
@@ -1,0 +1,15 @@
+output "auth_registry_public_dns" {
+  value = aws_instance.auth_registry.public_dns
+}
+
+output "non_auth_registry_public_dns" {
+  value = aws_instance.non_auth_registry.public_dns
+}
+
+output "global_registry_public_dns" {
+  value = aws_instance.global_registry.public_dns
+}
+
+output "ecr_registry_public_dns" {
+  value = aws_instance.ecr_registry.public_dns
+}

--- a/modules/registries/auth/main.tf
+++ b/modules/registries/auth/main.tf
@@ -1,0 +1,1 @@
+// Leave blank - main.tf will be set during testing

--- a/modules/registries/auth/outputs.tf
+++ b/modules/registries/auth/outputs.tf
@@ -1,0 +1,3 @@
+output "auth_registry_public_dns" {
+  value = aws_instance.auth_registry.public_dns
+}

--- a/modules/registries/ecr/main.tf
+++ b/modules/registries/ecr/main.tf
@@ -1,0 +1,1 @@
+// Leave blank - main.tf will be set during testing

--- a/modules/registries/ecr/outputs.tf
+++ b/modules/registries/ecr/outputs.tf
@@ -1,0 +1,3 @@
+output "ecr_registry_public_dns" {
+  value = aws_instance.ecr_registry.public_dns
+}

--- a/modules/registries/nonauth/main.tf
+++ b/modules/registries/nonauth/main.tf
@@ -1,0 +1,1 @@
+// Leave blank - main.tf will be set during testing

--- a/modules/registries/nonauth/outputs.tf
+++ b/modules/registries/nonauth/outputs.tf
@@ -1,0 +1,3 @@
+output "non_auth_registry_public_dns" {
+  value = aws_instance.non_auth_registry.public_dns
+}

--- a/tests/infrastructure/cli/cli.go
+++ b/tests/infrastructure/cli/cli.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/rancher/tfp-automation/tests/infrastructure/clusters"
 	"github.com/rancher/tfp-automation/tests/infrastructure/ranchers"
+	"github.com/rancher/tfp-automation/tests/infrastructure/registries"
 	"github.com/stretchr/testify/require"
 )
 
@@ -34,12 +35,19 @@ var setupRancherFuncs = map[string]func(*testing.T, string) error{
 	"--registry:fresh": ranchers.CreateRegistryRancher,
 }
 
+var setupRegistryFuncs = map[string]func(*testing.T, string) error{
+	"--registries-all":     registries.SetupAllRegistries,
+	"--registries-auth":    registries.SetupAuthenticatedRegistry,
+	"--registries-nonauth": registries.SetupNonAuthenticatedRegistry,
+	"--registries-ecr":     registries.SetupECR,
+}
+
 // RunCLI is a function that runs the CLI setup based on command-line arguments
 func RunCLI() int {
 	t := &testing.T{}
 	key := os.Args[1]
 
-	// If there are two arguments, we assume this is a Rancher setup. If only one, it's a cluster setup.
+	// If there are two arguments, we assume this is a Rancher setup. If only one, it's a cluster or registry setup.
 	if len(os.Args) > 2 {
 		key += ":" + os.Args[2]
 
@@ -51,6 +59,13 @@ func RunCLI() int {
 		}
 	} else {
 		if setupFunc, ok := setupClusterFuncs[key]; ok {
+			err := setupFunc(t, "")
+			require.NoError(t, err)
+
+			return 0
+		}
+
+		if setupFunc, ok := setupRegistryFuncs[key]; ok {
 			err := setupFunc(t, "")
 			require.NoError(t, err)
 

--- a/tests/infrastructure/handlers/cluster_handler.go
+++ b/tests/infrastructure/handlers/cluster_handler.go
@@ -2,11 +2,15 @@ package handlers
 
 import "net/http"
 
+const (
+	post = "POST"
+)
+
 // ClusterTypeHandler is a function that handles the cluster type selection page
 func ClusterTypeHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html")
 
-	if r.Method == "POST" {
+	if r.Method == post {
 		selection := r.FormValue("selection")
 
 		data := struct {

--- a/tests/infrastructure/handlers/confirm_handler.go
+++ b/tests/infrastructure/handlers/confirm_handler.go
@@ -22,11 +22,12 @@ func ConfirmHandler(w http.ResponseWriter, r *http.Request) {
 	selection := retrieve.GetFormOrCookie(r, "selection")
 	clustertype := retrieve.GetFormOrCookie(r, "clustertype")
 	ranchertype := retrieve.GetFormOrCookie(r, "ranchertype")
+	registrytype := retrieve.GetFormOrCookie(r, "registrytype")
 	installtype := retrieve.GetFormOrCookie(r, "installtype")
 	provider := retrieve.GetFormOrCookie(r, "provider")
 	providerversion := retrieve.GetFormOrCookie(r, "providerversion")
 
-	if clustertype == "" && ranchertype == "" {
+	if clustertype == "" && ranchertype == "" && registrytype == "" {
 		http.Redirect(w, r, "/", http.StatusSeeOther)
 		return
 	}
@@ -46,11 +47,11 @@ func ConfirmHandler(w http.ResponseWriter, r *http.Request) {
 	rancherConfig, terraformConfig, terratestConfig, standaloneConfig := config.LoadTFPConfigs(cattleConfig)
 
 	editMode := false
-	if r.Method == "POST" && r.FormValue("action") == "edit" {
+	if r.Method == post && r.FormValue("action") == "edit" {
 		editMode = true
 	}
 
-	if r.Method == "POST" && r.FormValue("action") == "save" {
+	if r.Method == post && r.FormValue("action") == "save" {
 		webConfig.UpdateConfigFromForm(r.PostForm, rancherConfig)
 		webConfig.UpdateConfigFromForm(r.PostForm, terraformConfig)
 		webConfig.UpdateConfigFromForm(r.PostForm, terratestConfig)
@@ -64,11 +65,12 @@ func ConfirmHandler(w http.ResponseWriter, r *http.Request) {
 	terratestConfigStr, _ := json.MarshalIndent(terratestConfig, "", "  ")
 	standaloneConfigStr, _ := json.MarshalIndent(standaloneConfig, "", "  ")
 
-	if r.Method == "POST" && r.FormValue("action") == "confirm" {
+	if r.Method == post && r.FormValue("action") == "confirm" {
 		selection := r.FormValue("selection")
 		clustertype := r.FormValue("clustertype")
 		ranchertype := r.FormValue("ranchertype")
 		installtype := r.FormValue("installtype")
+		registrytype := r.FormValue("registrytype")
 		provider := r.FormValue("provider")
 		providerversion := r.FormValue("providerversion")
 		confirm := r.FormValue("confirm")
@@ -89,6 +91,8 @@ func ConfirmHandler(w http.ResponseWriter, r *http.Request) {
 			share.State.StageMsg = strings.Join(share.ClusterStageMessage, "\n")
 		} else if ranchertype != "" {
 			share.State.StageMsg = strings.Join(share.RancherStageMessage, "\n")
+		} else if registrytype != "" {
+			share.State.StageMsg = strings.Join(share.RegistryStageMessage, "\n")
 		}
 
 		share.State.ErrorMsg = ""
@@ -98,6 +102,8 @@ func ConfirmHandler(w http.ResponseWriter, r *http.Request) {
 			go web.RunClusterSetupWeb(provider, providerversion, clustertype)
 		} else if ranchertype != "" {
 			go web.RunRancherSetupWeb(provider, providerversion, ranchertype, installtype)
+		} else if registrytype != "" {
+			go web.RunRegistrySetupWeb(provider, providerversion, registrytype)
 		}
 
 		http.Redirect(w, r, "/status", http.StatusSeeOther)
@@ -137,6 +143,7 @@ func ConfirmHandler(w http.ResponseWriter, r *http.Request) {
 		Selection           string
 		ClusterType         string
 		RancherType         string
+		RegistryType        string
 		InstallType         string
 		Provider            string
 		ProviderVersion     string
@@ -157,6 +164,7 @@ func ConfirmHandler(w http.ResponseWriter, r *http.Request) {
 		Selection:           selection,
 		ClusterType:         clustertype,
 		RancherType:         ranchertype,
+		RegistryType:        registrytype,
 		InstallType:         installtype,
 		Provider:            provider,
 		ProviderVersion:     providerversion,

--- a/tests/infrastructure/handlers/provider_handlers.go
+++ b/tests/infrastructure/handlers/provider_handlers.go
@@ -6,10 +6,11 @@ import "net/http"
 func ProviderHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html")
 
-	if r.Method == "POST" {
+	if r.Method == post {
 		selection := r.FormValue("selection")
 		clustertype := r.FormValue("clustertype")
 		ranchertype := r.FormValue("ranchertype")
+		registrytype := r.FormValue("registrytype")
 		installtype := r.FormValue("installtype")
 
 		var installOptions []string
@@ -30,6 +31,13 @@ func ProviderHandler(w http.ResponseWriter, r *http.Request) {
 			default:
 				installOptions = []string{"aws", "linode", "vsphere"}
 			}
+		} else if registrytype != "" {
+			switch registrytype {
+			case "all", "auth", "nonauth", "ecr":
+				installOptions = []string{"aws"}
+			default:
+				installOptions = []string{"aws"}
+			}
 		} else {
 			installOptions = []string{}
 		}
@@ -38,12 +46,14 @@ func ProviderHandler(w http.ResponseWriter, r *http.Request) {
 			Selection      string
 			ClusterType    string
 			RancherType    string
+			RegistryType   string
 			InstallType    string
 			InstallOptions []string
 		}{
 			Selection:      selection,
 			ClusterType:    clustertype,
 			RancherType:    ranchertype,
+			RegistryType:   registrytype,
 			InstallType:    installtype,
 			InstallOptions: installOptions,
 		}
@@ -60,25 +70,28 @@ func ProviderHandler(w http.ResponseWriter, r *http.Request) {
 func ProviderVersionHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html")
 
-	if r.Method == "POST" {
+	if r.Method == post {
 		selection := r.FormValue("selection")
 		clustertype := r.FormValue("clustertype")
 		ranchertype := r.FormValue("ranchertype")
+		registrytype := r.FormValue("registrytype")
 		installtype := r.FormValue("installtype")
 		provider := r.FormValue("provider")
 
 		data := struct {
-			Selection   string
-			ClusterType string
-			RancherType string
-			InstallType string
-			Provider    string
+			Selection    string
+			ClusterType  string
+			RancherType  string
+			RegistryType string
+			InstallType  string
+			Provider     string
 		}{
-			Selection:   selection,
-			ClusterType: clustertype,
-			RancherType: ranchertype,
-			InstallType: installtype,
-			Provider:    provider,
+			Selection:    selection,
+			ClusterType:  clustertype,
+			RancherType:  ranchertype,
+			RegistryType: registrytype,
+			InstallType:  installtype,
+			Provider:     provider,
 		}
 
 		Templates.ExecuteTemplate(w, "providerversion", data)

--- a/tests/infrastructure/handlers/rancher_handlers.go
+++ b/tests/infrastructure/handlers/rancher_handlers.go
@@ -6,7 +6,7 @@ import "net/http"
 func RancherTypeHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html")
 
-	if r.Method == "POST" {
+	if r.Method == post {
 		selection := r.FormValue("selection")
 
 		data := struct {
@@ -27,7 +27,7 @@ func RancherTypeHandler(w http.ResponseWriter, r *http.Request) {
 func InstallTypeHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html")
 
-	if r.Method == "POST" {
+	if r.Method == post {
 		selection := r.FormValue("selection")
 		ranchertype := r.FormValue("ranchertype")
 

--- a/tests/infrastructure/handlers/registry_handlers.go
+++ b/tests/infrastructure/handlers/registry_handlers.go
@@ -1,0 +1,24 @@
+package handlers
+
+import "net/http"
+
+// RegistryTypeHandler is a function that handles the Registry type selection page
+func RegistryTypeHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/html")
+
+	if r.Method == post {
+		selection := r.FormValue("selection")
+
+		data := struct {
+			Selection string
+		}{
+			Selection: selection,
+		}
+
+		Templates.ExecuteTemplate(w, "registrytype", data)
+
+		return
+	} else {
+		Templates.ExecuteTemplate(w, "registrytype", nil)
+	}
+}

--- a/tests/infrastructure/handlers/run_handler.go
+++ b/tests/infrastructure/handlers/run_handler.go
@@ -8,7 +8,7 @@ import (
 
 // RunHandler is a function that handles the run action
 func RunHandler(w http.ResponseWriter, r *http.Request) {
-	if r.Method == "POST" {
+	if r.Method == post {
 		selection := retrieve.GetFormOrCookie(r, "selection")
 		clustertype := retrieve.GetFormOrCookie(r, "clustertype")
 		ranchertype := retrieve.GetFormOrCookie(r, "ranchertype")

--- a/tests/infrastructure/main.go
+++ b/tests/infrastructure/main.go
@@ -18,6 +18,7 @@ func main() {
 		http.HandleFunc("/selection", handlers.ClusterOrRancherHandler)
 		http.HandleFunc("/clustertype", handlers.ClusterTypeHandler)
 		http.HandleFunc("/ranchertype", handlers.RancherTypeHandler)
+		http.HandleFunc("/registrytype", handlers.RegistryTypeHandler)
 		http.HandleFunc("/installtype", handlers.InstallTypeHandler)
 		http.HandleFunc("/provider", handlers.ProviderHandler)
 		http.HandleFunc("/providerversion", handlers.ProviderVersionHandler)

--- a/tests/infrastructure/registries/setup_all_registries.go
+++ b/tests/infrastructure/registries/setup_all_registries.go
@@ -1,0 +1,110 @@
+package registries
+
+import (
+	"os"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	shepherdConfig "github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/keypath"
+	"github.com/rancher/tfp-automation/framework"
+	"github.com/rancher/tfp-automation/framework/cleanup"
+	"github.com/rancher/tfp-automation/framework/set/resources/providers"
+	"github.com/rancher/tfp-automation/framework/set/resources/rancher2"
+	registry "github.com/rancher/tfp-automation/framework/set/resources/registries/createRegistry"
+	"github.com/rancher/tfp-automation/framework/set/resources/sanity"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	authRegistryPublicDNS    = "auth_registry_public_dns"
+	nonAuthRegistryPublicDNS = "non_auth_registry_public_dns"
+	globalRegistryPublicDNS  = "global_registry_public_dns"
+	ecrRegistryPublicDNS     = "ecr_registry_public_dns"
+
+	authRegistry    = "auth_registry"
+	nonAuthRegistry = "non_auth_registry"
+	globalRegistry  = "global_registry"
+	ecrRegistry     = "ecr_registry"
+
+	terraformConst = "terraform"
+)
+
+// SetupAllRegistries is a function that creates all registries in a Rancher setup, either via CLI or web application
+func SetupAllRegistries(t *testing.T, provider string) error {
+	os.Getenv("CLOUD_PROVIDER_VERSION")
+
+	configPath := os.Getenv("CATTLE_TEST_CONFIG")
+	cattleConfig := shepherdConfig.LoadConfigFromFile(configPath)
+	rancherConfig, terraformConfig, terratestConfig, _ := config.LoadTFPConfigs(cattleConfig)
+
+	if provider != "" {
+		terraformConfig.Provider = provider
+	}
+
+	_, keyPath := rancher2.SetKeyPath(keypath.RegistryKeyPath, terratestConfig.PathToRepo, "all")
+	terraformOptions := framework.Setup(t, terraformConfig, terratestConfig, keyPath)
+
+	terraformConfig.StandaloneRegistry.Enabled = true
+
+	var file *os.File
+	file = sanity.OpenFile(file, keyPath)
+	defer file.Close()
+
+	newFile := hclwrite.NewEmptyFile()
+	rootBody := newFile.Body()
+
+	tfBlock := rootBody.AppendNewBlock(terraformConst, nil)
+	tfBlockBody := tfBlock.Body()
+
+	instances := []string{authRegistry, nonAuthRegistry, globalRegistry, ecrRegistry}
+
+	providerTunnel := providers.TunnelToProvider(terraformConfig.Provider)
+	file, err := providerTunnel.CreateNonAirgap(file, newFile, tfBlockBody, rootBody, terraformConfig, terratestConfig, instances)
+	require.NoError(t, err)
+
+	_, err = terraform.InitAndApplyE(t, terraformOptions)
+	if err != nil && *rancherConfig.Cleanup {
+		logrus.Infof("Error while creating resources. Cleaning up...")
+		cleanup.Cleanup(t, terraformOptions, keyPath)
+		return err
+	}
+
+	authRegistryPublicDNS := terraform.Output(t, terraformOptions, authRegistryPublicDNS)
+	nonAuthRegistryPublicDNS := terraform.Output(t, terraformOptions, nonAuthRegistryPublicDNS)
+	globalRegistryPublicDNS := terraform.Output(t, terraformOptions, globalRegistryPublicDNS)
+	ecrRegistryPublicDNS := terraform.Output(t, terraformOptions, ecrRegistryPublicDNS)
+
+	file = sanity.OpenFile(file, keyPath)
+	logrus.Infof("Creating non-authenticated registry...")
+	file, err = registry.CreateNonAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, nonAuthRegistryPublicDNS, nonAuthRegistry)
+	require.NoError(t, err)
+
+	terraform.InitAndApply(t, terraformOptions)
+
+	file = sanity.OpenFile(file, keyPath)
+	logrus.Infof("Creating global registry...")
+	file, err = registry.CreateNonAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, globalRegistryPublicDNS, globalRegistry)
+	require.NoError(t, err)
+
+	terraform.InitAndApply(t, terraformOptions)
+
+	file = sanity.OpenFile(file, keyPath)
+	logrus.Infof("Creating authenticated registry...")
+	file, err = registry.CreateAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, authRegistryPublicDNS)
+	require.NoError(t, err)
+
+	terraform.InitAndApply(t, terraformOptions)
+
+	file = sanity.OpenFile(file, keyPath)
+	logrus.Infof("Creating ecr registry...")
+	file, err = registry.CreateECRRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, ecrRegistryPublicDNS)
+	require.NoError(t, err)
+
+	terraform.InitAndApply(t, terraformOptions)
+
+	return nil
+}

--- a/tests/infrastructure/registries/setup_auth_registry.go
+++ b/tests/infrastructure/registries/setup_auth_registry.go
@@ -1,0 +1,66 @@
+package registries
+
+import (
+	"os"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	shepherdConfig "github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/keypath"
+	"github.com/rancher/tfp-automation/framework"
+	"github.com/rancher/tfp-automation/framework/set/resources/providers"
+	"github.com/rancher/tfp-automation/framework/set/resources/rancher2"
+	registry "github.com/rancher/tfp-automation/framework/set/resources/registries/createRegistry"
+	"github.com/rancher/tfp-automation/framework/set/resources/sanity"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+// SetupAuthenticatedRegistry is a function that creates an authenticated registry in a Rancher setup, either via CLI or web application
+func SetupAuthenticatedRegistry(t *testing.T, provider string) error {
+	os.Getenv("CLOUD_PROVIDER_VERSION")
+
+	configPath := os.Getenv("CATTLE_TEST_CONFIG")
+	cattleConfig := shepherdConfig.LoadConfigFromFile(configPath)
+	_, terraformConfig, terratestConfig, _ := config.LoadTFPConfigs(cattleConfig)
+
+	if provider != "" {
+		terraformConfig.Provider = provider
+	}
+
+	_, keyPath := rancher2.SetKeyPath(keypath.RegistryKeyPath, terratestConfig.PathToRepo, "auth")
+	terraformOptions := framework.Setup(t, terraformConfig, terratestConfig, keyPath)
+
+	terraformConfig.StandaloneRegistry.Enabled = true
+
+	var file *os.File
+	file = sanity.OpenFile(file, keyPath)
+	defer file.Close()
+
+	newFile := hclwrite.NewEmptyFile()
+	rootBody := newFile.Body()
+
+	tfBlock := rootBody.AppendNewBlock(terraformConst, nil)
+	tfBlockBody := tfBlock.Body()
+
+	instances := []string{authRegistry}
+
+	providerTunnel := providers.TunnelToProvider(terraformConfig.Provider)
+	file, err := providerTunnel.CreateNonAirgap(file, newFile, tfBlockBody, rootBody, terraformConfig, terratestConfig, instances)
+	require.NoError(t, err)
+
+	terraform.InitAndApply(t, terraformOptions)
+
+	authRegistryPublicDNS := terraform.Output(t, terraformOptions, authRegistryPublicDNS)
+
+	file = sanity.OpenFile(file, keyPath)
+	logrus.Infof("Creating authenticated registry...")
+	file, err = registry.CreateAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, authRegistryPublicDNS)
+	require.NoError(t, err)
+
+	terraform.InitAndApply(t, terraformOptions)
+
+	return nil
+}

--- a/tests/infrastructure/registries/setup_ecr.go
+++ b/tests/infrastructure/registries/setup_ecr.go
@@ -1,0 +1,66 @@
+package registries
+
+import (
+	"os"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	shepherdConfig "github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/keypath"
+	"github.com/rancher/tfp-automation/framework"
+	"github.com/rancher/tfp-automation/framework/set/resources/providers"
+	"github.com/rancher/tfp-automation/framework/set/resources/rancher2"
+	registry "github.com/rancher/tfp-automation/framework/set/resources/registries/createRegistry"
+	"github.com/rancher/tfp-automation/framework/set/resources/sanity"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+// SetupECR is a function that creates an ECR registry in a Rancher setup, either via CLI or web application
+func SetupECR(t *testing.T, provider string) error {
+	os.Getenv("CLOUD_PROVIDER_VERSION")
+
+	configPath := os.Getenv("CATTLE_TEST_CONFIG")
+	cattleConfig := shepherdConfig.LoadConfigFromFile(configPath)
+	_, terraformConfig, terratestConfig, _ := config.LoadTFPConfigs(cattleConfig)
+
+	if provider != "" {
+		terraformConfig.Provider = provider
+	}
+
+	_, keyPath := rancher2.SetKeyPath(keypath.RegistryKeyPath, terratestConfig.PathToRepo, "ecr")
+	terraformOptions := framework.Setup(t, terraformConfig, terratestConfig, keyPath)
+
+	terraformConfig.StandaloneRegistry.Enabled = true
+
+	var file *os.File
+	file = sanity.OpenFile(file, keyPath)
+	defer file.Close()
+
+	newFile := hclwrite.NewEmptyFile()
+	rootBody := newFile.Body()
+
+	tfBlock := rootBody.AppendNewBlock(terraformConst, nil)
+	tfBlockBody := tfBlock.Body()
+
+	instances := []string{ecrRegistry}
+
+	providerTunnel := providers.TunnelToProvider(terraformConfig.Provider)
+	file, err := providerTunnel.CreateNonAirgap(file, newFile, tfBlockBody, rootBody, terraformConfig, terratestConfig, instances)
+	require.NoError(t, err)
+
+	terraform.InitAndApply(t, terraformOptions)
+
+	ecrRegistryPublicDNS := terraform.Output(t, terraformOptions, ecrRegistryPublicDNS)
+
+	file = sanity.OpenFile(file, keyPath)
+	logrus.Infof("Creating ecr registry...")
+	file, err = registry.CreateECRRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, ecrRegistryPublicDNS)
+	require.NoError(t, err)
+
+	terraform.InitAndApply(t, terraformOptions)
+
+	return nil
+}

--- a/tests/infrastructure/registries/setup_non_auth_registry.go
+++ b/tests/infrastructure/registries/setup_non_auth_registry.go
@@ -1,0 +1,66 @@
+package registries
+
+import (
+	"os"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	shepherdConfig "github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/keypath"
+	"github.com/rancher/tfp-automation/framework"
+	"github.com/rancher/tfp-automation/framework/set/resources/providers"
+	"github.com/rancher/tfp-automation/framework/set/resources/rancher2"
+	registry "github.com/rancher/tfp-automation/framework/set/resources/registries/createRegistry"
+	"github.com/rancher/tfp-automation/framework/set/resources/sanity"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+// SetupNonAuthenticatedRegistry is a function that creates a non-authenticated registry in a Rancher setup, either via CLI or web application
+func SetupNonAuthenticatedRegistry(t *testing.T, provider string) error {
+	os.Getenv("CLOUD_PROVIDER_VERSION")
+
+	configPath := os.Getenv("CATTLE_TEST_CONFIG")
+	cattleConfig := shepherdConfig.LoadConfigFromFile(configPath)
+	_, terraformConfig, terratestConfig, _ := config.LoadTFPConfigs(cattleConfig)
+
+	if provider != "" {
+		terraformConfig.Provider = provider
+	}
+
+	_, keyPath := rancher2.SetKeyPath(keypath.RegistryKeyPath, terratestConfig.PathToRepo, "nonauth")
+	terraformOptions := framework.Setup(t, terraformConfig, terratestConfig, keyPath)
+
+	terraformConfig.StandaloneRegistry.Enabled = true
+
+	var file *os.File
+	file = sanity.OpenFile(file, keyPath)
+	defer file.Close()
+
+	newFile := hclwrite.NewEmptyFile()
+	rootBody := newFile.Body()
+
+	tfBlock := rootBody.AppendNewBlock(terraformConst, nil)
+	tfBlockBody := tfBlock.Body()
+
+	instances := []string{nonAuthRegistry}
+
+	providerTunnel := providers.TunnelToProvider(terraformConfig.Provider)
+	file, err := providerTunnel.CreateNonAirgap(file, newFile, tfBlockBody, rootBody, terraformConfig, terratestConfig, instances)
+	require.NoError(t, err)
+
+	terraform.InitAndApply(t, terraformOptions)
+
+	nonAuthRegistryPublicDNS := terraform.Output(t, terraformOptions, nonAuthRegistryPublicDNS)
+
+	file = sanity.OpenFile(file, keyPath)
+	logrus.Infof("Creating non-authenticated registry...")
+	file, err = registry.CreateNonAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, nonAuthRegistryPublicDNS, nonAuthRegistry)
+	require.NoError(t, err)
+
+	terraform.InitAndApply(t, terraformOptions)
+
+	return nil
+}

--- a/tests/infrastructure/state/state.go
+++ b/tests/infrastructure/state/state.go
@@ -29,3 +29,12 @@ var RancherStageMessage = []string{
 	"\nRegistry Rancher : ~2.5 hours",
 	"\n\nThe Rancher URL will be displayed once the setup successfully finishes.",
 }
+
+var RegistryStageMessage = []string{
+	"Please do not close this window while the setup is in progress.",
+	"\n\nAll Registries : ~3 hours",
+	"\nAuthenticated Registry : ~1 hour",
+	"\nNon-Authenticated Registry : ~40 minutes",
+	"\nECR : ~50 minutes",
+	"\n\nThe registry access information will be displayed once the setup successfully finishes.",
+}

--- a/tests/infrastructure/templates/confirm.tmpl
+++ b/tests/infrastructure/templates/confirm.tmpl
@@ -29,12 +29,16 @@
                     {{else if eq .Selection "rancher"}}
                         <input type="hidden" name="ranchertype" value="{{.RancherType}}">
                         <input type="hidden" name="installtype" value="{{.InstallType}}">
+                    {{else if eq .Selection "registry"}}
+                        <input type="hidden" name="registrytype" value="{{.RegistryType}}">
                     {{else}}
                         {{if .ClusterType}}
                             <input type="hidden" name="clustertype" value="{{.ClusterType}}">
                         {{else if .RancherType}}
                             <input type="hidden" name="ranchertype" value="{{.RancherType}}">
                             <input type="hidden" name="installtype" value="{{.InstallType}}">
+                        {{else if .RegistryType}}
+                            <input type="hidden" name="registrytype" value="{{.RegistryType}}">
                         {{end}}
                     {{end}}
                     <input type="hidden" name="provider" value="{{.Provider}}" />
@@ -81,12 +85,16 @@
                     {{else if eq .Selection "rancher"}}
                         <input type="hidden" name="ranchertype" value="{{.RancherType}}">
                         <input type="hidden" name="installtype" value="{{.InstallType}}">
+                    {{else if eq .Selection "registry"}}
+                        <input type="hidden" name="registrytype" value="{{.RegistryType}}">
                     {{else}}
                         {{if .ClusterType}}
                             <input type="hidden" name="clustertype" value="{{.ClusterType}}">
                         {{else if .RancherType}}
                             <input type="hidden" name="ranchertype" value="{{.RancherType}}">
                             <input type="hidden" name="installtype" value="{{.InstallType}}">
+                        {{else if .RegistryType}}
+                            <input type="hidden" name="registrytype" value="{{.RegistryType}}">
                         {{end}}
                     {{end}}
                     <input type="hidden" name="provider" value="{{.Provider}}" />

--- a/tests/infrastructure/templates/provider.tmpl
+++ b/tests/infrastructure/templates/provider.tmpl
@@ -37,15 +37,18 @@
                     <input type="hidden" name="selection" value="{{.Selection}}" />
                     {{if .ClusterType}}
                         <input type="hidden" name="clustertype" value="{{.ClusterType}}">
-                    {{else}}
+                    {{else if .RancherType}}
                         <input type="hidden" name="ranchertype" value="{{.RancherType}}">
                         <input type="hidden" name="installtype" value="{{.InstallType}}">
+                    {{else if .RegistryType}}
+                        <input type="hidden" name="registrytype" value="{{.RegistryType}}">
                     {{end}}
                     <input type="hidden" id="provider-input" name="provider" required />
                     <div class="provider-select-grid">
                         {{if or (eq .RancherType "airgap") (eq .RancherType "dual") (eq .RancherType "ipv6") (eq .RancherType "registry") (eq .RancherType "proxy")
                             (eq .ClusterType "airgap-rke2") (eq .ClusterType "dual-rke2") (eq .ClusterType "dual-k3s") (eq .ClusterType "ipv6-rke2") 
-                            (eq .ClusterType "ipv6-k3s")}}
+                            (eq .ClusterType "ipv6-k3s") (eq .RegistryType "registries-all") (eq .RegistryType "registries-auth") 
+                            (eq .RegistryType "registries-nonauth") (eq .RegistryType "registries-ecr") }}
                             <label id="label-aws" class="provider-img-label" onclick="selectProvider('aws')">
                                 <img src="/static/images/aws.png" alt="AWS" class="provider-img" />
                                 <div>AWS</div>
@@ -85,6 +88,12 @@
                     <input type="hidden" name="selection" value="{{.Selection}}" />
                     <input type="hidden" name="ranchertype" value="{{.RancherType}}">
                     <input type="hidden" name="installtype" value="{{.InstallType}}">
+                    <button type="submit" class="form-button" style="background:#ccc;color:#333;">&#8592; Back</button>
+                </form>
+                {{else if eq .Selection "registry"}}
+                <form action="/registrytype" method="post" style="margin-top:1rem;">
+                    <input type="hidden" name="selection" value="{{.Selection}}" />
+                    <input type="hidden" name="registrytype" value="{{.RegistryType}}">
                     <button type="submit" class="form-button" style="background:#ccc;color:#333;">&#8592; Back</button>
                 </form>
                 {{end}}

--- a/tests/infrastructure/templates/providerversion.tmpl
+++ b/tests/infrastructure/templates/providerversion.tmpl
@@ -35,9 +35,11 @@
                     <input type="hidden" name="selection" value="{{.Selection}}" />
                     {{if .ClusterType}}
                         <input type="hidden" name="clustertype" value="{{.ClusterType}}">
-                    {{else}}
+                    {{else if .RancherType}}
                         <input type="hidden" name="ranchertype" value="{{.RancherType}}">
                         <input type="hidden" name="installtype" value="{{.InstallType}}">
+                    {{else if .RegistryType}}
+                        <input type="hidden" name="registrytype" value="{{.RegistryType}}">
                     {{end}}
                     <input type="hidden" name="provider" value="{{.Provider}}" />
                     <label class="form-label" for="providerversion">Cloud Provider Version:</label>
@@ -55,6 +57,8 @@
                    {{else if eq .Selection "rancher"}}
                         <input type="hidden" name="ranchertype" value="{{.RancherType}}">
                         <input type="hidden" name="installtype" value="{{.InstallType}}">
+                    {{else if eq .Selection "registry"}}
+                        <input type="hidden" name="registrytype" value="{{.RegistryType}}">
                     {{end}}
                     <input type="hidden" name="provider" value="{{.Provider}}" />
                     <button type="submit" class="form-button" style="background:#ccc;color:#333;">&#8592; Back</button>

--- a/tests/infrastructure/templates/registrytype.tmpl
+++ b/tests/infrastructure/templates/registrytype.tmpl
@@ -1,0 +1,50 @@
+{{define "registrytype"}}
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <title>Registry Types</title>
+        <link rel="stylesheet" href="/static/styles.css" />
+        <link rel="icon" type="image/x-icon" href="/static/favicon.ico" />
+        <link rel="preload" href="/static/favicon.ico" as="image" />
+    </head>
+    <body>
+        <!-- Logo -->
+        <header>
+            <a href="https://www.rancher.com/" target="_blank">
+                <img src="/static/images/rancher.png" class="logo" alt="Rancher by SUSE Logo" />
+            </a>
+        </header>
+
+        <main>
+            <div class="container">
+                <h2>Select Registry Type</h2>
+
+                <!-- Registry Type Form -->
+                <form action="/provider" method="post">
+                    <input type="hidden" name="selection" value="{{.Selection}}" />
+                    <div style="margin-bottom:1.5rem;">
+                        <label class="form-label-radio">
+                            <input type="radio" class="form-radio" name="registrytype" value="registries-all" required /> All Registries
+                        </label>
+                        <label class="form-label-radio">
+                            <input type="radio" class="form-radio" name="registrytype" value="registries-auth" required /> Authenticated Registry
+                        </label>
+                        <label class="form-label-radio">
+                            <input type="radio" class="form-radio" name="registrytype" value="registries-nonauth" required /> Non-Authenticated Registry
+                        </label>
+                        <label class="form-label-radio">
+                            <input type="radio" class="form-radio" name="registrytype" value="registries-ecr" required /> ECR
+                        </label>
+                    </div>
+                    <button type="submit" class="form-button">Next &#8594;</button>
+                </form>
+                <form action="/selection" method="post" style="margin-top:1rem;">
+                    <input type="hidden" name="selection" value="{{.Selection}}" />
+                    <button type="submit" class="form-button" style="background:#ccc;color:#333;">&#8592; Back</button>
+                </form>
+            </div>
+        </main>
+    </body>
+</html>
+{{end}}

--- a/tests/infrastructure/templates/selection.tmpl
+++ b/tests/infrastructure/templates/selection.tmpl
@@ -18,9 +18,9 @@
 
         <main>
             <div class="container">
-                <h2>Select Cluster or Rancher</h2>
+                <h2>Select Cluster, Rancher, or Registry</h2>
 
-                <!-- Cluster or Rancher Form -->
+                <!-- Cluster, Rancher, or Registry Form -->
                 <form id="selectionForm" action="/installtype" method="post">
                     <input type="hidden" name="selection" id="selectionInput" value="" />
                     <label class="form-label-radio">
@@ -28,6 +28,9 @@
                     </label>
                     <label class="form-label-radio">
                         <input type="radio" class="form-radio" name="selectionRadio" value="rancher" required /> Rancher
+                    </label>
+                    <label class="form-label-radio">
+                        <input type="radio" class="form-radio" name="selectionRadio" value="registry" required /> Registry
                     </label>
 
                     <button type="submit" class="form-button">Next &#8594;</button>
@@ -44,6 +47,8 @@
                         this.action = '/clustertype';
                     } else if (selected.value === 'rancher') {
                         this.action = '/ranchertype';
+                    } else if (selected.value === 'registry') {
+                        this.action = '/registrytype';
                     }
 
                 });

--- a/tests/infrastructure/templates/status.tmpl
+++ b/tests/infrastructure/templates/status.tmpl
@@ -39,7 +39,7 @@
                   document.getElementById('stage-msg').innerHTML = newStage.innerHTML;
 
                   if (!newError || newError.innerText.trim() === "") {
-                    header.innerText = "Creating Rancher/Cluster";
+                    header.innerText = "Please Wait";
                   }
                 }
             }
@@ -70,7 +70,7 @@
 
     <main>
       <div class="container">
-        <h2 id="status-header">Creating Rancher/Cluster</h2>
+        <h2 id="status-header">Please Wait</h2>
 
         <!-- Stage message -->
         <div id="stage-msg" class="rancher-link-center">

--- a/tests/infrastructure/templates/welcome.tmpl
+++ b/tests/infrastructure/templates/welcome.tmpl
@@ -23,6 +23,7 @@
                 <ul>
                     <li>Deploy a Rancher Server</li>
                     <li>Deploy a standalone RKE2 / K3S Cluster</li>
+                    <li>Deploy a standalone private registry</li>
                 </ul>
                 <p>Click the button below to get started.</p>
 

--- a/tests/infrastructure/web/web.go
+++ b/tests/infrastructure/web/web.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/tests/infrastructure/clusters"
 	"github.com/rancher/tfp-automation/tests/infrastructure/ranchers"
+	"github.com/rancher/tfp-automation/tests/infrastructure/registries"
 	share "github.com/rancher/tfp-automation/tests/infrastructure/state"
 )
 
@@ -45,6 +46,13 @@ var setupRancherFuncs = map[string]map[string]func(*testing.T, string) error{
 	"registry": {
 		"fresh": ranchers.CreateRegistryRancher,
 	},
+}
+
+var setupRegistryFuncs = map[string]func(*testing.T, string) error{
+	"registries-all":     registries.SetupAllRegistries,
+	"registries-auth":    registries.SetupAuthenticatedRegistry,
+	"registries-nonauth": registries.SetupNonAuthenticatedRegistry,
+	"registries-ecr":     registries.SetupECR,
 }
 
 // RunClusterSetupWeb is a function that runs the standalone cluster web application setup
@@ -131,6 +139,51 @@ func RunRancherSetupWeb(provider, providerversion, ranchertype, installtype stri
 
 	url := "https://" + terraformConfig.Standalone.RancherHostname
 	share.State.StageMsg = strings.TrimSpace(url)
+
+	go func() {
+		time.Sleep(30 * time.Second)
+		os.Exit(0)
+	}()
+
+	return nil
+}
+
+// RunRegistrySetupWeb is a function that runs the standalone registry web application setup
+func RunRegistrySetupWeb(provider, providerversion, registrytype string) error {
+	configPath := os.Getenv("CATTLE_TEST_CONFIG")
+	cattleConfig := shepherdConfig.LoadConfigFromFile(configPath)
+	_, terraformConfig, _, _ := config.LoadTFPConfigs(cattleConfig)
+
+	os.Setenv("CLOUD_PROVIDER_VERSION", providerversion)
+
+	t := &testing.T{}
+
+	share.State.Mutex.Lock()
+
+	share.State.StageMsg = strings.Join(share.RegistryStageMessage, "\n")
+	share.State.ErrorMsg = ""
+	share.State.Mutex.Unlock()
+
+	var setupErr error
+	if setupFunc, ok := setupRegistryFuncs[registrytype]; ok {
+		setupErr = setupFunc(t, provider)
+	}
+
+	if setupErr != nil {
+		share.State.Mutex.Lock()
+		share.State.ErrorMsg = setupErr.Error()
+		share.State.StageMsg = "Unable to create registry. See error below:"
+		share.State.Mutex.Unlock()
+
+		go func() {
+			time.Sleep(30 * time.Second)
+			os.Exit(1)
+		}()
+
+		return setupErr
+	}
+
+	share.State.StageMsg = "Registry is ready! Please go to AWS Management Console and find it with prefix " + terraformConfig.ResourcePrefix
 
 	go func() {
 		time.Sleep(30 * time.Second)


### PR DESCRIPTION
### Description
As part of a broader effort to ensure that we can test Prime setups, we need to ensure that we can have standalone registries provisioned to then use in a Rancher setup. This PR adds support for that in the repo, some highlights before:
- Updates TFP GUI to allow private registry creation
- CLI options have been updated to allow: `--registries-all`, `--registries-auth`, `--registries-nonauth`, `--registries-ecr`

You have the choice to create all registries (all meaning global, non-auth, auth and ECR) or individually creating non-auth, auth or ECR.