### PR TITLE
Remove unnecessary verify delete check for sanity upgrades

### DIFF
--- a/tests/infrastructure/ranchers/upgrade_rancher_resources.go
+++ b/tests/infrastructure/ranchers/upgrade_rancher_resources.go
@@ -53,8 +53,6 @@ func CleanupDownstreamClusters(t *testing.T, client *rancher.Client, terraformCo
 		logrus.Infof("Cleaning up cluster: %v", dsCluster.ID)
 		err = extClusters.DeleteK3SRKE2Cluster(client, dsCluster.ID)
 		require.NoError(t, err)
-
-		provisioningActions.VerifyDeleteRKE2K3SCluster(t, client, dsCluster.ID)
 	}
 }
 


### PR DESCRIPTION
This PR removes the redundant "verify delete" check performed during sanity upgrades, streamlining the upgrade process by eliminating unnecessary verification steps.