### PR TITLE
Remove unused parameter call in DownstreamClusterModules for rancher2 tests

### DIFF
--- a/tests/rancher2/psact/psact_test.go
+++ b/tests/rancher2/psact/psact_test.go
@@ -81,7 +81,7 @@ func (p *PSACTTestSuite) TestTfpPSACT() {
 	standardToken := standardUserToken.Token
 
 	nodeRolesDedicated := []config.Nodepool{config.EtcdNodePool, config.ControlPlaneNodePool, config.WorkerNodePool}
-	rke2Module, _, _, k3sModule := provisioning.DownstreamClusterModules(p.terraformConfig)
+	rke2Module, _, k3sModule := provisioning.DownstreamClusterModules(p.terraformConfig)
 
 	tests := []struct {
 		name      string

--- a/tests/rancher2/rbac/rbac_test.go
+++ b/tests/rancher2/rbac/rbac_test.go
@@ -81,7 +81,7 @@ func (r *RBACTestSuite) TestTfpRBAC() {
 	standardToken := standardUserToken.Token
 
 	nodeRolesDedicated := []config.Nodepool{config.EtcdNodePool, config.ControlPlaneNodePool, config.WorkerNodePool}
-	rke2Module, _, _, k3sModule := provisioning.DownstreamClusterModules(r.terraformConfig)
+	rke2Module, _, k3sModule := provisioning.DownstreamClusterModules(r.terraformConfig)
 
 	tests := []struct {
 		name     string

--- a/tests/rancher2/snapshot/snapshot_restore_test.go
+++ b/tests/rancher2/snapshot/snapshot_restore_test.go
@@ -81,7 +81,7 @@ func (s *SnapshotRestoreTestSuite) TestTfpSnapshotRestore() {
 	standardToken := standardUserToken.Token
 
 	nodeRolesDedicated := []config.Nodepool{config.EtcdNodePool, config.ControlPlaneNodePool, config.WorkerNodePool}
-	rke2Module, _, _, k3sModule := provisioning.DownstreamClusterModules(s.terraformConfig)
+	rke2Module, _, k3sModule := provisioning.DownstreamClusterModules(s.terraformConfig)
 
 	snapshotRestoreNone := config.TerratestConfig{
 		SnapshotInput: config.Snapshots{


### PR DESCRIPTION
This PR removes an unused parameter call in the DownstreamClusterModules module, specifically within the rancher2 test suite. This cleanup improves code clarity by eliminating unnecessary code.