### PR TITLE
Remove pull_request trigger on main branch for weekly PR summary workflow

### DIFF
--- a/.github/workflows/weekly-pr-summary.yaml
+++ b/.github/workflows/weekly-pr-summary.yaml
@@ -1,9 +1,6 @@
 name: Weekly PR Summary
 
 on:
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
   schedule:
     - cron: '0 8 * * 3'


### PR DESCRIPTION
### Description
In the last PR, forgot to remove the `pull_request` trigger that was being used in testing efforts. Small PR to remove that trigger as that is not intended to be in use for production settings; that was an oversight when merging the last PR.