### PR TITLE
Remove Windows 2019 test cases as they're ported over to rancher/tests

### DIFF
--- a/tests/extensions/provisioning/supportedModules.go
+++ b/tests/extensions/provisioning/supportedModules.go
@@ -15,13 +15,12 @@ import (
 )
 
 // DownstreamClusterModules is a function that will return the correct module names based on the provider.
-func DownstreamClusterModules(terraformConfig *config.TerraformConfig) (string, string, string, string) {
-	var rke2Module, rke2Windows2019, rke2Windows2022, k3sModule string
+func DownstreamClusterModules(terraformConfig *config.TerraformConfig) (string, string, string) {
+	var rke2Module, rke2Windows, k3sModule string
 	switch terraformConfig.DownstreamClusterProvider {
 	case aws.Aws:
 		rke2Module = modules.NodeDriverAWSRKE2
-		rke2Windows2019 = modules.CustomAWSRKE2Windows2019
-		rke2Windows2022 = modules.CustomAWSRKE2Windows2022
+		rke2Windows = modules.CustomAWSRKE2Windows2022
 		k3sModule = modules.NodeDriverAWSK3S
 	case azure.Azure:
 		rke2Module = modules.NodeDriverAzureRKE2
@@ -42,17 +41,16 @@ func DownstreamClusterModules(terraformConfig *config.TerraformConfig) (string, 
 		panic("Unsupported provider: " + terraformConfig.DownstreamClusterProvider)
 	}
 
-	return rke2Module, rke2Windows2019, rke2Windows2022, k3sModule
+	return rke2Module, rke2Windows, k3sModule
 }
 
 // ImportedClusterModules is a function that will return the correct module names based on the provider.
-func ImportedClusterModules(terraformConfig *config.TerraformConfig) (string, string, string, string) {
-	var rke2Module, rke2Windows2019, rke2Windows2022, k3sModule string
+func ImportedClusterModules(terraformConfig *config.TerraformConfig) (string, string, string) {
+	var rke2Module, rke2Windows, k3sModule string
 	switch terraformConfig.DownstreamClusterProvider {
 	case aws.Aws:
 		rke2Module = modules.ImportedAWSRKE2
-		rke2Windows2019 = modules.ImportedAWSRKE2Windows2019
-		rke2Windows2022 = modules.ImportedAWSRKE2Windows2022
+		rke2Windows = modules.ImportedAWSRKE2Windows2022
 		k3sModule = modules.ImportedAWSK3S
 	case vsphere.Vsphere:
 		rke2Module = modules.ImportedVsphereRKE2
@@ -61,7 +59,7 @@ func ImportedClusterModules(terraformConfig *config.TerraformConfig) (string, st
 		panic("Unsupported provider: " + terraformConfig.DownstreamClusterProvider)
 	}
 
-	return rke2Module, rke2Windows2019, rke2Windows2022, k3sModule
+	return rke2Module, rke2Windows, k3sModule
 }
 
 func IsImportedModule(module string) bool {

--- a/tests/infrastructure/downstream/custom/create_custom.go
+++ b/tests/infrastructure/downstream/custom/create_custom.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/rancher/shepherd/clients/rancher"
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	provisioningActions "github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/framework"
 	"github.com/rancher/tfp-automation/framework/set/resources/rancher2"
@@ -17,7 +18,7 @@ import (
 
 // CreateCustomCluster is a function that will create a custom cluster using the provided terraform configuration and return the cluster object and the terraform options used to create the cluster.
 func CreateCustomCluster(t *testing.T, client *rancher.Client, rancherConfig *rancher.Config, terraformConfig *config.TerraformConfig,
-	terratestConfig *config.TerratestConfig, clusterType, dataDir string) (string, *terraform.Options, string, *v1.SteveAPIObject) {
+	terratestConfig *config.TerratestConfig, clusterType, dataDir string, isWindows bool) (string, *terraform.Options, string, *v1.SteveAPIObject) {
 	terraformConfig = provisioning.UniquifyTerraform(terraformConfig)
 	terraformConfig.Module = fmt.Sprintf("%s_%s_custom", terraformConfig.DownstreamClusterProvider, clusterType)
 
@@ -36,9 +37,18 @@ func CreateCustomCluster(t *testing.T, client *rancher.Client, rancherConfig *ra
 	terratestConfig, err = provisioning.GetK8sVersion(adminClient, terraformConfig, terratestConfig)
 	require.NoError(t, err)
 
-	clusters, _ := provisioning.Provision(t, adminClient, client, rancherConfig, terraformConfig, terratestConfig, "", "", perTestTerraformOptions,
+	clusters, customClusterName := provisioning.Provision(t, adminClient, client, rancherConfig, terraformConfig, terratestConfig, "", "", perTestTerraformOptions,
 		newFile, rootBody, file, false, false, true, "", nestedRancherModuleDir)
 	require.NotEmpty(t, clusters)
+
+	if isWindows {
+		err = provisioningActions.VerifyClusterReady(adminClient, clusters[0])
+		require.NoError(t, err)
+
+		clusters, _ = provisioning.Provision(t, adminClient, client, rancherConfig, terraformConfig, terratestConfig, "", "", perTestTerraformOptions,
+			newFile, rootBody, file, isWindows, true, true, customClusterName, nestedRancherModuleDir)
+		require.NotEmpty(t, clusters)
+	}
 
 	return nestedRancherModuleDir, perTestTerraformOptions, keyPath, clusters[0]
 }

--- a/tests/kdm/kdm_test.go
+++ b/tests/kdm/kdm_test.go
@@ -121,6 +121,7 @@ func (k *KDMTestSuite) TestKDM() {
 
 			newFile, rootBody, file := rancher2.InitializeNestedMainTFs(nestedRancherModuleDir)
 			defer file.Close()
+
 			terratest, err = provisioning.GetK8sVersion(k.standardUserClient, terraform, terratest)
 			require.NoError(k.T(), err)
 

--- a/tests/rancher2/provisioning/dynamic_provision_custom_test.go
+++ b/tests/rancher2/provisioning/dynamic_provision_custom_test.go
@@ -101,6 +101,7 @@ func (p *DynamicProvisionCustomTestSuite) TestTfpProvisionCustomDynamicInput() {
 
 			newFile, rootBody, file := rancher2.InitializeNestedMainTFs(nestedRancherModuleDir)
 			defer file.Close()
+
 			terratest, err = provisioning.GetK8sVersion(p.client, terraform, terratest)
 			require.NoError(p.T(), err)
 

--- a/tests/rancher2/provisioning/dynamic_provision_import_test.go
+++ b/tests/rancher2/provisioning/dynamic_provision_import_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/rancher/tfp-automation/defaults/keypath"
 	"github.com/rancher/tfp-automation/framework"
 	"github.com/rancher/tfp-automation/framework/cleanup"
-	"github.com/rancher/tfp-automation/framework/set/provisioning/imported"
 	"github.com/rancher/tfp-automation/framework/set/resources/rancher2"
 	tfpQase "github.com/rancher/tfp-automation/pipeline/qase"
 	"github.com/rancher/tfp-automation/pipeline/qase/results"
@@ -121,9 +120,6 @@ func (p *DynamicImportedClusterTestSuite) TestTfpImportedClusterDynamicInput() {
 
 			logrus.Infof("Verifying cluster pods (%s)", clusters[0].Name)
 			err = pods.VerifyClusterPods(p.client, clusters[0])
-			require.NoError(p.T(), err)
-
-			err = imported.SetUpgradeImportedCluster(p.client, terraform)
 			require.NoError(p.T(), err)
 
 			params := tfpQase.GetProvisioningSchemaParams(p.terraformConfig, p.terratestConfig)

--- a/tests/rancher2/provisioning/dynamic_provision_test.go
+++ b/tests/rancher2/provisioning/dynamic_provision_test.go
@@ -99,6 +99,7 @@ func (p *DynamicTfpProvisionTestSuite) TestTfpProvisionDynamicInput() {
 
 			newFile, rootBody, file := rancher2.InitializeNestedMainTFs(nestedRancherModuleDir)
 			defer file.Close()
+
 			terratest, err = provisioning.GetK8sVersion(p.client, terraform, terratest)
 			require.NoError(p.T(), err)
 

--- a/tests/rancher2/provisioning/provision_ace_test.go
+++ b/tests/rancher2/provisioning/provision_ace_test.go
@@ -81,7 +81,7 @@ func (p *ProvisionACETestSuite) TestTfpProvisionACE() {
 	standardToken := standardUserToken.Token
 
 	nodeRolesDedicated := []config.Nodepool{config.EtcdNodePool, config.ControlPlaneNodePool, config.WorkerNodePool}
-	rke2Module, _, _, k3sModule := provisioning.DownstreamClusterModules(p.terraformConfig)
+	rke2Module, _, k3sModule := provisioning.DownstreamClusterModules(p.terraformConfig)
 
 	localAuthEndpoint := config.TerraformConfig{
 		LocalAuthEndpoint: true,
@@ -113,6 +113,7 @@ func (p *ProvisionACETestSuite) TestTfpProvisionACE() {
 
 			newFile, rootBody, file := rancher2.InitializeNestedMainTFs(nestedRancherModuleDir)
 			defer file.Close()
+
 			terratest, err = provisioning.GetK8sVersion(p.client, terraform, terratest)
 			require.NoError(p.T(), err)
 

--- a/tests/rancher2/provisioning/provision_custom_test.go
+++ b/tests/rancher2/provisioning/provision_custom_test.go
@@ -88,8 +88,7 @@ func (p *ProvisionCustomTestSuite) TestTfpProvisionCustom() {
 		module string
 	}{
 		{"Custom_TFP_RKE2", modules.CustomAWSRKE2},
-		{"Custom_TFP_RKE2_Windows_2019", modules.CustomAWSRKE2Windows2019},
-		{"Custom_TFP_RKE2_Windows_2022", modules.CustomAWSRKE2Windows2022},
+		{"Custom_TFP_RKE2_Windows", modules.CustomAWSRKE2Windows2022},
 		{"Custom_TFP_K3S", modules.CustomAWSK3S},
 	}
 

--- a/tests/rancher2/provisioning/provision_data_directory_test.go
+++ b/tests/rancher2/provisioning/provision_data_directory_test.go
@@ -81,7 +81,7 @@ func (p *ProvisionDataDirectoryTestSuite) TestTfpProvisionDataDirectory() {
 	standardToken := standardUserToken.Token
 
 	nodeRolesDedicated := []config.Nodepool{config.EtcdNodePool, config.ControlPlaneNodePool, config.WorkerNodePool}
-	rke2Module, _, _, k3sModule := provisioning.DownstreamClusterModules(p.terraformConfig)
+	rke2Module, _, k3sModule := provisioning.DownstreamClusterModules(p.terraformConfig)
 
 	dataDirectories := config.TerraformConfig{
 		DataDirectories: &config.DataDirectories{
@@ -117,6 +117,7 @@ func (p *ProvisionDataDirectoryTestSuite) TestTfpProvisionDataDirectory() {
 
 			newFile, rootBody, file := rancher2.InitializeNestedMainTFs(nestedRancherModuleDir)
 			defer file.Close()
+
 			terratest, err = provisioning.GetK8sVersion(p.client, terraform, terratest)
 			require.NoError(p.T(), err)
 

--- a/tests/rancher2/provisioning/provision_import_test.go
+++ b/tests/rancher2/provisioning/provision_import_test.go
@@ -82,15 +82,14 @@ func (p *ImportedClusterTestSuite) TestTfpImportedCluster() {
 
 	standardToken := standardUserToken.Token
 
-	rke2Module, rke2Windows2019, rke2Windows2022, k3sModule := provisioning.ImportedClusterModules(p.terraformConfig)
+	rke2Module, rke2Windows, k3sModule := provisioning.ImportedClusterModules(p.terraformConfig)
 
 	tests := []struct {
 		name   string
 		module string
 	}{
 		{"Imported_RKE2", rke2Module},
-		{"Imported_RKE2_Windows_2019", rke2Windows2019},
-		{"Imported_RKE2_Windows_2022", rke2Windows2022},
+		{"Imported_RKE2_Windows", rke2Windows},
 		{"Imported_K3S", k3sModule},
 	}
 

--- a/tests/rancher2/provisioning/schemas/schemas.yaml
+++ b/tests/rancher2/provisioning/schemas/schemas.yaml
@@ -51,39 +51,14 @@
     customfield:
       "14": Validation
       "18": Hostbusters
-  - description: Provisions downstream RKE2 Windows 2019 custom cluster
-    title: Custom_TFP_RKE2_Windows_2019
+  - description: Provisions downstream RKE2 Windows custom cluster
+    title: Custom_TFP_RKE2_Windows
     priority: 4
     type: 8
     automation: 2
     attachments: []
     steps:
-    - action: Provision downstream RKE2 Windows 2019 custom cluster
-      expectedresult: ""
-      data: ""
-      position: 1
-      attachments: []
-      steps: []
-    - action: Post cluster creation checks
-      expectedresult: ""
-      data: ""
-      position: 2
-      attachments: []
-      steps: []
-    tags: []
-    params: {}
-    parameters: []
-    customfield:
-      "14": Validation
-      "18": Hostbusters
-  - description: Provisions downstream RKE2 Windows 2022 custom cluster
-    title: Custom_TFP_RKE2_Windows_2022
-    priority: 4
-    type: 8
-    automation: 2
-    attachments: []
-    steps:
-    - action: Provision downstream RKE2 Windows 2022 custom cluster
+    - action: Provision downstream RKE2 Windows custom cluster
       expectedresult: ""
       data: ""
       position: 1
@@ -147,31 +122,8 @@
     customfield:
       "14": Validation
       "18": Hostbusters
-  - description: Import RKE2 Windows 2019 cluster
-    title: Imported_RKE2_Windows_2019
-    priority: 4
-    type: 8
-    automation: 2
-    attachments: []
-    steps:
-    - action: Import RKE2 Windows 2019 cluster
-      expectedresult: ""
-      data: ""
-      position: 1
-      attachments: []
-      steps: []
-    - action: Post imported cluster checks
-      expectedresult: ""
-      data: ""
-      position: 2
-      attachments: []
-      steps: []
-    tags: []
-    customfield:
-      "14": Validation
-      "18": Hostbusters
-  - description: Import RKE2 Windows 2022 cluster
-    title: Imported_RKE2_Windows_2022
+  - description: Import RKE2 Windows cluster
+    title: Imported_RKE2_Windows
     priority: 4
     type: 8
     automation: 2

--- a/tests/rancher2/psact/psact_test.go
+++ b/tests/rancher2/psact/psact_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/rancher/shepherd/clients/rancher"
 	shepherdConfig "github.com/rancher/shepherd/pkg/config"
-        configDefaults "github.com/rancher/tests/actions/config/defaults"
 	"github.com/rancher/shepherd/pkg/session"
 	clusterActions "github.com/rancher/tests/actions/clusters"
+	configDefaults "github.com/rancher/tests/actions/config/defaults"
 	provisioningActions "github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads/pods"
@@ -45,12 +45,12 @@ type PSACTTestSuite struct {
 }
 
 func (p *PSACTTestSuite) SetupSuite() {
-        var err error
+	var err error
 
-        p.cattleConfig = shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
+	p.cattleConfig = shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
 
-        p.cattleConfig, err = configDefaults.LoadPackageDefaults(p.cattleConfig, "")
-        require.NoError(p.T(), err)
+	p.cattleConfig, err = configDefaults.LoadPackageDefaults(p.cattleConfig, "")
+	require.NoError(p.T(), err)
 
 	p.rancherConfig, p.terraformConfig, p.terratestConfig, _ = config.LoadTFPConfigs(p.cattleConfig)
 
@@ -113,6 +113,7 @@ func (p *PSACTTestSuite) TestTfpPSACT() {
 
 			newFile, rootBody, file := rancher2.InitializeNestedMainTFs(nestedRancherModuleDir)
 			defer file.Close()
+
 			terratest, err = provisioning.GetK8sVersion(p.client, terraform, terratest)
 			require.NoError(t, err)
 

--- a/tests/rancher2/rbac/rbac_test.go
+++ b/tests/rancher2/rbac/rbac_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/rancher/shepherd/clients/rancher"
 	shepherdConfig "github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/session"
-	configDefaults "github.com/rancher/tests/actions/config/defaults"
 	clusterActions "github.com/rancher/tests/actions/clusters"
+	configDefaults "github.com/rancher/tests/actions/config/defaults"
 	provisioningActions "github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads/pods"
@@ -109,6 +109,7 @@ func (r *RBACTestSuite) TestTfpRBAC() {
 
 			newFile, rootBody, file := rancher2.InitializeNestedMainTFs(nestedRancherModuleDir)
 			defer file.Close()
+
 			terratest, err = provisioning.GetK8sVersion(r.client, terraform, terratest)
 			require.NoError(r.T(), err)
 

--- a/tests/rancher2/snapshot/snapshot_restore_test.go
+++ b/tests/rancher2/snapshot/snapshot_restore_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/rancher/shepherd/clients/rancher"
 	shepherdConfig "github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/session"
-	configDefaults "github.com/rancher/tests/actions/config/defaults"
 	clusterActions "github.com/rancher/tests/actions/clusters"
+	configDefaults "github.com/rancher/tests/actions/config/defaults"
 	provisioningActions "github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads/pods"
@@ -115,6 +115,7 @@ func (s *SnapshotRestoreTestSuite) TestTfpSnapshotRestore() {
 
 			newFile, rootBody, file := rancher2.InitializeNestedMainTFs(nestedRancherModuleDir)
 			defer file.Close()
+
 			terratest, err = provisioning.GetK8sVersion(s.client, terraform, terratest)
 			require.NoError(s.T(), err)
 

--- a/tests/sanity/sanity_provisioning_test.go
+++ b/tests/sanity/sanity_provisioning_test.go
@@ -71,7 +71,7 @@ func (s *TfpSanityProvisioningTestSuite) TestTfpProvisioningSanity() {
 
 	nodeRolesDedicated := []config.Nodepool{config.EtcdNodePool, config.ControlPlaneNodePool, config.WorkerNodePool}
 	nodeRolesWindows := []config.Nodepool{config.EtcdNodePool, config.ControlPlaneNodePool, config.WorkerNodePool, config.WindowsNodePool}
-	rke2Module, rke2Windows2019, rke2Windows2022, k3sModule := provisioning.DownstreamClusterModules(s.terraformConfig)
+	rke2Module, rke2Windows, k3sModule := provisioning.DownstreamClusterModules(s.terraformConfig)
 
 	tests := []struct {
 		name      string
@@ -79,8 +79,7 @@ func (s *TfpSanityProvisioningTestSuite) TestTfpProvisioningSanity() {
 		module    string
 	}{
 		{"Sanity_RKE2", nodeRolesDedicated, rke2Module},
-		{"Sanity_RKE2_Windows_2019", nodeRolesWindows, rke2Windows2019},
-		{"Sanity_RKE2_Windows_2022", nodeRolesWindows, rke2Windows2022},
+		{"Sanity_RKE2_Windows", nodeRolesWindows, rke2Windows},
 		{"Sanity_K3S", nodeRolesDedicated, k3sModule},
 	}
 
@@ -169,7 +168,7 @@ func (s *TfpSanityProvisioningTestSuite) TestTfpProvisioningSanityImported() {
 
 	standardToken := standardUserToken.Token
 
-	rke2ImportedModule, _, _, k3sImportedModule := provisioning.ImportedClusterModules(s.terraformConfig)
+	rke2ImportedModule, _, k3sImportedModule := provisioning.ImportedClusterModules(s.terraformConfig)
 
 	tests := []struct {
 		name   string

--- a/tests/sanity/sanity_upgrade_dual_stack_rancher_test.go
+++ b/tests/sanity/sanity_upgrade_dual_stack_rancher_test.go
@@ -86,7 +86,7 @@ func (s *TfpSanityDualStackUpgradeRancherTestSuite) provisionAndVerifyCluster(na
 	var nestedRancherModuleDir string
 
 	nodeRolesDedicated := []config.Nodepool{config.EtcdNodePool, config.ControlPlaneNodePool, config.WorkerNodePool}
-	rke2Module, _, _, k3sModule := provisioning.DownstreamClusterModules(s.terraformConfig)
+	rke2Module, _, k3sModule := provisioning.DownstreamClusterModules(s.terraformConfig)
 
 	tests := []struct {
 		name      string

--- a/tests/sanity/sanity_upgrade_ipv6_rancher_test.go
+++ b/tests/sanity/sanity_upgrade_ipv6_rancher_test.go
@@ -86,7 +86,7 @@ func (s *TfpSanityIPv6UpgradeRancherTestSuite) provisionAndVerifyCluster(name st
 	var nestedRancherModuleDir string
 
 	nodeRolesDedicated := []config.Nodepool{config.EtcdNodePool, config.ControlPlaneNodePool, config.WorkerNodePool}
-	rke2Module, _, _, k3sModule := provisioning.DownstreamClusterModules(s.terraformConfig)
+	rke2Module, _, k3sModule := provisioning.DownstreamClusterModules(s.terraformConfig)
 
 	tests := []struct {
 		name      string

--- a/tests/sanity/sanity_upgrade_rancher_test.go
+++ b/tests/sanity/sanity_upgrade_rancher_test.go
@@ -90,15 +90,14 @@ func (s *TfpSanityUpgradeRancherTestSuite) provisionAndVerifyCluster(name string
 	var nestedRancherModuleDir string
 	nodeRolesDedicated := []config.Nodepool{config.EtcdNodePool, config.ControlPlaneNodePool, config.WorkerNodePool}
 	nodeRolesWindows := []config.Nodepool{config.EtcdNodePool, config.ControlPlaneNodePool, config.WorkerNodePool, config.WindowsNodePool}
-	rke2Module, rke2Windows2019, rke2Windows2022, k3sModule := provisioning.DownstreamClusterModules(s.terraformConfig)
+	rke2Module, rke2Windows, k3sModule := provisioning.DownstreamClusterModules(s.terraformConfig)
 	tests := []struct {
 		name      string
 		nodeRoles []config.Nodepool
 		module    string
 	}{
 		{name + "_RKE2", nodeRolesDedicated, rke2Module},
-		{name + "_RKE2_Windows_2019", nodeRolesWindows, rke2Windows2019},
-		{name + "_RKE2_Windows_2022", nodeRolesWindows, rke2Windows2022},
+		{name + "_RKE2_Windows", nodeRolesWindows, rke2Windows},
 		{name + "_K3S", nodeRolesDedicated, k3sModule},
 	}
 

--- a/tests/sanity/schemas/schemas.yaml
+++ b/tests/sanity/schemas/schemas.yaml
@@ -24,35 +24,14 @@
       "14": Validation
       "18": Hostbusters
 
-  - description: Provisions downstream RKE2 Windows 2019 custom cluster
-    title: Sanity_RKE2_Windows_2019
+  - description: Provisions downstream RKE2 Windows custom cluster
+    title: Sanity_RKE2_Windows
     priority: 4
     type: 8
     is_flaky: 0
     automation: 2
     steps:
-    - action: Provision downstream RKE2 Windows 2019 custom cluster
-      expectedresult: ""
-      data: ""
-      position: 1
-      attachments: []
-    - action: Post cluster creation checks
-      expectedresult: ""
-      data: ""
-      position: 2
-      attachments: []
-    custom_field:
-      "14": Validation
-      "18": Hostbusters
-
-  - description: Provisions downstream RKE2 Windows 2022 custom cluster
-    title: Sanity_RKE2_Windows_2022
-    priority: 4
-    type: 8
-    is_flaky: 0
-    automation: 2
-    steps:
-    - action: Provision downstream RKE2 Windows 2022 custom cluster
+    - action: Provision downstream RKE2 Windows custom cluster
       expectedresult: ""
       data: ""
       position: 1
@@ -150,35 +129,14 @@
       "14": Validation
       "18": Hostbusters
 
-  - description: Provisions downstream RKE2 Windows 2019 custom cluster prior to Rancher upgrade
-    title: Sanity_Pre_Rancher_Upgrade_RKE2_Windows_2019
+  - description: Provisions downstream RKE2 Windows custom cluster prior to Rancher upgrade
+    title: Sanity_Pre_Rancher_Upgrade_RKE2_Windows
     priority: 4
     type: 8
     is_flaky: 0
     automation: 2
     steps:
-    - action: Provision downstream RKE2 Windows 2019 custom cluster
-      expectedresult: ""
-      data: ""
-      position: 1
-      attachments: []
-    - action: Post cluster creation checks
-      expectedresult: ""
-      data: ""
-      position: 2
-      attachments: []
-    custom_field:
-      "14": Validation
-      "18": Hostbusters
-
-  - description: Provisions downstream RKE2 Windows 2022 custom cluster prior to Rancher upgrade
-    title: Sanity_Pre_Rancher_Upgrade_RKE2_Windows_2022
-    priority: 4
-    type: 8
-    is_flaky: 0
-    automation: 2
-    steps:
-    - action: Provision downstream RKE2 Windows 2022 custom cluster
+    - action: Provision downstream RKE2 Windows custom cluster
       expectedresult: ""
       data: ""
       position: 1
@@ -234,35 +192,14 @@
       "14": Validation
       "18": Hostbusters
 
-  - description: Provisions downstream RKE2 Windows 2019 custom cluster post Rancher upgrade
-    title: Sanity_Post_Rancher_Upgrade_RKE2_Windows_2019
+  - description: Provisions downstream RKE2 Windows custom cluster post Rancher upgrade
+    title: Sanity_Post_Rancher_Upgrade_RKE2_Windows
     priority: 4
     type: 8
     is_flaky: 0
     automation: 2
     steps:
-    - action: Provision downstream RKE2 Windows 2019 custom cluster
-      expectedresult: ""
-      data: ""
-      position: 1
-      attachments: []
-    - action: Post cluster creation checks
-      expectedresult: ""
-      data: ""
-      position: 2
-      attachments: []
-    custom_field:
-      "14": Validation
-      "18": Hostbusters
-
-  - description: Provisions downstream RKE2 Windows 2022 custom cluster post Rancher upgrade
-    title: Sanity_Post_Rancher_Upgrade_RKE2_Windows_2022
-    priority: 4
-    type: 8
-    is_flaky: 0
-    automation: 2
-    steps:
-    - action: Provision downstream RKE2 Windows 2022 custom cluster
+    - action: Provision downstream RKE2 Windows custom cluster
       expectedresult: ""
       data: ""
       position: 1


### PR DESCRIPTION
This PR removes the Windows 2019 test cases from the repository, as they have been successfully ported over to the rancher/tests suite. This helps prevent duplication and ensures that tests are maintained in their new location.