### PR TITLE
Add Qase release ID to local cluster K8s upgrade workflow

### DIFF
--- a/.github/workflows/local-cluster-k8s-upgrade-test.yaml
+++ b/.github/workflows/local-cluster-k8s-upgrade-test.yaml
@@ -135,6 +135,7 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
+          qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_15 }}"
           qase_recurring_id: "${{ vars.QASE_RECURRING_TEST_RUN_ID_2_15 }}"
 
       - name: Set upgraded Rancher chart url
@@ -422,6 +423,7 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
+          qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_14 }}"
           qase_recurring_id: "${{ vars.QASE_RECURRING_TEST_RUN_ID_2_14 }}"
 
       - name: Set upgraded Rancher chart url
@@ -709,6 +711,7 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
+          qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_13 }}"
           qase_recurring_id: "${{ vars.QASE_RECURRING_TEST_RUN_ID_2_13 }}"
 
       - name: Set upgraded Rancher chart url


### PR DESCRIPTION
This PR adds the Qase release ID to the local cluster Kubernetes upgrade workflow, enabling improved tracking and integration with Qase during upgrade processes.