### PR TITLE
Update Imported clusters to use nodepools

### DIFF
--- a/framework/set/provisioning/imported/importNodes.go
+++ b/framework/set/provisioning/imported/importNodes.go
@@ -2,8 +2,10 @@ package imported
 
 import (
 	"encoding/base64"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
@@ -17,19 +19,16 @@ import (
 )
 
 const (
-	address       = "address"
 	addServer     = "add_server_"
+	addAgent      = "add_agent_"
+	createCluster = "create_cluster"
 	importCluster = "import_cluster"
 	copyScript    = "copy_script"
-	role          = "role"
-	serverTwo     = "server2"
-	serverThree   = "server3"
-	user          = "user"
-	windows       = "windows"
 )
 
 // ImportNodes is a function that will import the nodes to the cluster
-func ImportNodes(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig, nodeOnePublicIP, importCommand string) error {
+func ImportNodes(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig,
+	nodeOnePublicIP, importCommand string, additionalServerNodeNames, additionalAgentNodeNames []string) error {
 	userDir, _ := rancher2.SetKeyPath(keypath.RancherKeyPath, terratestConfig.PathToRepo, terraformConfig.Provider)
 
 	scriptPath := filepath.Join(userDir, terratestConfig.PathToRepo, "/framework/set/provisioning/imported/import-nodes.sh")
@@ -51,9 +50,14 @@ func ImportNodes(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfi
 	command := "bash -c '/tmp/import-nodes.sh " + encodedPEMFile + " " + terraformConfig.Standalone.OSUser + " " +
 		terraformConfig.Standalone.OSGroup + " " + importCommand + "'"
 
+	linuxNodeNames := make([]string, 0, len(additionalServerNodeNames)+len(additionalAgentNodeNames)+1)
+	linuxNodeNames = append(linuxNodeNames, terraformConfig.ResourcePrefix+"_server1")
+	linuxNodeNames = append(linuxNodeNames, additionalServerNodeNames...)
+	linuxNodeNames = append(linuxNodeNames, additionalAgentNodeNames...)
+
 	// Need to first create a null resource block to copy the script to the node.
 	copyScriptName := terraformConfig.ResourcePrefix + `_` + copyScript
-	nullResourceBlockBody, provisionerBlockBody := nullresource.CreateImportedNullResource(rootBody, terraformConfig, nodeOnePublicIP, copyScriptName)
+	nullResourceBlockBody, provisionerBlockBody := nullresource.CreateImportedNullResource(rootBody, terraformConfig, nodeOnePublicIP, copyScriptName, linuxNodeNames)
 
 	provisionerBlockBody.SetAttributeValue(general.Inline, cty.ListVal([]cty.Value{
 		cty.StringVal("echo '" + string(scriptContent) + "' > /tmp/import-nodes.sh"),
@@ -63,12 +67,23 @@ func ImportNodes(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfi
 	var dependsOnServer string
 
 	switch terraformConfig.Module {
-	case modules.ImportedAWSRKE2, modules.ImportedAWSK3S, modules.ImportedVsphereRKE2, modules.ImportedVsphereK3S:
-		addServerTwoName := addServer + terraformConfig.ResourcePrefix + `_` + serverTwo
-		addServerThreeName := addServer + terraformConfig.ResourcePrefix + `_` + serverThree
-		dependsOnServer = `[` + general.NullResource + `.` + addServerTwoName + `, ` + general.NullResource + `.` + addServerThreeName + `]`
 	case modules.ImportedAWSRKE2Windows2019, modules.ImportedAWSRKE2Windows2022:
 		dependsOnServer = `[` + general.TimeSleep + `.` + general.TimeSleep + `-` + terraformConfig.ResourcePrefix + `-import_wins` + `]`
+	default:
+		if len(additionalServerNodeNames) == 0 && len(additionalAgentNodeNames) == 0 {
+			dependsOnServer = fmt.Sprintf("[%s.%s_%s]", general.NullResource, terraformConfig.ResourcePrefix, createCluster)
+		} else {
+			dependsOnResources := make([]string, 0, len(additionalServerNodeNames)+len(additionalAgentNodeNames))
+			for _, nodeName := range additionalServerNodeNames {
+				dependsOnResources = append(dependsOnResources, fmt.Sprintf("%s.%s%s", general.NullResource, addServer, nodeName))
+			}
+
+			for _, nodeName := range additionalAgentNodeNames {
+				dependsOnResources = append(dependsOnResources, fmt.Sprintf("%s.%s%s", general.NullResource, addAgent, nodeName))
+			}
+
+			dependsOnServer = fmt.Sprintf("[%s]", strings.Join(dependsOnResources, ", "))
+		}
 	}
 
 	server := hclwrite.Tokens{
@@ -80,7 +95,7 @@ func ImportNodes(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfi
 	// A second null resource block is needed to properly run the script on the node. This is because the cluster registration
 	// token will not be passed correctly as Bash parameters.
 	importClusterName := terraformConfig.ResourcePrefix + `_` + importCluster
-	nullResourceBlockBody, provisionerBlockBody = nullresource.CreateImportedNullResource(rootBody, terraformConfig, nodeOnePublicIP, importClusterName)
+	nullResourceBlockBody, provisionerBlockBody = nullresource.CreateImportedNullResource(rootBody, terraformConfig, nodeOnePublicIP, importClusterName, linuxNodeNames)
 
 	provisionerBlockBody.SetAttributeRaw(general.Inline, hclwrite.Tokens{
 		{Type: hclsyntax.TokenOQuote, Bytes: []byte(`["`), SpacesBefore: 1},

--- a/framework/set/provisioning/imported/nullresource/importNullResource.go
+++ b/framework/set/provisioning/imported/nullresource/importNullResource.go
@@ -1,6 +1,8 @@
 package nullresource
 
 import (
+	"strings"
+
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/rancher/tfp-automation/config"
@@ -10,14 +12,9 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-const (
-	serverOne   = "server1"
-	serverTwo   = "server2"
-	serverThree = "server3"
-)
-
 // CreateImportedNullResource is a helper function that will create the null_resource for the cluster.
-func CreateImportedNullResource(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, publicIP, resourceName string) (*hclwrite.Body, *hclwrite.Body) {
+func CreateImportedNullResource(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, publicIP, resourceName string,
+	linuxNodeNames []string) (*hclwrite.Body, *hclwrite.Body) {
 	nullResourceBlock := rootBody.AppendNewBlock(general.Resource, []string{general.NullResource, resourceName})
 	nullResourceBlockBody := nullResourceBlock.Body()
 
@@ -51,17 +48,23 @@ func CreateImportedNullResource(rootBody *hclwrite.Body, terraformConfig *config
 
 	connectionBlockBody.SetAttributeRaw(general.PrivateKey, keyPath)
 
-	serverOneName := terraformConfig.ResourcePrefix + `_` + serverOne
-	serverTwoName := terraformConfig.ResourcePrefix + `_` + serverTwo
-	serverThreeName := terraformConfig.ResourcePrefix + `_` + serverThree
-
-	var dependsOnServer string
+	dependsOnResources := make([]string, 0, len(linuxNodeNames))
 	switch terraformConfig.Provider {
 	case aws.Aws:
-		dependsOnServer = `[` + aws.AwsInstance + `.` + serverOneName + `, ` + aws.AwsInstance + `.` + serverTwoName + `, ` + aws.AwsInstance + `.` + serverThreeName + `]`
+		for _, nodeName := range linuxNodeNames {
+			dependsOnResources = append(dependsOnResources, aws.AwsInstance+"."+nodeName)
+		}
 	case vsphere.Vsphere:
-		dependsOnServer = `[` + vsphere.VsphereVirtualMachine + `.` + serverOneName + `, ` + vsphere.VsphereVirtualMachine + `.` + serverTwoName + `, ` + vsphere.VsphereVirtualMachine + `.` + serverThreeName + `]`
+		for _, nodeName := range linuxNodeNames {
+			dependsOnResources = append(dependsOnResources, vsphere.VsphereVirtualMachine+"."+nodeName)
+		}
 	}
+
+	dependsOnServer := `[`
+	if len(dependsOnResources) > 0 {
+		dependsOnServer += strings.Join(dependsOnResources, ", ")
+	}
+	dependsOnServer += `]`
 
 	server := hclwrite.Tokens{
 		{Type: hclsyntax.TokenIdent, Bytes: []byte(dependsOnServer)},

--- a/framework/set/provisioning/imported/nullresource/importWindowsNullResource.go
+++ b/framework/set/provisioning/imported/nullresource/importWindowsNullResource.go
@@ -15,7 +15,7 @@ import (
 
 // CreateImportedWindowsNullResource is a helper function that will create the null_resource for the Windows node.
 func CreateImportedWindowsNullResource(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig,
-	publicDNS, resourceName string) (*hclwrite.Body, *hclwrite.Body) {
+	resourceName string) (*hclwrite.Body, *hclwrite.Body) {
 	nullResourceBlock := rootBody.AppendNewBlock(general.Resource, []string{general.NullResource, resourceName})
 	nullResourceBlockBody := nullResourceBlock.Body()
 

--- a/framework/set/provisioning/imported/rke2k3s/getProviderIPAddresses.go
+++ b/framework/set/provisioning/imported/rke2k3s/getProviderIPAddresses.go
@@ -15,13 +15,9 @@ import (
 
 // getProviderIPAddresses is a helper function that returns the IP addresses of the nodes
 func getProviderIPAddresses(terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig, rootBody *hclwrite.Body,
-	serverOneName string) (string, string, string, string) {
-	var nodeOnePublicIP, nodeOnePrivateIP, nodeTwoPublicIP, nodeThreePublicIP string
-
-	serverTwoName := terraformConfig.ResourcePrefix + `_` + serverTwo
-	serverThreeName := terraformConfig.ResourcePrefix + `_` + serverThree
-
-	instances := []string{serverOneName, serverTwoName, serverThreeName}
+	linuxNodeNames []string) (map[string]string, map[string]string) {
+	nodePublicIPs := make(map[string]string, len(linuxNodeNames))
+	nodePrivateIPs := make(map[string]string, len(linuxNodeNames))
 
 	if terraformConfig.Provider == vsphereDefaults.Vsphere {
 		dataCenterExpression := fmt.Sprintf(general.Data + `.` + vsphereDefaults.VsphereDatacenter + `.` + vsphereDefaults.VsphereDatacenter + `.id`)
@@ -45,26 +41,22 @@ func getProviderIPAddresses(terraformConfig *config.TerraformConfig, terratestCo
 		rootBody.AppendNewline()
 	}
 
-	for _, instance := range instances {
+	for _, instance := range linuxNodeNames {
 		switch terraformConfig.Provider {
 		case awsDefaults.Aws:
 			aws.CreateAWSInstances(rootBody, terraformConfig, terratestConfig, instance)
 			rootBody.AppendNewline()
 
-			nodeOnePrivateIP = fmt.Sprintf("${%s.%s.private_ip}", awsDefaults.AwsInstance, serverOneName)
-			nodeOnePublicIP = fmt.Sprintf("${%s.%s.public_ip}", awsDefaults.AwsInstance, serverOneName)
-			nodeTwoPublicIP = fmt.Sprintf("${%s.%s.public_ip}", awsDefaults.AwsInstance, serverTwoName)
-			nodeThreePublicIP = fmt.Sprintf("${%s.%s.public_ip}", awsDefaults.AwsInstance, serverThreeName)
+			nodePrivateIPs[instance] = fmt.Sprintf("${%s.%s.private_ip}", awsDefaults.AwsInstance, instance)
+			nodePublicIPs[instance] = fmt.Sprintf("${%s.%s.public_ip}", awsDefaults.AwsInstance, instance)
 		case vsphereDefaults.Vsphere:
 			vsphere.CreateVsphereVirtualMachine(rootBody, terraformConfig, terratestConfig, instance)
 			rootBody.AppendNewline()
 
-			nodeOnePrivateIP = fmt.Sprintf("${%s.%s.default_ip_address}", vsphereDefaults.VsphereVirtualMachine, serverOneName)
-			nodeOnePublicIP = fmt.Sprintf("${%s.%s.default_ip_address}", vsphereDefaults.VsphereVirtualMachine, serverOneName)
-			nodeTwoPublicIP = fmt.Sprintf("${%s.%s.default_ip_address}", vsphereDefaults.VsphereVirtualMachine, serverTwoName)
-			nodeThreePublicIP = fmt.Sprintf("${%s.%s.default_ip_address}", vsphereDefaults.VsphereVirtualMachine, serverThreeName)
+			nodePrivateIPs[instance] = fmt.Sprintf("${%s.%s.default_ip_address}", vsphereDefaults.VsphereVirtualMachine, instance)
+			nodePublicIPs[instance] = fmt.Sprintf("${%s.%s.default_ip_address}", vsphereDefaults.VsphereVirtualMachine, instance)
 		}
 	}
 
-	return nodeOnePublicIP, nodeOnePrivateIP, nodeTwoPublicIP, nodeThreePublicIP
+	return nodePublicIPs, nodePrivateIPs
 }

--- a/framework/set/provisioning/imported/rke2k3s/setConfig.go
+++ b/framework/set/provisioning/imported/rke2k3s/setConfig.go
@@ -3,6 +3,7 @@ package rke2k3s
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2/hclwrite"
@@ -11,25 +12,16 @@ import (
 	"github.com/rancher/tfp-automation/defaults/clustertypes"
 	"github.com/rancher/tfp-automation/framework/set/defaults/general"
 	awsDefaults "github.com/rancher/tfp-automation/framework/set/defaults/providers/aws"
+	customnodepools "github.com/rancher/tfp-automation/framework/set/provisioning/custom/nodepools"
 	"github.com/rancher/tfp-automation/framework/set/provisioning/custom/sleep"
 	"github.com/rancher/tfp-automation/framework/set/provisioning/imported"
 	resources "github.com/rancher/tfp-automation/framework/set/resources/imported"
 	"github.com/rancher/tfp-automation/framework/set/resources/providers/aws"
+	rancher2resources "github.com/rancher/tfp-automation/framework/set/resources/rancher2"
 )
 
 const (
-	address          = "address"
-	addServer        = "add_server_"
-	importCluster    = "import_cluster"
-	copyScript       = "copy_script"
-	enableCriDockerD = "enable_cri_dockerd"
-	role             = "role"
-	serverOne        = "server1"
-	serverTwo        = "server2"
-	serverThree      = "server3"
-	sshKey           = "ssh_key"
-	user             = "user"
-	windows          = "windows"
+	windows = "windows"
 )
 
 // // SetImportedRKE2K3s is a function that will set the imported RKE2/K3s cluster configurations in the main.tf file.
@@ -38,14 +30,26 @@ func SetImportedRKE2K3s(terraformConfig *config.TerraformConfig, terratestConfig
 	imported.SetImportedCluster(rootBody, terraformConfig.ResourcePrefix)
 	rootBody.AppendNewline()
 
-	serverOneName := terraformConfig.ResourcePrefix + `_` + serverOne
+	serverNodeNames, agentNodeNames, err := buildImportedLinuxNodeNames(terraformConfig, terratestConfig)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	linuxNodeNames := append(append([]string{}, serverNodeNames...), agentNodeNames...)
+	if len(serverNodeNames) == 0 {
+		return nil, nil, fmt.Errorf("at least one non-windows imported nodepool entry is required")
+	}
+
+	serverOneName := serverNodeNames[0]
 	windowsNodeName := terraformConfig.ResourcePrefix + `-` + windows
 
-	nodeOnePublicIP, nodeOnePrivateIP, nodeTwoPublicIP, nodeThreePublicIP := getProviderIPAddresses(terraformConfig, terratestConfig, rootBody, serverOneName)
+	nodePublicIPs, nodePrivateIPs := getProviderIPAddresses(terraformConfig, terratestConfig, rootBody, linuxNodeNames)
 
 	token := namegen.AppendRandomString(general.Import)
 
-	resources.CreateRKE2K3SImportedCluster(rootBody, terraformConfig, terratestConfig, nodeOnePublicIP, nodeOnePrivateIP, nodeTwoPublicIP, nodeThreePublicIP, token)
+	if err := resources.CreateRKE2K3SImportedCluster(rootBody, terraformConfig, terratestConfig, linuxNodeNames, serverNodeNames, agentNodeNames, nodePublicIPs, nodePrivateIPs, token); err != nil {
+		return nil, nil, err
+	}
 	rootBody.AppendNewline()
 
 	if strings.Contains(terraformConfig.Module, clustertypes.WINDOWS) {
@@ -53,7 +57,7 @@ func SetImportedRKE2K3s(terraformConfig *config.TerraformConfig, terratestConfig
 		rootBody.AppendNewline()
 
 		windowsNodePublicDNS := fmt.Sprintf("${%s.%s.public_dns}", awsDefaults.AwsInstance, windowsNodeName)
-		resources.AddWindowsNodeToImportedCluster(rootBody, terraformConfig, terratestConfig, nodeOnePrivateIP, windowsNodePublicDNS, token)
+		resources.AddWindowsNodeToImportedCluster(rootBody, terraformConfig, terratestConfig, nodePrivateIPs[serverOneName], windowsNodePublicDNS, token)
 
 		// Add the sleep command to wait for the Windows node to be ready
 		rootBody.AppendNewline()
@@ -65,10 +69,40 @@ func SetImportedRKE2K3s(terraformConfig *config.TerraformConfig, terratestConfig
 
 	importCommand := imported.GetImportCommand(terraformConfig.ResourcePrefix)
 
-	err := imported.ImportNodes(rootBody, terraformConfig, terratestConfig, nodeOnePublicIP, importCommand[serverOneName])
+	err = imported.ImportNodes(rootBody, terraformConfig, terratestConfig, nodePublicIPs[serverOneName], importCommand[serverOneName], serverNodeNames[1:], agentNodeNames)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	return newFile, file, nil
+}
+
+func buildImportedLinuxNodeNames(terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig) ([]string, []string, error) {
+	linuxNodeCount := customnodepools.TotalNodeCount(terratestConfig)
+	serverNodes := make([]string, 0, linuxNodeCount)
+	agentNodes := make([]string, 0, linuxNodeCount)
+
+	nodeIndex := int64(1)
+	for count, pool := range terratestConfig.Nodepools {
+		if pool.Windows {
+			continue
+		}
+
+		if _, err := rancher2resources.SetResourceNodepoolValidation(terraformConfig, pool, strconv.Itoa(count)); err != nil {
+			return nil, nil, err
+		}
+
+		for i := int64(0); i < pool.Quantity; i++ {
+			nodeName := fmt.Sprintf("%s_server%d", terraformConfig.ResourcePrefix, nodeIndex)
+			if pool.Etcd || pool.Controlplane {
+				serverNodes = append(serverNodes, nodeName)
+			} else {
+				agentNodes = append(agentNodes, nodeName)
+			}
+
+			nodeIndex++
+		}
+	}
+
+	return serverNodes, agentNodes, nil
 }

--- a/framework/set/provisioning/imported/setImportedCluster.go
+++ b/framework/set/provisioning/imported/setImportedCluster.go
@@ -8,11 +8,10 @@ import (
 )
 
 // SetImportedCluster is a function that will set the imported rancher2_cluster configurations in the main.tf file.
-func SetImportedCluster(rootBody *hclwrite.Body, clusterName string) error {
+func SetImportedCluster(rootBody *hclwrite.Body, clusterName string) {
 	clusterBlock := rootBody.AppendNewBlock(general.Resource, []string{rancher2.Cluster, clusterName})
 	clusterBlockBody := clusterBlock.Body()
 
 	clusterBlockBody.SetAttributeValue(general.ResourceName, cty.StringVal(clusterName))
 	clusterBlockBody.SetAttributeValue(general.Description, cty.StringVal("tfp-automation imported cluster"))
-	return nil
 }

--- a/framework/set/resources/imported/addWindowsNode.go
+++ b/framework/set/resources/imported/addWindowsNode.go
@@ -16,6 +16,11 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
+const (
+	addWindowsNode = "add_windows_node"
+	windowsServer  = "windows_server"
+)
+
 // AddWindowsNodeToImportedCluster is a helper function that will add an additional Windows node to the initial server.
 func AddWindowsNodeToImportedCluster(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig,
 	serverOnePrivateIP, windowsNodePublicDNS, token string) error {
@@ -39,7 +44,7 @@ func addImportedWindowsNode(rootBody *hclwrite.Body, terraformConfig *config.Ter
 	token string, script []byte) {
 	copyScriptName := terraformConfig.ResourcePrefix + copyScript + windowsServer
 
-	nullResourceBlockBody, provisionerBlockBody := nullresource.CreateImportedWindowsNullResource(rootBody, terraformConfig, terratestConfig, windowsNodePublicDNS, copyScriptName)
+	nullResourceBlockBody, provisionerBlockBody := nullresource.CreateImportedWindowsNullResource(rootBody, terraformConfig, terratestConfig, copyScriptName)
 	rootBody.AppendNewline()
 
 	dependsOnServer := `[` + aws.AwsInstance + `.` + terraformConfig.ResourcePrefix + `-windows` + `]`
@@ -72,7 +77,7 @@ func addImportedWindowsNode(rootBody *hclwrite.Body, terraformConfig *config.Ter
 	}
 
 	provisionerBlockBody.SetAttributeValue(general.Inline, cty.ListVal(inlineCommands))
-	nullResourceBlockBody, provisionerBlockBody = nullresource.CreateImportedWindowsNullResource(rootBody, terraformConfig, terratestConfig, windowsNodePublicDNS, addWindowsNode)
+	nullResourceBlockBody, provisionerBlockBody = nullresource.CreateImportedWindowsNullResource(rootBody, terraformConfig, terratestConfig, addWindowsNode)
 
 	version := terraformConfig.Standalone.RKE2Version
 	version += "+rke2r1"

--- a/framework/set/resources/imported/createRKE2K3SCluster.go
+++ b/framework/set/resources/imported/createRKE2K3SCluster.go
@@ -17,30 +17,31 @@ import (
 )
 
 const (
-	addServer      = "add_server"
-	addWindowsNode = "add_windows_node"
-	copyScript     = "_copy_script_"
-	createCluster  = "create_cluster"
-	serverOne      = "server1"
-	serverTwo      = "server2"
-	serverThree    = "server3"
-	windowsServer  = "windows_server"
-	token          = "token"
+	addServer     = "add_server"
+	addAgent      = "add_agent"
+	copyScript    = "_copy_script_"
+	createCluster = "create_cluster"
 )
 
 // CreateRKE2K3SImportedCluster is a helper function that will create the RKE2/K3S cluster to be imported into Rancher.
 func CreateRKE2K3SImportedCluster(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, terratestConfig *config.TerratestConfig,
-	serverOnePublicIP, serverOnePrivateIP, serverTwoPublicIP, serverThreePublicIP, token string) error {
-	var serverScriptPath, newServersScriptPath string
+	linuxNodeNames, serverNodeNames, agentNodeNames []string, nodePublicIPs, nodePrivateIPs map[string]string, token string) error {
+	if len(serverNodeNames) == 0 {
+		return nil
+	}
+
+	var serverScriptPath, addServersScriptPath, addAgentsScriptPath string
 
 	userDir, _ := rancher2.SetKeyPath(keypath.RancherKeyPath, terratestConfig.PathToRepo, terraformConfig.Provider)
 
 	if strings.Contains(terraformConfig.Module, clustertypes.K3S) && strings.Contains(terraformConfig.Module, general.Import) {
 		serverScriptPath = filepath.Join(userDir, terratestConfig.PathToRepo, "/framework/set/resources/k3s/init-server.sh")
-		newServersScriptPath = filepath.Join(userDir, terratestConfig.PathToRepo, "/framework/set/resources/k3s/add-servers.sh")
+		addServersScriptPath = filepath.Join(userDir, terratestConfig.PathToRepo, "/framework/set/resources/k3s/add-servers.sh")
+		addAgentsScriptPath = filepath.Join(userDir, terratestConfig.PathToRepo, "/framework/set/resources/k3s/add-agents.sh")
 	} else if strings.Contains(terraformConfig.Module, clustertypes.RKE2) && strings.Contains(terraformConfig.Module, general.Import) {
 		serverScriptPath = filepath.Join(userDir, terratestConfig.PathToRepo, "/framework/set/resources/rke2/init-server.sh")
-		newServersScriptPath = filepath.Join(userDir, terratestConfig.PathToRepo, "/framework/set/resources/rke2/add-servers.sh")
+		addServersScriptPath = filepath.Join(userDir, terratestConfig.PathToRepo, "/framework/set/resources/rke2/add-servers.sh")
+		addAgentsScriptPath = filepath.Join(userDir, terratestConfig.PathToRepo, "/framework/set/resources/rke2/add-agents.sh")
 	}
 
 	serverOneScriptContent, err := os.ReadFile(serverScriptPath)
@@ -48,22 +49,32 @@ func CreateRKE2K3SImportedCluster(rootBody *hclwrite.Body, terraformConfig *conf
 		return err
 	}
 
-	newServersScriptContent, err := os.ReadFile(newServersScriptPath)
+	newServersScriptContent, err := os.ReadFile(addServersScriptPath)
 	if err != nil {
 		return err
 	}
 
-	createImportedRKE2K3SServer(rootBody, terraformConfig, serverOnePublicIP, serverOnePrivateIP, token, serverOneScriptContent)
-	addImportedRKE2K3SServerNodes(rootBody, terraformConfig, serverOnePrivateIP, serverTwoPublicIP, serverThreePublicIP, token, newServersScriptContent)
+	agentsScriptContent, err := os.ReadFile(addAgentsScriptPath)
+	if err != nil {
+		return err
+	}
+
+	bootstrapNodeName := serverNodeNames[0]
+	serverOnePublicIP := nodePublicIPs[bootstrapNodeName]
+	serverOnePrivateIP := nodePrivateIPs[bootstrapNodeName]
+
+	createImportedRKE2K3SServer(rootBody, terraformConfig, linuxNodeNames, bootstrapNodeName, serverOnePublicIP, serverOnePrivateIP, token, serverOneScriptContent)
+	addImportedRKE2K3SServerNodes(rootBody, terraformConfig, linuxNodeNames, serverNodeNames[1:], serverOnePrivateIP, nodePublicIPs, token, newServersScriptContent)
+	addImportedRKE2K3SAgentNodes(rootBody, terraformConfig, linuxNodeNames, agentNodeNames, serverOnePrivateIP, nodePublicIPs, token, agentsScriptContent)
 
 	return nil
 }
 
 // createImportedRKE2K3SServer is a helper function that will create the server to be imported into Rancher.
-func createImportedRKE2K3SServer(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, serverOnePublicIP, serverOnePrivateIP,
-	token string, script []byte) {
-	copyScriptName := terraformConfig.ResourcePrefix + copyScript + serverOne
-	_, provisionerBlockBody := nullresource.CreateImportedNullResource(rootBody, terraformConfig, serverOnePublicIP, copyScriptName)
+func createImportedRKE2K3SServer(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, linuxNodeNames []string,
+	bootstrapNodeName, serverOnePublicIP, serverOnePrivateIP, token string, script []byte) {
+	copyScriptName := terraformConfig.ResourcePrefix + copyScript + bootstrapNodeName
+	_, provisionerBlockBody := nullresource.CreateImportedNullResource(rootBody, terraformConfig, serverOnePublicIP, copyScriptName, linuxNodeNames)
 
 	var version, command string
 
@@ -86,7 +97,7 @@ func createImportedRKE2K3SServer(rootBody *hclwrite.Body, terraformConfig *confi
 	}))
 
 	createClusterName := terraformConfig.ResourcePrefix + `_` + createCluster
-	nullResourceBlockBody, provisionerBlockBody := nullresource.CreateImportedNullResource(rootBody, terraformConfig, serverOnePublicIP, createClusterName)
+	nullResourceBlockBody, provisionerBlockBody := nullresource.CreateImportedNullResource(rootBody, terraformConfig, serverOnePublicIP, createClusterName, linuxNodeNames)
 
 	provisionerBlockBody.SetAttributeRaw(general.Inline, hclwrite.Tokens{
 		{Type: hclsyntax.TokenOQuote, Bytes: []byte(`["`), SpacesBefore: 1},
@@ -104,15 +115,14 @@ func createImportedRKE2K3SServer(rootBody *hclwrite.Body, terraformConfig *confi
 }
 
 // addImportedServerNodes is a helper function that will add additional server nodes to the initial server.
-func addImportedRKE2K3SServerNodes(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, serverOnePrivateIP, serverTwoPublicIP,
-	serverThreePublicIP, token string, script []byte) {
-	instances := []string{serverTwoPublicIP, serverThreePublicIP}
+func addImportedRKE2K3SServerNodes(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, linuxNodeNames, serverNodeNames []string,
+	serverOnePrivateIP string, nodePublicIPs map[string]string, token string, script []byte) {
 	createClusterName := terraformConfig.ResourcePrefix + `_` + createCluster
-	resourceNames := []string{serverTwo, serverThree}
 
-	for i, instance := range instances {
-		resourceName := terraformConfig.ResourcePrefix + `_` + resourceNames[i]
-		nullResourceBlockBody, provisionerBlockBody := nullresource.CreateImportedNullResource(rootBody, terraformConfig, instance, resourceName)
+	for _, nodeName := range serverNodeNames {
+		resourceName := nodeName
+		instance := nodePublicIPs[nodeName]
+		nullResourceBlockBody, provisionerBlockBody := nullresource.CreateImportedNullResource(rootBody, terraformConfig, instance, resourceName, linuxNodeNames)
 
 		var version, command string
 
@@ -140,7 +150,7 @@ func addImportedRKE2K3SServerNodes(rootBody *hclwrite.Body, terraformConfig *con
 
 		nullResourceBlockBody.SetAttributeRaw(general.DependsOn, server)
 
-		nullResourceBlockBody, provisionerBlockBody = nullresource.CreateImportedNullResource(rootBody, terraformConfig, instance, addServer+"_"+resourceName)
+		nullResourceBlockBody, provisionerBlockBody = nullresource.CreateImportedNullResource(rootBody, terraformConfig, instance, addServer+"_"+resourceName, linuxNodeNames)
 
 		provisionerBlockBody.SetAttributeRaw(general.Inline, hclwrite.Tokens{
 			{Type: hclsyntax.TokenOQuote, Bytes: []byte(`["`), SpacesBefore: 1},
@@ -148,7 +158,7 @@ func addImportedRKE2K3SServerNodes(rootBody *hclwrite.Body, terraformConfig *con
 			{Type: hclsyntax.TokenCQuote, Bytes: []byte(`"]`), SpacesBefore: 1},
 		})
 
-		importClusterName := terraformConfig.ResourcePrefix + `_` + resourceNames[i]
+		importClusterName := resourceName
 		dependsOnServer = `[` + general.NullResource + `.` + importClusterName + `]`
 
 		server = hclwrite.Tokens{
@@ -157,4 +167,60 @@ func addImportedRKE2K3SServerNodes(rootBody *hclwrite.Body, terraformConfig *con
 
 		nullResourceBlockBody.SetAttributeRaw(general.DependsOn, server)
 	}
+
+}
+
+func addImportedRKE2K3SAgentNodes(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, linuxNodeNames, agentNodeNames []string,
+	serverOnePrivateIP string, nodePublicIPs map[string]string, token string, script []byte) {
+	createClusterName := terraformConfig.ResourcePrefix + `_` + createCluster
+
+	for _, nodeName := range agentNodeNames {
+		resourceName := nodeName
+		instance := nodePublicIPs[nodeName]
+		nullResourceBlockBody, provisionerBlockBody := nullresource.CreateImportedNullResource(rootBody, terraformConfig, instance, resourceName, linuxNodeNames)
+
+		var version, command string
+
+		if strings.Contains(terraformConfig.Module, clustertypes.K3S) && strings.Contains(terraformConfig.Module, general.Import) {
+			version = terraformConfig.Standalone.K3SVersion
+
+			command = "bash -c '/tmp/add-agents.sh " + terraformConfig.Standalone.OSUser + " " + terraformConfig.Standalone.OSGroup + " " +
+				version + " " + serverOnePrivateIP + " " + instance + " " + token + "'"
+		} else if strings.Contains(terraformConfig.Module, clustertypes.RKE2) && strings.Contains(terraformConfig.Module, general.Import) {
+			version = terraformConfig.Standalone.RKE2Version
+
+			command = "bash -c '/tmp/add-agents.sh " + terraformConfig.Standalone.OSUser + " " + version + " " + serverOnePrivateIP + " " +
+				instance + " " + token + " " + terraformConfig.CNI + "'"
+		}
+
+		provisionerBlockBody.SetAttributeValue(general.Inline, cty.ListVal([]cty.Value{
+			cty.StringVal("echo '" + string(script) + "' > /tmp/add-agents.sh"),
+			cty.StringVal("chmod +x /tmp/add-agents.sh"),
+		}))
+
+		dependsOnServer := `[` + general.NullResource + `.` + createClusterName + `]`
+		server := hclwrite.Tokens{
+			{Type: hclsyntax.TokenIdent, Bytes: []byte(dependsOnServer)},
+		}
+
+		nullResourceBlockBody.SetAttributeRaw(general.DependsOn, server)
+
+		nullResourceBlockBody, provisionerBlockBody = nullresource.CreateImportedNullResource(rootBody, terraformConfig, instance, addAgent+"_"+resourceName, linuxNodeNames)
+
+		provisionerBlockBody.SetAttributeRaw(general.Inline, hclwrite.Tokens{
+			{Type: hclsyntax.TokenOQuote, Bytes: []byte(`["`), SpacesBefore: 1},
+			{Type: hclsyntax.TokenStringLit, Bytes: []byte(command)},
+			{Type: hclsyntax.TokenCQuote, Bytes: []byte(`"]`), SpacesBefore: 1},
+		})
+
+		importClusterName := resourceName
+		dependsOnServer = `[` + general.NullResource + `.` + importClusterName + `]`
+
+		server = hclwrite.Tokens{
+			{Type: hclsyntax.TokenIdent, Bytes: []byte(dependsOnServer)},
+		}
+
+		nullResourceBlockBody.SetAttributeRaw(general.DependsOn, server)
+	}
+
 }

--- a/framework/set/resources/k3s/add-agents.sh
+++ b/framework/set/resources/k3s/add-agents.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+USER=$1
+GROUP=$2
+K8S_VERSION=$3
+K3S_SERVER_IP=$4
+K3S_NEW_AGENT_IP=$5
+K3S_TOKEN=$6
+REGISTRY_USERNAME=$7
+REGISTRY_PASSWORD=$8
+
+set -e
+
+sudo hostnamectl set-hostname ${K3S_NEW_AGENT_IP}
+
+sudo mkdir -p /etc/rancher/k3s
+sudo touch /etc/rancher/k3s/registries.yaml
+
+echo "mirrors:
+  docker.io:
+    endpoint:
+      - \"https://registry-1.docker.io\"
+configs:
+  \"registry-1.docker.io\":
+    auth:
+      username: \"${REGISTRY_USERNAME}\"
+      password: \"${REGISTRY_PASSWORD}\"
+  \"docker.io\":
+    auth:
+      username: \"${REGISTRY_USERNAME}\"
+      password: \"${REGISTRY_PASSWORD}\"" | sudo tee -a /etc/rancher/k3s/registries.yaml > /dev/null
+
+curl -fsSL --max-time 30 -o install.sh https://get.k3s.io
+chmod +x install.sh
+sudo INSTALL_K3S_VERSION=${K8S_VERSION} K3S_TOKEN=${K3S_TOKEN} INSTALL_K3S_EXEC="agent --server https://${K3S_SERVER_IP}:6443" sh install.sh

--- a/framework/set/resources/k3s/add-servers.sh
+++ b/framework/set/resources/k3s/add-servers.sh
@@ -32,4 +32,4 @@ configs:
 
 curl -fsSL --max-time 30 -o install.sh https://get.k3s.io
 chmod +x install.sh
-sudo INSTALL_K3S_VERSION=${K8S_VERSION} K3S_TOKEN=${K3S_TOKEN} sh install.sh - server --server https://${K3S_SERVER_IP}:6443
+sudo INSTALL_K3S_VERSION=${K8S_VERSION} K3S_TOKEN=${K3S_TOKEN} INSTALL_K3S_EXEC="server --server https://${K3S_SERVER_IP}:6443" sh install.sh

--- a/framework/set/resources/k3s/init-server.sh
+++ b/framework/set/resources/k3s/init-server.sh
@@ -31,7 +31,7 @@ configs:
 
 curl -fsSL --max-time 30 -o install.sh https://get.k3s.io
 chmod +x install.sh
-sudo INSTALL_K3S_VERSION=${K8S_VERSION} K3S_TOKEN=${K3S_TOKEN} sh install.sh - server --cluster-init
+sudo INSTALL_K3S_VERSION=${K8S_VERSION} K3S_TOKEN=${K3S_TOKEN} INSTALL_K3S_EXEC="server --cluster-init" sh install.sh
 
 sudo mkdir -p /home/${USER}/.kube
 sudo chown ${USER}:${GROUP} /etc/rancher/k3s/k3s.yaml

--- a/framework/set/resources/providers/aws/windowsInstances.go
+++ b/framework/set/resources/providers/aws/windowsInstances.go
@@ -100,9 +100,17 @@ func CreateWindowsAWSInstances(rootBody *hclwrite.Body, terraformConfig *config.
 	configBlockBody.AppendNewline()
 
 	if terraformConfig.Module == modules.ImportedAWSRKE2Windows2019 || terraformConfig.Module == modules.ImportedAWSRKE2Windows2022 {
-		serverTwoName := terraformConfig.ResourcePrefix + `_server2`
-		serverThreeName := terraformConfig.ResourcePrefix + `_server3`
-		dependsOnServer := `[` + general.NullResource + `.` + serverTwoName + `, ` + general.NullResource + `.` + serverThreeName + `]`
+		nonWindowsNodeCount := customnodepools.TotalNodeCount(terratestConfig)
+		dependsOnResources := make([]string, 0, nonWindowsNodeCount)
+
+		for i := int64(2); i <= nonWindowsNodeCount; i++ {
+			dependsOnResources = append(dependsOnResources, fmt.Sprintf("%s.%s_server%d", general.NullResource, terraformConfig.ResourcePrefix, i))
+		}
+
+		dependsOnServer := "[]"
+		if len(dependsOnResources) > 0 {
+			dependsOnServer = `[` + strings.Join(dependsOnResources, ", ") + `]`
+		}
 
 		server := hclwrite.Tokens{
 			{Type: hclsyntax.TokenIdent, Bytes: []byte(dependsOnServer)},

--- a/framework/set/resources/rke2/add-agents.sh
+++ b/framework/set/resources/rke2/add-agents.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+USER=$1
+K8S_VERSION=$2
+RKE2_SERVER_ONE_IP=$3
+RKE2_NEW_AGENT_IP=$4
+RKE2_TOKEN=$5
+CNI=$6
+REGISTRY_USERNAME=$7
+REGISTRY_PASSWORD=$8
+
+set -e
+
+sudo hostnamectl set-hostname ${RKE2_NEW_AGENT_IP}
+
+ARCH=$(uname -m)
+if [[ $ARCH == "x86_64" ]]; then
+    ARCH="amd64"
+elif [[ $ARCH == "arm64" || $ARCH == "aarch64" ]]; then
+    ARCH="arm64"
+fi
+
+curl -fsSL --max-time 30 -o rke2.linux-${ARCH}.tar.gz https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2.linux-${ARCH}.tar.gz
+curl -fsSL --max-time 30 -o rke2-images.linux-${ARCH}.tar.zst https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2-images.linux-${ARCH}.tar.zst
+curl -fsSL --max-time 30 -o sha256sum-${ARCH}.txt https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/sha256sum-${ARCH}.txt
+
+echo "Validating checksum for rke2.linux-${ARCH}.tar.gz"
+ZIP_NAME="rke2.linux-${ARCH}.tar.gz"
+CHECKSUM_LINE=$(grep "${ZIP_NAME}" sha256sum-${ARCH}.txt)
+
+if [ -z "$CHECKSUM_LINE" ]; then
+  echo "ERROR: Checksum for $ZIP_NAME not found in sha256sum-${ARCH}.txt file!"
+  exit 1
+fi
+
+CHECKSUM=$(echo "$CHECKSUM_LINE" | awk "{print \$1}")
+echo "$CHECKSUM  rke2.linux-${ARCH}.tar.gz" | sha256sum -c -
+
+if [[ "${USER}" == "root" ]]; then
+  mkdir -p /home/root
+  mv rke2.linux-${ARCH}.tar.gz /home/root/
+  mv rke2-images.linux-${ARCH}.tar.zst /home/root/
+  mv sha256sum-${ARCH}.txt /home/root/
+fi
+
+sudo mkdir -p /etc/rancher/rke2
+sudo touch /etc/rancher/rke2/config.yaml
+
+echo "server: https://${RKE2_SERVER_ONE_IP}:9345
+cni: ${CNI}
+token: ${RKE2_TOKEN}" | sudo tee /etc/rancher/rke2/config.yaml > /dev/null
+
+echo "mirrors:
+  docker.io:
+    endpoint:
+      - \"https://registry-1.docker.io\"
+configs:
+  \"registry-1.docker.io\":
+    auth:
+      username: \"${REGISTRY_USERNAME}\"
+      password: \"${REGISTRY_PASSWORD}\"
+  \"docker.io\":
+    auth:
+      username: \"${REGISTRY_USERNAME}\"
+      password: \"${REGISTRY_PASSWORD}\"" | sudo tee -a /etc/rancher/rke2/registries.yaml > /dev/null
+
+curl -fsSL --max-time 30 -o install.sh https://get.rke2.io
+chmod +x install.sh
+
+sudo INSTALL_RKE2_ARTIFACT_PATH=/home/${USER} INSTALL_RKE2_TYPE=\"agent\" sh install.sh
+sudo systemctl enable rke2-agent
+sudo systemctl start rke2-agent


### PR DESCRIPTION
This PR updates the handling of imported clusters to utilize nodepools, ensuring that imported cluster configurations now reference and manage nodepools as part of their setup.