### PR TITLE
Add Slack group team handle to the weekly PR summary workflow

### DIFF
--- a/.github/workflows/weekly-pr-summary.yaml
+++ b/.github/workflows/weekly-pr-summary.yaml
@@ -1,6 +1,9 @@
 name: Weekly PR Summary
 
 on:
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
   schedule:
     - cron: '0 8 * * 3'
@@ -48,7 +51,11 @@ jobs:
 
       - name: Prepare PR input
         run: |
-          jq -r '.[] | "- <" + .url + "|" + .title + "> (" + .state + ")"' prs.json > prs_input.txt
+          {
+            echo "<!subteam^${{ secrets.SLACK_GROUP_ID }}|${{ secrets.SLACK_GROUP_HANDLE }}>"
+            echo ""
+            jq -r '.[] | "- <" + .url + "|" + .title + "> (" + .state + ")"' prs.json
+          } > prs_input.txt
 
       - name: Run GitHub Model prompt
         id: run-prompt


### PR DESCRIPTION
### Description
Yesterday, I introduced a workflow that uses Github Models to give our team Slack channel a weekly PR summary. This outlines both open and closed PRs in the hope to enhance productivity for any open PRs that exist.

A nice touch would be to add our team Slack handle so that each Wednesday when this workflow executes, we will all get a ping so that there is a bit more accountability. That is what this PR serves to do.