### PR TITLE
Fix weeklyTestsReports path in generate_weekly_chart.go

### DIFF
--- a/weeklyTestsReports/generate_weekly_chart.go
+++ b/weeklyTestsReports/generate_weekly_chart.go
@@ -18,10 +18,10 @@ import (
 )
 
 const (
-	headerPath   = "weeklyReports/assets/workflow_header.html"
-	templatePath = "weeklyReports/assets/template.html"
+	headerPath   = "weeklyTestsReports/assets/workflow_header.html"
+	templatePath = "weeklyTestsReports/assets/template.html"
 
-	assetsSrcDir = "weeklyReports/assets"
+	assetsSrcDir = "weeklyTestsReports/assets"
 	assetsDstDir = "results/assets"
 	resultsDir   = "results"
 


### PR DESCRIPTION
This pull request fixes an incorrect path for weeklyTestsReports in the generate_weekly_chart.go file, ensuring the report is generated and accessed correctly.