### PR TITLE
Add support for authenticated registries to be set as the system default registry

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -161,20 +161,21 @@ type Standalone struct {
 }
 
 type StandaloneRegistry struct {
-	AssetsPath          string `json:"assetsPath,omitempty" yaml:"assetsPath,omitempty"`
-	Authenticated       bool   `json:"authenticated,omitempty" yaml:"authenticated,omitempty"`
-	AuthRegistryFQDN    string `json:"authRegistryFQDN,omitempty" yaml:"authRegistryFQDN,omitempty"`
-	ECRFQDN             string `json:"ecrFQDN,omitempty" yaml:"ecrFQDN,omitempty"`
-	ECRURI              string `json:"ecrURI,omitempty" yaml:"ecrURI,omitempty"`
-	ECRUsername         string `json:"ecrUsername,omitempty" yaml:"ecrUsername,omitempty"`
-	ECRPassword         string `json:"ecrPassword,omitempty" yaml:"ecrPassword,omitempty"`
-	Enabled             bool   `json:"enabled,omitempty" yaml:"enabled,omitempty" default:"false"`
-	GlobalRegistryFQDN  string `json:"globalRegistryFQDN,omitempty" yaml:"globalRegistryFQDN,omitempty"`
-	NonAuthRegistryFQDN string `json:"nonAuthRegistryFQDN,omitempty" yaml:"nonAuthRegistryFQDN,omitempty"`
-	RegistryName        string `json:"registryName,omitempty" yaml:"registryName,omitempty"`
-	RegistryPassword    string `json:"registryPassword,omitempty" yaml:"registryPassword,omitempty"`
-	RegistryUsername    string `json:"registryUsername,omitempty" yaml:"registryUsername,omitempty"`
-	UpgradedAssetsPath  string `json:"upgradedAssetsPath,omitempty" yaml:"upgradedAssetsPath,omitempty"`
+	AssetsPath            string `json:"assetsPath,omitempty" yaml:"assetsPath,omitempty"`
+	Authenticated         bool   `json:"authenticated,omitempty" yaml:"authenticated,omitempty"`
+	AuthRegistryFQDN      string `json:"authRegistryFQDN,omitempty" yaml:"authRegistryFQDN,omitempty"`
+	ECRFQDN               string `json:"ecrFQDN,omitempty" yaml:"ecrFQDN,omitempty"`
+	ECRURI                string `json:"ecrURI,omitempty" yaml:"ecrURI,omitempty"`
+	ECRUsername           string `json:"ecrUsername,omitempty" yaml:"ecrUsername,omitempty"`
+	ECRPassword           string `json:"ecrPassword,omitempty" yaml:"ecrPassword,omitempty"`
+	Enabled               bool   `json:"enabled,omitempty" yaml:"enabled,omitempty" default:"false"`
+	GlobalRegistryFQDN    string `json:"globalRegistryFQDN,omitempty" yaml:"globalRegistryFQDN,omitempty"`
+	NonAuthRegistryFQDN   string `json:"nonAuthRegistryFQDN,omitempty" yaml:"nonAuthRegistryFQDN,omitempty"`
+	NonAuthGlobalRegistry bool   `json:"nonAuthGlobalRegistry,omitempty" yaml:"nonAuthGlobalRegistry,omitempty" default:"true"`
+	RegistryName          string `json:"registryName,omitempty" yaml:"registryName,omitempty"`
+	RegistryPassword      string `json:"registryPassword,omitempty" yaml:"registryPassword,omitempty"`
+	RegistryUsername      string `json:"registryUsername,omitempty" yaml:"registryUsername,omitempty"`
+	UpgradedAssetsPath    string `json:"upgradedAssetsPath,omitempty" yaml:"upgradedAssetsPath,omitempty"`
 }
 
 type TerraformConfig struct {
@@ -214,6 +215,8 @@ type TerraformConfig struct {
 	Module                              string                       `json:"module,omitempty" yaml:"module,omitempty"`
 	NetworkPlugin                       string                       `json:"networkPlugin,omitempty" yaml:"networkPlugin,omitempty"`
 	PartnerRC                           bool                         `json:"partnerRC,omitempty" yaml:"partnerRC,omitempty" default:"false"`
+	PrivateFullChainPath                string                       `json:"privateFullChainPath,omitempty" yaml:"privateFullChainPath,omitempty"`
+	PrivateCertKeyPath                  string                       `json:"privateCertKeyPath,omitempty" yaml:"privateCertKeyPath,omitempty"`
 	PrivateKeyPath                      string                       `json:"privateKeyPath,omitempty" yaml:"privateKeyPath,omitempty"`
 	PrivateRegistries                   *PrivateRegistries           `json:"privateRegistries,omitempty" yaml:"privateRegistries,omitempty"`
 	Proxy                               *Proxy                       `json:"proxy,omitempty" yaml:"proxy,omitempty"`

--- a/framework/set/resources/providers/aws/createResources.go
+++ b/framework/set/resources/providers/aws/createResources.go
@@ -35,23 +35,28 @@ func CreateAWSResources(file *os.File, newFile *hclwrite.File, tfBlockBody, root
 	if terraformConfig.Standalone.RancherHostname != "" && terraformConfig.Provider != providers.EKS {
 		ports := []int64{80, 443, 6443, 9345}
 		for _, port := range ports {
-			CreateTargetGroupAttachments(rootBody, terraformConfig, aws.LoadBalancerTargetGroupAttachment, getTargetGroupAttachment(port, false), port)
+			CreateTargetGroupAttachments(rootBody, terraformConfig, aws.LoadBalancerTargetGroupAttachment, getTargetGroupAttachment(port, false), port, false)
 			rootBody.AppendNewline()
 		}
 
-		CreateLoadBalancer(rootBody, terraformConfig)
+		CreateLoadBalancer(rootBody, terraformConfig, false)
 		rootBody.AppendNewline()
 
 		for _, port := range ports {
-			CreateTargetGroups(rootBody, terraformConfig, port)
+			CreateTargetGroups(rootBody, terraformConfig, port, false)
 			rootBody.AppendNewline()
 
-			CreateLoadBalancerListeners(rootBody, port)
+			CreateLoadBalancerListeners(rootBody, terraformConfig, port, false)
 			rootBody.AppendNewline()
 		}
 
-		CreateRoute53Record(rootBody, terraformConfig)
+		CreateRoute53Record(rootBody, terraformConfig, false)
 		rootBody.AppendNewline()
+	}
+
+	// Create a second pair of networking so that the authenticated global registry can reference it for certificates later.
+	if terraformConfig.StandaloneRegistry != nil && !terraformConfig.StandaloneRegistry.NonAuthGlobalRegistry {
+		globalRegistryResources(rootBody, terraformConfig)
 	}
 
 	var err error
@@ -157,22 +162,22 @@ func CreateIPv6AWSResources(file *os.File, newFile *hclwrite.File, tfBlockBody, 
 	if terraformConfig.Standalone.CertManagerVersion != "" {
 		ports := []int64{80, 443, 6443, 9345}
 		for _, port := range ports {
-			CreateTargetGroupAttachments(rootBody, terraformConfig, aws.LoadBalancerTargetGroupAttachment, getTargetGroupAttachment(port, false), port)
+			CreateTargetGroupAttachments(rootBody, terraformConfig, aws.LoadBalancerTargetGroupAttachment, getTargetGroupAttachment(port, false), port, false)
 			rootBody.AppendNewline()
 		}
 
-		CreateLoadBalancer(rootBody, terraformConfig)
+		CreateLoadBalancer(rootBody, terraformConfig, false)
 		rootBody.AppendNewline()
 
 		for _, port := range ports {
-			CreateTargetGroups(rootBody, terraformConfig, port)
+			CreateTargetGroups(rootBody, terraformConfig, port, false)
 			rootBody.AppendNewline()
 
-			CreateLoadBalancerListeners(rootBody, port)
+			CreateLoadBalancerListeners(rootBody, terraformConfig, port, false)
 			rootBody.AppendNewline()
 		}
 
-		CreateRoute53Record(rootBody, terraformConfig)
+		CreateRoute53Record(rootBody, terraformConfig, false)
 		rootBody.AppendNewline()
 	}
 
@@ -211,4 +216,28 @@ func getTargetGroupAttachment(port int64, internal bool) string {
 	default:
 		return ""
 	}
+}
+
+func globalRegistryResources(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig) {
+	terraformConfig.ResourcePrefix = "global-" + terraformConfig.ResourcePrefix
+
+	ports := []int64{80, 443, 6443, 9345}
+	for _, port := range ports {
+		CreateTargetGroupAttachments(rootBody, terraformConfig, aws.LoadBalancerTargetGroupAttachment, getTargetGroupAttachment(port, false), port, true)
+		rootBody.AppendNewline()
+	}
+
+	CreateLoadBalancer(rootBody, terraformConfig, true)
+	rootBody.AppendNewline()
+
+	for _, port := range ports {
+		CreateTargetGroups(rootBody, terraformConfig, port, true)
+		rootBody.AppendNewline()
+
+		CreateLoadBalancerListeners(rootBody, terraformConfig, port, true)
+		rootBody.AppendNewline()
+	}
+
+	CreateRoute53Record(rootBody, terraformConfig, true)
+	rootBody.AppendNewline()
 }

--- a/framework/set/resources/providers/aws/listeners.go
+++ b/framework/set/resources/providers/aws/listeners.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/framework/set/defaults/general"
 	"github.com/rancher/tfp-automation/framework/set/defaults/providers/aws"
 	"github.com/zclconf/go-cty/cty"
@@ -17,11 +18,22 @@ const (
 )
 
 // CreateLoadBalancerListeners is a function that will set the load balancer listeners configurations in the main.tf file.
-func CreateLoadBalancerListeners(rootBody *hclwrite.Body, port int64) {
-	listenersGroupBlock := rootBody.AppendNewBlock(general.Resource, []string{aws.LoadBalancerListener, aws.LoadBalancerListener + "_" + strconv.FormatInt(port, 10)})
-	listenersGroupBlockBody := listenersGroupBlock.Body()
+func CreateLoadBalancerListeners(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, port int64, authGlobalRegistry bool) {
+	var listenersGroupBlockBody *hclwrite.Body
+	var loadBalancerExpression string
 
-	loadBalancerExpression := aws.LoadBalancer + "." + aws.LoadBalancer + ".arn"
+	if authGlobalRegistry {
+		listenersGroupBlock := rootBody.AppendNewBlock(general.Resource, []string{aws.LoadBalancerListener, terraformConfig.ResourcePrefix + "_" + strconv.FormatInt(port, 10)})
+		listenersGroupBlockBody = listenersGroupBlock.Body()
+
+		loadBalancerExpression = aws.LoadBalancer + "." + terraformConfig.ResourcePrefix + ".arn"
+	} else {
+		listenersGroupBlock := rootBody.AppendNewBlock(general.Resource, []string{aws.LoadBalancerListener, aws.LoadBalancerListener + "_" + strconv.FormatInt(port, 10)})
+		listenersGroupBlockBody = listenersGroupBlock.Body()
+
+		loadBalancerExpression = aws.LoadBalancer + "." + aws.LoadBalancer + ".arn"
+	}
+
 	values := hclwrite.Tokens{
 		{Type: hclsyntax.TokenIdent, Bytes: []byte(loadBalancerExpression)},
 	}
@@ -35,7 +47,12 @@ func CreateLoadBalancerListeners(rootBody *hclwrite.Body, port int64) {
 
 	defaultActionBlockBody.SetAttributeValue(general.Type, cty.StringVal(forward))
 
-	targetGroupExpression := aws.LoadBalancerTargetGroup + "." + aws.TargetGroupPrefix + strconv.FormatInt(port, 10) + ".arn"
+	var targetGroupExpression string
+	if authGlobalRegistry {
+		targetGroupExpression = aws.LoadBalancerTargetGroup + "." + terraformConfig.ResourcePrefix + "-" + aws.TargetGroupPrefix + strconv.FormatInt(port, 10) + ".arn"
+	} else {
+		targetGroupExpression = aws.LoadBalancerTargetGroup + "." + aws.TargetGroupPrefix + strconv.FormatInt(port, 10) + ".arn"
+	}
 	values = hclwrite.Tokens{
 		{Type: hclsyntax.TokenIdent, Bytes: []byte(targetGroupExpression)},
 	}

--- a/framework/set/resources/providers/aws/loadbalancer.go
+++ b/framework/set/resources/providers/aws/loadbalancer.go
@@ -18,9 +18,16 @@ const (
 )
 
 // CreateLoadBalancer is a function that will set the load balancer configurations in the main.tf file.
-func CreateLoadBalancer(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig) {
-	loadBalancerBlock := rootBody.AppendNewBlock(general.Resource, []string{aws.LoadBalancer, aws.LoadBalancer})
-	loadBalancerBlockBody := loadBalancerBlock.Body()
+func CreateLoadBalancer(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, authGlobalRegistry bool) {
+	var loadBalancerBlockBody *hclwrite.Body
+
+	if authGlobalRegistry {
+		loadBalancerBlock := rootBody.AppendNewBlock(general.Resource, []string{aws.LoadBalancer, terraformConfig.ResourcePrefix})
+		loadBalancerBlockBody = loadBalancerBlock.Body()
+	} else {
+		loadBalancerBlock := rootBody.AppendNewBlock(general.Resource, []string{aws.LoadBalancer, aws.LoadBalancer})
+		loadBalancerBlockBody = loadBalancerBlock.Body()
+	}
 
 	loadBalancerBlockBody.SetAttributeValue(internal, cty.BoolVal(false))
 	loadBalancerBlockBody.SetAttributeValue(aws.LoadBalancerType, cty.StringVal(network))

--- a/framework/set/resources/providers/aws/route53.go
+++ b/framework/set/resources/providers/aws/route53.go
@@ -20,11 +20,22 @@ const (
 )
 
 // CreateRoute53Record is a function that will set the AWS Route 53 record configuration in the main.tf file.
-func CreateRoute53Record(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig) {
-	routeRecordBlock := rootBody.AppendNewBlock(general.Resource, []string{aws.Route53Record, aws.Route53Record})
-	routeRecordBlockBody := routeRecordBlock.Body()
+func CreateRoute53Record(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, authGlobalRegistry bool) {
+	var routeRecordBlockBody *hclwrite.Body
+	var zoneIDExpression string
 
-	zoneIDExpression := general.Data + "." + aws.Route53Zone + "." + selected + "." + zoneID
+	if authGlobalRegistry {
+		routeRecordBlock := rootBody.AppendNewBlock(general.Resource, []string{aws.Route53Record, terraformConfig.ResourcePrefix})
+		routeRecordBlockBody = routeRecordBlock.Body()
+
+		zoneIDExpression = general.Data + "." + aws.Route53Zone + "." + terraformConfig.ResourcePrefix + "." + zoneID
+	} else {
+		routeRecordBlock := rootBody.AppendNewBlock(general.Resource, []string{aws.Route53Record, aws.Route53Record})
+		routeRecordBlockBody = routeRecordBlock.Body()
+
+		zoneIDExpression = general.Data + "." + aws.Route53Zone + "." + selected + "." + zoneID
+	}
+
 	values := hclwrite.Tokens{
 		{Type: hclsyntax.TokenIdent, Bytes: []byte(zoneIDExpression)},
 	}
@@ -34,7 +45,13 @@ func CreateRoute53Record(rootBody *hclwrite.Body, terraformConfig *config.Terraf
 	routeRecordBlockBody.SetAttributeValue(general.Type, cty.StringVal(CNAME))
 	routeRecordBlockBody.SetAttributeValue(ttl, cty.NumberIntVal(300))
 
-	loadBalancerExpression := "[" + aws.LoadBalancer + "." + aws.LoadBalancer + "." + dnsName + "]"
+	var loadBalancerExpression string
+
+	if authGlobalRegistry {
+		loadBalancerExpression = "[" + aws.LoadBalancer + "." + terraformConfig.ResourcePrefix + "." + dnsName + "]"
+	} else {
+		loadBalancerExpression = "[" + aws.LoadBalancer + "." + aws.LoadBalancer + "." + dnsName + "]"
+	}
 	values = hclwrite.Tokens{
 		{Type: hclsyntax.TokenIdent, Bytes: []byte(loadBalancerExpression)},
 	}
@@ -43,8 +60,15 @@ func CreateRoute53Record(rootBody *hclwrite.Body, terraformConfig *config.Terraf
 
 	rootBody.AppendNewline()
 
-	zoneBlock := rootBody.AppendNewBlock(general.Data, []string{aws.Route53Zone, selected})
-	zoneBlockBody := zoneBlock.Body()
+	var zoneBlock *hclwrite.Block
+	var zoneBlockBody *hclwrite.Body
+	if authGlobalRegistry {
+		zoneBlock = rootBody.AppendNewBlock(general.Data, []string{aws.Route53Zone, terraformConfig.ResourcePrefix})
+		zoneBlockBody = zoneBlock.Body()
+	} else {
+		zoneBlock = rootBody.AppendNewBlock(general.Data, []string{aws.Route53Zone, selected})
+		zoneBlockBody = zoneBlock.Body()
+	}
 
 	zoneBlockBody.SetAttributeValue(name, cty.StringVal(terraformConfig.AWSConfig.AWSRoute53Zone))
 	zoneBlockBody.SetAttributeValue(privateZone, cty.BoolVal(false))

--- a/framework/set/resources/providers/aws/targetGroupAttachments.go
+++ b/framework/set/resources/providers/aws/targetGroupAttachments.go
@@ -19,9 +19,16 @@ const (
 
 // CreateTargetGroupAttachments is a function that will set the target group attachments configurations in the main.tf file.
 func CreateTargetGroupAttachments(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, lbTargetGroupAttachment,
-	targetGroupAttachmentServer string, port int64) {
-	targetGroupBlock := rootBody.AppendNewBlock(general.Resource, []string{lbTargetGroupAttachment, targetGroupAttachmentServer})
-	targetGroupBlockBody := targetGroupBlock.Body()
+	targetGroupAttachmentServer string, port int64, authGlobalRegistry bool) {
+	var targetGroupBlockBody *hclwrite.Body
+
+	if authGlobalRegistry {
+		targetGroupBlock := rootBody.AppendNewBlock(general.Resource, []string{lbTargetGroupAttachment, terraformConfig.ResourcePrefix + "-" + targetGroupAttachmentServer})
+		targetGroupBlockBody = targetGroupBlock.Body()
+	} else {
+		targetGroupBlock := rootBody.AppendNewBlock(general.Resource, []string{lbTargetGroupAttachment, targetGroupAttachmentServer})
+		targetGroupBlockBody = targetGroupBlock.Body()
+	}
 
 	instanceValueExpression := general.Local + "." + instanceIDs
 	values := hclwrite.Tokens{
@@ -30,15 +37,31 @@ func CreateTargetGroupAttachments(rootBody *hclwrite.Body, terraformConfig *conf
 
 	targetGroupBlockBody.SetAttributeRaw(forEach, values)
 
-	targetGroupExpression := aws.LoadBalancerTargetGroup + "." + aws.TargetGroupPrefix + fmt.Sprint(port) + ".arn"
-	values = hclwrite.Tokens{
-		{Type: hclsyntax.TokenIdent, Bytes: []byte(targetGroupExpression)},
+	var targetGroupExpression string
+
+	if authGlobalRegistry {
+		targetGroupExpression = aws.LoadBalancerTargetGroup + "." + terraformConfig.ResourcePrefix + "-" + aws.TargetGroupPrefix + fmt.Sprint(port) + ".arn"
+		values = hclwrite.Tokens{
+			{Type: hclsyntax.TokenIdent, Bytes: []byte(targetGroupExpression)},
+		}
+	} else {
+		targetGroupExpression = aws.LoadBalancerTargetGroup + "." + aws.TargetGroupPrefix + fmt.Sprint(port) + ".arn"
+		values = hclwrite.Tokens{
+			{Type: hclsyntax.TokenIdent, Bytes: []byte(targetGroupExpression)},
+		}
 	}
 
 	targetGroupBlockBody.SetAttributeRaw(aws.TargetGroupARN, values)
 
-	values = hclwrite.Tokens{
-		{Type: hclsyntax.TokenIdent, Bytes: []byte(eachValue)},
+	if authGlobalRegistry {
+		globalRegistryExpression := aws.AwsInstance + `.global_registry.id`
+		values = hclwrite.Tokens{
+			{Type: hclsyntax.TokenIdent, Bytes: []byte(globalRegistryExpression)},
+		}
+	} else {
+		values = hclwrite.Tokens{
+			{Type: hclsyntax.TokenIdent, Bytes: []byte(eachValue)},
+		}
 	}
 
 	targetGroupBlockBody.SetAttributeRaw(aws.TargetID, values)

--- a/framework/set/resources/providers/aws/targetGroups.go
+++ b/framework/set/resources/providers/aws/targetGroups.go
@@ -25,9 +25,16 @@ const (
 )
 
 // CreateTargetGroups is a function that will set the target group configurations in the main.tf file.
-func CreateTargetGroups(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, port int64) {
-	targetGroupBlock := rootBody.AppendNewBlock(general.Resource, []string{aws.LoadBalancerTargetGroup, aws.TargetGroupPrefix + strconv.FormatInt(port, 10)})
-	targetGroupBlockBody := targetGroupBlock.Body()
+func CreateTargetGroups(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, port int64, authGlobalRegistry bool) {
+	var targetGroupBlockBody *hclwrite.Body
+
+	if authGlobalRegistry {
+		targetGroupBlock := rootBody.AppendNewBlock(general.Resource, []string{aws.LoadBalancerTargetGroup, terraformConfig.ResourcePrefix + "-" + aws.TargetGroupPrefix + strconv.FormatInt(port, 10)})
+		targetGroupBlockBody = targetGroupBlock.Body()
+	} else {
+		targetGroupBlock := rootBody.AppendNewBlock(general.Resource, []string{aws.LoadBalancerTargetGroup, aws.TargetGroupPrefix + strconv.FormatInt(port, 10)})
+		targetGroupBlockBody = targetGroupBlock.Body()
+	}
 
 	targetGroupBlockBody.SetAttributeValue(general.Port, cty.NumberIntVal(port))
 	targetGroupBlockBody.SetAttributeValue(protocol, cty.StringVal(TCP))

--- a/framework/set/resources/registries/createMainTF.go
+++ b/framework/set/resources/registries/createMainTF.go
@@ -23,6 +23,8 @@ const (
 	globalRegistryPublicDNS  = "global_registry_public_dns"
 	ecrRegistryPublicDNS     = "ecr_registry_public_dns"
 
+	globalRegistryRoute53FQDN = "global_registry_route_53_fqdn"
+
 	authRegistry    = "auth_registry"
 	nonAuthRegistry = "non_auth_registry"
 	globalRegistry  = "global_registry"
@@ -70,6 +72,7 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 	authRegistryPublicDNS := terraform.Output(t, terraformOptions, authRegistryPublicDNS)
 	nonAuthRegistryPublicDNS := terraform.Output(t, terraformOptions, nonAuthRegistryPublicDNS)
 	globalRegistryPublicDNS := terraform.Output(t, terraformOptions, globalRegistryPublicDNS)
+	globalRegistryRoute53FQDN := terraform.Output(t, terraformOptions, globalRegistryRoute53FQDN)
 	ecrRegistryPublicDNS := terraform.Output(t, terraformOptions, ecrRegistryPublicDNS)
 	serverOnePublicDNS := terraform.Output(t, terraformOptions, serverOnePublicDNS)
 	serverOnePrivateIP := terraform.Output(t, terraformOptions, serverOnePrivateIP)
@@ -92,9 +95,16 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 
 	file = sanity.OpenFile(file, keyPath)
 	logrus.Infof("Creating global registry...")
-	file, err = registry.CreateNonAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, globalRegistryPublicDNS, globalRegistry)
-	if err != nil {
-		logrus.Fatalf("Error creating global registry: %v", err)
+	if terraformConfig.StandaloneRegistry.NonAuthGlobalRegistry {
+		file, err = registry.CreateNonAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, globalRegistryPublicDNS, globalRegistry)
+		if err != nil {
+			logrus.Fatalf("Error creating global registry: %v", err)
+		}
+	} else {
+		file, err = registry.CreateAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, globalRegistryPublicDNS, globalRegistryRoute53FQDN)
+		if err != nil {
+			logrus.Fatalf("Error creating global registry: %v", err)
+		}
 	}
 
 	_, err = terraform.InitAndApplyE(t, terraformOptions)
@@ -106,7 +116,7 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 
 	file = sanity.OpenFile(file, keyPath)
 	logrus.Infof("Creating authenticated registry...")
-	file, err = registry.CreateAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, authRegistryPublicDNS)
+	file, err = registry.CreateAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, authRegistryPublicDNS, globalRegistryRoute53FQDN)
 	if err != nil {
 		logrus.Fatalf("Error creating authenticated registry: %v", err)
 	}
@@ -130,6 +140,12 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 		logrus.Infof("Error while creating registries. Cleaning up...")
 		cleanup.Cleanup(t, terraformOptions, keyPath)
 		return "", "", "", err
+	}
+
+	// Needed so that when building the local cluster and setting up Rancher, we use the correct registry images based on
+	// whether the global registry is authenticated or not.
+	if !terraformConfig.StandaloneRegistry.NonAuthGlobalRegistry {
+		globalRegistryPublicDNS = globalRegistryRoute53FQDN
 	}
 
 	file = sanity.OpenFile(file, keyPath)

--- a/framework/set/resources/registries/createRegistry/auth-registry.sh
+++ b/framework/set/resources/registries/createRegistry/auth-registry.sh
@@ -1,21 +1,44 @@
 #!/usr/bin/bash
 
-REGISTRY_NAME=$1
-REGISTRY_USER=$2
-REGISTRY_PASS=$3
-DOCKERHUB_USER=$4
-DOCKERHUB_PASS=$5
-HOST=$6
-RANCHER_VERSION=$7
-ASSET_DIR=$8
-USER=$9
-RANCHER_IMAGE=${10}
-RANCHER_AGENT_IMAGE=${11}
+CERT_MANAGER_VERSION=$1
+REGISTRY_NAME=$2
+REGISTRY_USER=$3
+REGISTRY_PASS=$4
+DOCKERHUB_USER=$5
+DOCKERHUB_PASS=$6
+HOST=$7
+RANCHER_VERSION=$8
+ASSET_DIR=$9
+USER=${10}
+RANCHER_IMAGE=${11}
+FULL_CHAIN_FILE=${12}
+CERT_KEY_FILE=${13}
+ROUTE53_FQDN=${14}
+RANCHER_AGENT_IMAGE=${15}
 
 set -e
 
+if [ ! -d "/home/$USER/certs" ]; then
+    echo "Decoding certificate files..."
+    base64 -d <<< "$FULL_CHAIN_FILE" > /home/$USER/fullchain.pem
+    base64 -d <<< "$CERT_KEY_FILE" > /home/$USER/privkey.pem
+
+    chmod 600 /home/$USER/fullchain.pem
+    chmod 600 /home/$USER/privkey.pem
+else
+    echo "Certificate files already exist. Skipping decoding..."
+fi
+
+FULL_CHAIN_PATH=/home/$USER/fullchain.pem
+CERT_KEY_PATH=/home/$USER/privkey.pem
+
+REGISTRY_ENDPOINT="${HOST}"
+if [ -n "${ROUTE53_FQDN}" ]; then
+    REGISTRY_ENDPOINT="${ROUTE53_FQDN}"
+fi
+
 docker_login() {
-    echo "Logging into private registry ${HOST}..."
+    echo "Logging into Docker Hub..."
     sudo docker login https://registry-1.docker.io -u "${DOCKERHUB_USER}" -p "${DOCKERHUB_PASS}"
 }
 
@@ -26,17 +49,15 @@ create_registry() {
         sudo mkdir -p /home/${USER}/auth
         sudo htpasswd -Bbn ${REGISTRY_USER} ${REGISTRY_PASS} | sudo tee /home/${USER}/auth/htpasswd
 
-        echo "Creating a self-signed certificate..."
         sudo mkdir -p /home/${USER}/certs
-        sudo openssl req -newkey rsa:4096 -nodes -sha256 \
-            -keyout /home/${USER}/certs/domain.key \
-            -addext "subjectAltName = DNS:${HOST}" \
-            -x509 -days 365 -out /home/${USER}/certs/domain.crt \
-            -subj "/C=US/ST=CA/L=SUSE/O=Dis/CN=${HOST}"
+        sudo mv $FULL_CHAIN_PATH /home/${USER}/certs/domain.crt
+        sudo mv $CERT_KEY_PATH /home/${USER}/certs/domain.key
+        sudo chmod 644 /home/${USER}/certs/domain.crt
+        sudo chmod 600 /home/${USER}/certs/domain.key
 
-        echo "Copying the certificate to the /etc/docker/certs.d/${HOST} directory..."
-        sudo mkdir -p /etc/docker/certs.d/${HOST}
-        sudo cp /home/${USER}/certs/domain.crt /etc/docker/certs.d/${HOST}/ca.crt
+        echo "Copying the certificate to the /etc/docker/certs.d/${REGISTRY_ENDPOINT} directory..."
+        sudo mkdir -p /etc/docker/certs.d/${REGISTRY_ENDPOINT}
+        sudo cp /home/${USER}/certs/domain.crt /etc/docker/certs.d/${REGISTRY_ENDPOINT}/ca.crt
 
         echo "Creating a private registry..."
         sudo docker run -d --restart=always --name "${REGISTRY_NAME}" \
@@ -51,8 +72,8 @@ create_registry() {
             -p 443:443 registry:2
     fi
 
-    echo "Logging into private registry ${HOST}..."
-    sudo docker login -u ${REGISTRY_USER} -p ${REGISTRY_PASS} https://${HOST}
+    echo "Logging into private registry ${REGISTRY_ENDPOINT}..."
+    sudo docker login -u ${REGISTRY_USER} -p ${REGISTRY_PASS} https://${REGISTRY_ENDPOINT}
 }
 
 fetch_images() {
@@ -86,6 +107,22 @@ fetch_images() {
     fi
 }
 
+cert_manager_images() {
+    echo "Adding cert-manager images to the list..."
+    CERT_MANAGER_IMAGES=(
+        "quay.io/jetstack/cert-manager-controller:${CERT_MANAGER_VERSION}"
+        "quay.io/jetstack/cert-manager-webhook:${CERT_MANAGER_VERSION}"
+        "quay.io/jetstack/cert-manager-cainjector:${CERT_MANAGER_VERSION}"
+        "quay.io/jetstack/cert-manager-startupapicheck:${CERT_MANAGER_VERSION}"
+    )
+
+    for IMAGE in "${CERT_MANAGER_IMAGES[@]}"; do
+        sudo docker pull ${IMAGE}
+        sudo docker tag ${IMAGE} ${REGISTRY_ENDPOINT}/${IMAGE}
+        sudo docker push ${REGISTRY_ENDPOINT}/${IMAGE}
+    done
+}
+
 manage_images() {
     ACTION=$1
     mapfile -t IMAGES < /home/${USER}/rancher-images.txt
@@ -109,9 +146,9 @@ action() {
     IMAGE=$2
     
     if [ "$ACTION" == "pull" ]; then
-        sudo docker pull ${IMAGE} && sudo docker tag ${IMAGE} ${HOST}/${IMAGE} &
+        sudo docker pull ${IMAGE} && sudo docker tag ${IMAGE} ${REGISTRY_ENDPOINT}/${IMAGE} &
     elif [ "$ACTION" == "push" ]; then
-        sudo docker push ${HOST}/${IMAGE} &
+        sudo docker push ${REGISTRY_ENDPOINT}/${IMAGE} &
     fi
 }
 
@@ -124,7 +161,7 @@ verify_images() {
 
     for IMAGE in "${IMAGES[@]}"; do
         {
-            TARGET_IMAGE=${HOST}/${IMAGE}
+            TARGET_IMAGE=${REGISTRY_ENDPOINT}/${IMAGE}
             if sudo docker manifest inspect ${TARGET_IMAGE} >/dev/null 2>&1; then
                 echo "${IMAGE} exists"
             else
@@ -149,6 +186,7 @@ verify_images() {
 docker_login
 create_registry
 fetch_images
+cert_manager_images
 manage_images "pull"
 manage_images "push"
 verify_images

--- a/framework/set/resources/registries/createRegistry/createRegistry.go
+++ b/framework/set/resources/registries/createRegistry/createRegistry.go
@@ -1,6 +1,7 @@
 package createRegistry
 
 import (
+	"encoding/base64"
 	"os"
 	"path/filepath"
 
@@ -16,13 +17,14 @@ import (
 
 const (
 	authRegistry    = "auth_registry"
+	globalRegistry  = "global_registry"
 	nonAuthRegistry = "non_auth_registry"
 	ecrRegistry     = "ecr_registry"
 )
 
 // CreateAuthenticatedRegistry is a helper function that will create an authenticated registry.
 func CreateAuthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
-	terratestConfig *config.TerratestConfig, rke2AuthRegistryPublicDNS string) (*os.File, error) {
+	terratestConfig *config.TerratestConfig, rke2AuthRegistryPublicDNS, rke2AuthRegistryRoute53FQDN string) (*os.File, error) {
 	userDir, _ := rancher2.SetKeyPath(keypath.RegistryKeyPath, terratestConfig.PathToRepo, terraformConfig.Provider)
 
 	scriptPath := filepath.Join(userDir, terratestConfig.PathToRepo, "/framework/set/resources/registries/createRegistry/auth-registry.sh")
@@ -32,18 +34,37 @@ func CreateAuthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootBody
 		return nil, err
 	}
 
+	privateFullChain, err := os.ReadFile(terraformConfig.PrivateFullChainPath)
+	if err != nil {
+		return nil, err
+	}
+
+	privateCertKey, err := os.ReadFile(terraformConfig.PrivateCertKeyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	encodedFullChain := base64.StdEncoding.EncodeToString((privateFullChain))
+	encodedCertKey := base64.StdEncoding.EncodeToString((privateCertKey))
+
 	_, provisionerBlockBody := rke2.SSHNullResource(rootBody, terraformConfig, rke2AuthRegistryPublicDNS, authRegistry)
 
-	command := "bash -c '/tmp/auth-registry.sh " + terraformConfig.StandaloneRegistry.RegistryName + " " + terraformConfig.StandaloneRegistry.RegistryUsername + " " +
+	command := "/tmp/auth-registry.sh " + terraformConfig.Standalone.CertManagerVersion + " " + terraformConfig.StandaloneRegistry.RegistryName + " " + terraformConfig.StandaloneRegistry.RegistryUsername + " " +
 		terraformConfig.StandaloneRegistry.RegistryPassword + " " + terraformConfig.Standalone.RegistryUsername + " " + terraformConfig.Standalone.RegistryPassword + " " +
-		rke2AuthRegistryPublicDNS + " " + terraformConfig.Standalone.RancherTagVersion + " " + terraformConfig.StandaloneRegistry.AssetsPath + " " + terraformConfig.Standalone.OSUser + " " +
-		terraformConfig.Standalone.RancherImage
+		rke2AuthRegistryPublicDNS + " " + terraformConfig.Standalone.RancherTagVersion + " " + terraformConfig.StandaloneRegistry.AssetsPath + " " +
+		terraformConfig.Standalone.OSUser + " " + terraformConfig.Standalone.RancherImage + " " + encodedFullChain + " " + encodedCertKey
+
+	if !terraformConfig.StandaloneRegistry.NonAuthGlobalRegistry {
+		command += " " + rke2AuthRegistryRoute53FQDN
+	} else {
+		command += " \"\""
+	}
 
 	if terraformConfig.Standalone.RancherAgentImage != "" {
 		command += " " + terraformConfig.Standalone.RancherAgentImage
+	} else {
+		command += " \"\""
 	}
-
-	command += "'"
 
 	provisionerBlockBody.SetAttributeValue(general.Inline, cty.ListVal([]cty.Value{
 		cty.StringVal("echo '" + string(registryScriptContent) + "' > /tmp/auth-registry.sh"),
@@ -77,13 +98,15 @@ func CreateNonAuthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootB
 	var command string
 
 	if terraformConfig.Standalone.UpgradeAirgapRancher {
-		command = "bash -c '/tmp/non-auth-registry.sh " + terraformConfig.StandaloneRegistry.RegistryName + " " + terraformConfig.Standalone.CertManagerVersion + " " +
+		command = "/tmp/non-auth-registry.sh " + terraformConfig.StandaloneRegistry.RegistryName + " " + terraformConfig.Standalone.CertManagerVersion + " " +
 			terraformConfig.Standalone.RegistryUsername + " " + terraformConfig.Standalone.RegistryPassword + " " + rke2NonAuthRegistryPublicDNS + " " +
 			terraformConfig.Standalone.UpgradedRancherTagVersion + " " + terraformConfig.StandaloneRegistry.UpgradedAssetsPath + " " +
 			terraformConfig.Standalone.OSUser + " " + terraformConfig.Standalone.UpgradedRancherImage
 
-		if terraformConfig.Standalone.UpgradedRancherAgentImage != "" {
-			command += " " + terraformConfig.Standalone.UpgradedRancherAgentImage
+		if terraformConfig.Standalone.RancherAgentImage != "" {
+			command += " " + terraformConfig.Standalone.RancherAgentImage
+		} else {
+			command += " \"\""
 		}
 	} else {
 		command = "bash -c '/tmp/non-auth-registry.sh " + terraformConfig.StandaloneRegistry.RegistryName + " " + terraformConfig.Standalone.CertManagerVersion + " " +
@@ -93,10 +116,10 @@ func CreateNonAuthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootB
 
 		if terraformConfig.Standalone.RancherAgentImage != "" {
 			command += " " + terraformConfig.Standalone.RancherAgentImage
+		} else {
+			command += " \"\""
 		}
 	}
-
-	command += "'"
 
 	provisionerBlockBody.SetAttributeValue(general.Inline, cty.ListVal([]cty.Value{
 		cty.StringVal("echo '" + string(registryScriptContent) + "' > /tmp/non-auth-registry.sh"),
@@ -127,16 +150,16 @@ func CreateECRRegistry(file *os.File, newFile *hclwrite.File, rootBody *hclwrite
 
 	_, provisionerBlockBody := rke2.SSHNullResource(rootBody, terraformConfig, rke2EcrRegistryPublicDNS, ecrRegistry)
 
-	command := "bash -c '/tmp/ecr-registry.sh " + terraformConfig.StandaloneRegistry.ECRURI + " " + terraformConfig.Standalone.RegistryUsername + " " +
+	command := "/tmp/ecr-registry.sh " + terraformConfig.StandaloneRegistry.ECRURI + " " + terraformConfig.Standalone.RegistryUsername + " " +
 		terraformConfig.Standalone.RegistryPassword + " " + terraformConfig.Standalone.RancherTagVersion + " " + terraformConfig.Standalone.RancherImage + " " +
 		terraformConfig.Standalone.OSUser + " " + terraformConfig.StandaloneRegistry.AssetsPath + " " + terraformConfig.AWSCredentials.AWSAccessKey + " " +
 		terraformConfig.AWSCredentials.AWSSecretKey + " " + terraformConfig.AWSConfig.Region
 
 	if terraformConfig.Standalone.RancherAgentImage != "" {
 		command += " " + terraformConfig.Standalone.RancherAgentImage
+	} else {
+		command += " \"\""
 	}
-
-	command += "'"
 
 	provisionerBlockBody.SetAttributeValue(general.Inline, cty.ListVal([]cty.Value{
 		cty.StringVal("echo '" + string(registryScriptContent) + "' > /tmp/ecr-registry.sh"),

--- a/framework/set/resources/registries/rancher/createRancher.go
+++ b/framework/set/resources/registries/rancher/createRancher.go
@@ -38,8 +38,17 @@ func CreateRancher(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Bod
 		terraformConfig.Standalone.RancherTagVersion + " " + terraformConfig.Standalone.ChartVersion + " " +
 		terraformConfig.Standalone.BootstrapPassword + " " + terraformConfig.Standalone.RancherImage + " " + registryPublicDNS
 
+	if !terraformConfig.StandaloneRegistry.NonAuthGlobalRegistry {
+		command += " " + terraformConfig.StandaloneRegistry.RegistryUsername + " " + terraformConfig.StandaloneRegistry.RegistryPassword + " " +
+			terraformConfig.Standalone.RegistryUsername + " " + terraformConfig.Standalone.RegistryPassword
+	} else {
+		command += " \"\"" + " \"\"" + " \"\"" + " \"\""
+	}
+
 	if terraformConfig.Standalone.RancherAgentImage != "" {
 		command += " " + terraformConfig.Standalone.RancherAgentImage
+	} else {
+		command += " \"\""
 	}
 
 	provisionerBlockBody.SetAttributeValue(general.Inline, cty.ListVal([]cty.Value{

--- a/framework/set/resources/registries/rancher/setup.sh
+++ b/framework/set/resources/registries/rancher/setup.sh
@@ -10,7 +10,11 @@ CHART_VERSION=$7
 BOOTSTRAP_PASSWORD=$8
 RANCHER_IMAGE=$9
 REGISTRY=${10}
-RANCHER_AGENT_IMAGE=${11}
+REGISTRY_USERNAME=${11}
+REGISTRY_PASSWORD=${12}
+DOCKERHUB_USER=${13}
+DOCKERHUB_PASS=${14}
+RANCHER_AGENT_IMAGE=${15}
 
 if [[ $RANCHER_TAG_VERSION == v2.11* || $RANCHER_TAG_VERSION == v2.10* ]]; then
     RANCHER_TAG="--set rancherImageTag=${RANCHER_TAG_VERSION}" 
@@ -45,6 +49,8 @@ install_kubectl() {
     sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
     mkdir -p ~/.kube
     rm kubectl
+
+    kubectl create ns cattle-system
 }
 
 check_cluster_status() {
@@ -87,9 +93,20 @@ setup_helm_repo() {
     helm repo add rancher-${REPO} ${RANCHER_CHART_REPO}${REPO}
 }
 
+docker_login() {
+    printf '%s\n' \
+'{' \
+'  "insecure-registries" : [ "'"${REGISTRY}"'" ]' \
+'}' |
+sudo tee /etc/docker/daemon.json >/dev/null
+    
+    sudo systemctl restart docker && sudo systemctl daemon-reload
+    sudo docker login https://registry-1.docker.io -u "${DOCKERHUB_USER}" -p "${DOCKERHUB_PASS}"
+    sudo docker login https://${REGISTRY} -u "${REGISTRY_USERNAME}" -p "${REGISTRY_PASSWORD}"
+}
+
 install_cert_manager() {
     echo "Installing cert manager"
-    kubectl create ns cattle-system
     kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.crds.yaml
     helm repo add jetstack https://charts.jetstack.io
     helm repo update
@@ -114,8 +131,9 @@ install_self_signed_rancher() {
                                                                                          ${VERSION} \
                                                                                          ${RANCHER_TAG} \
                                                                                          ${IMAGE} \
+                                                                                         ${IMAGE_PULL_SECRET} \
                                                                                          --set 'extraEnv[0].name=CATTLE_AGENT_IMAGE' \
-                                                                                         --set "extraEnv[0].value=${RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}" \
+                                                                                         --set "extraEnv[0].value=${REGISTRY}/${RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}" \
                                                                                          --set 'extraEnv[1].name=RANCHER_VERSION_TYPE' \
                                                                                          --set 'extraEnv[1].value=prime' \
                                                                                          --set 'extraEnv[2].name=CATTLE_BASE_UI_BRAND' \
@@ -131,6 +149,7 @@ install_self_signed_rancher() {
                                                                                          ${VERSION} \
                                                                                          ${RANCHER_TAG} \
                                                                                          ${IMAGE} \
+                                                                                         ${IMAGE_PULL_SECRET} \
                                                                                          --set systemDefaultRegistry=${REGISTRY} \
                                                                                          --set agentTLSMode=system-store \
                                                                                          --set bootstrapPassword=${BOOTSTRAP_PASSWORD} \
@@ -146,11 +165,12 @@ install_lets_encrypt_rancher() {
                                                                                      ${VERSION} \
                                                                                      ${RANCHER_TAG} \
                                                                                      ${IMAGE} \
+                                                                                     ${IMAGE_PULL_SECRET} \
                                                                                      --set ingress.tls.source=letsEncrypt \
                                                                                      --set letsEncrypt.email=${LETS_ENCRYPT_EMAIL} \
                                                                                      --set letsEncrypt.ingress.class=traefik \
                                                                                      --set 'extraEnv[0].name=CATTLE_AGENT_IMAGE' \
-                                                                                     --set "extraEnv[0].value=${RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}" \
+                                                                                     --set "extraEnv[0].value=${REGISTRY}/${RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}" \
                                                                                      --set 'extraEnv[1].name=RANCHER_VERSION_TYPE' \
                                                                                      --set 'extraEnv[1].value=prime' \
                                                                                      --set 'extraEnv[2].name=CATTLE_BASE_UI_BRAND' \
@@ -165,6 +185,7 @@ install_lets_encrypt_rancher() {
                                                                                      ${VERSION} \
                                                                                      ${RANCHER_TAG} \
                                                                                      ${IMAGE} \
+                                                                                     ${IMAGE_PULL_SECRET} \
                                                                                      --set ingress.tls.source=letsEncrypt \
                                                                                      --set letsEncrypt.email=${LETS_ENCRYPT_EMAIL} \
                                                                                      --set letsEncrypt.ingress.class=traefik \
@@ -195,6 +216,15 @@ setup_helm_repo
 if [[ $RANCHER_TAG_VERSION == *head* ]]; then
     LATEST_CHART_VERSION=$(helm search repo rancher-${REPO} --devel | tail -n +2 | head -n 1 | cut -f2)
     VERSION="--version ${LATEST_CHART_VERSION}"
+fi
+
+if [ -z "$REGISTRY_USERNAME" ] || [ -z "$REGISTRY_PASSWORD" ]; then
+    IMAGE_PULL_SECRET=""
+else
+    docker_login
+
+    kubectl create secret docker-registry tfp-reg-cred -n cattle-system --docker-server=${REGISTRY} --docker-username=${REGISTRY_USERNAME} --docker-password=${REGISTRY_PASSWORD}
+    IMAGE_PULL_SECRET="--set imagePullSecrets[0].name=tfp-reg-cred --set systemRegistryInheritsPullSecrets=true"
 fi
 
 install_cert_manager

--- a/framework/set/resources/registries/rke2/add-servers.sh
+++ b/framework/set/resources/registries/rke2/add-servers.sh
@@ -8,9 +8,11 @@ RKE2_TOKEN=$5
 RANCHER_IMAGE=$6
 RANCHER_TAG_VERSION=$7
 REGISTRY=$8
-REGISTRY_USERNAME=$9
+REGISTRY_USERNAME=${9}
 REGISTRY_PASSWORD=${10}
-RANCHER_AGENT_IMAGE=${11}
+DOCKERHUB_USER=${11}
+DOCKERHUB_PASS=${12}
+RANCHER_AGENT_IMAGE=${13}
 
 set -e
 
@@ -23,8 +25,8 @@ system-default-registry: ${REGISTRY}
 tls-san:
   - ${RKE2_SERVER_IP}" | sudo tee /etc/rancher/rke2/config.yaml > /dev/null
 
-
-sudo tee /etc/rancher/rke2/registries.yaml > /dev/null << EOF
+if [ -z "$REGISTRY_USERNAME" ] || [ -z "$REGISTRY_PASSWORD" ]; then
+  sudo tee /etc/rancher/rke2/registries.yaml > /dev/null << EOF
 mirrors:
   "docker.io":
     endpoint:
@@ -36,6 +38,21 @@ configs:
     tls:
       insecure_skip_verify: true
 EOF
+else
+  sudo tee /etc/rancher/rke2/registries.yaml > /dev/null << EOF
+mirrors:
+  "docker.io":
+    endpoint:
+      - "https://${REGISTRY}"
+    rewrite:
+      "^rancher/(.*)": "${REGISTRY}/rancher/\$1"
+configs:
+  "${REGISTRY}":
+    auth:
+      username: "${REGISTRY_USERNAME}"
+      password: "${REGISTRY_PASSWORD}"
+EOF
+fi
 
 ARCH=$(uname -m)
 if [[ $ARCH == "x86_64" ]]; then
@@ -73,6 +90,11 @@ sudo tee /etc/docker/daemon.json > /dev/null << EOF
 EOF
 
 sudo systemctl restart docker && sudo systemctl daemon-reload
+
+if [ -n "${REGISTRY_USERNAME}" ] && [ -n "${REGISTRY_PASSWORD}" ]; then
+  sudo docker login https://registry-1.docker.io -u "${DOCKERHUB_USER}" -p "${DOCKERHUB_PASS}"
+  sudo docker login https://${REGISTRY} -u "${REGISTRY_USERNAME}" -p "${REGISTRY_PASSWORD}"
+fi
 
 if [ -n "$RANCHER_AGENT_IMAGE" ]; then
   sudo docker pull ${REGISTRY}/${RANCHER_IMAGE}:${RANCHER_TAG_VERSION}

--- a/framework/set/resources/registries/rke2/createCluster.go
+++ b/framework/set/resources/registries/rke2/createCluster.go
@@ -21,6 +21,16 @@ const (
 	rke2ServerTwo   = "server2"
 	rke2ServerThree = "server3"
 	token           = "token"
+
+	scpCertsFromRegistry = "scp_certs_from_registry"
+	scpCertsServer1      = "scp_certs_server1"
+	scpCertsServer2      = "scp_certs_server2"
+	scpCertsServer3      = "scp_certs_server3"
+	globalRegistry       = "global_registry"
+
+	localTempCertsPath = "/tmp/registry-certs"
+	scpOptions         = "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+	ubuntuUser         = "ubuntu"
 )
 
 // CreateRKE2Cluster is a helper function that will create the RKE2 cluster.
@@ -61,16 +71,22 @@ func createRKE2Server(rootBody *hclwrite.Body, terraformConfig *config.Terraform
 	rke2Token, registryPublicDNS string, script []byte) {
 	_, provisionerBlockBody := rke2.SSHNullResource(rootBody, terraformConfig, rke2ServerOnePublicDNS, rke2ServerOne)
 
-	command := "bash -c '/tmp/init-server.sh " + terraformConfig.Standalone.OSUser + " " + terraformConfig.Standalone.OSGroup + " " +
+	command := "/tmp/init-server.sh " + terraformConfig.Standalone.OSUser + " " + terraformConfig.Standalone.OSGroup + " " +
 		terraformConfig.Standalone.RKE2Version + " " + rke2ServerOnePrivateIP + " " + rke2Token + " " +
-		terraformConfig.Standalone.RancherImage + " " + terraformConfig.Standalone.RancherTagVersion + " " + registryPublicDNS + " " +
-		terraformConfig.Standalone.RegistryUsername + " " + terraformConfig.Standalone.RegistryPassword
+		terraformConfig.Standalone.RancherImage + " " + terraformConfig.Standalone.RancherTagVersion + " " + registryPublicDNS
+
+	if !terraformConfig.StandaloneRegistry.NonAuthGlobalRegistry {
+		command += " " + terraformConfig.StandaloneRegistry.RegistryUsername + " " + terraformConfig.StandaloneRegistry.RegistryPassword + " " +
+			terraformConfig.Standalone.RegistryUsername + " " + terraformConfig.Standalone.RegistryPassword
+	} else {
+		command += " \"\"" + " \"\"" + " \"\"" + " \"\""
+	}
 
 	if terraformConfig.Standalone.RancherAgentImage != "" {
 		command += " " + terraformConfig.Standalone.RancherAgentImage
+	} else {
+		command += " \"\""
 	}
-
-	command += "'"
 
 	provisionerBlockBody.SetAttributeValue(general.Inline, cty.ListVal([]cty.Value{
 		cty.StringVal("printf '" + string(script) + "' > /tmp/init-server.sh"),
@@ -89,16 +105,22 @@ func addRKE2ServerNodes(rootBody *hclwrite.Body, terraformConfig *config.Terrafo
 		host := hosts[i]
 		nullResourceBlockBody, provisionerBlockBody := rke2.SSHNullResource(rootBody, terraformConfig, instance, host)
 
-		command := "bash -c '/tmp/add-servers.sh " + terraformConfig.Standalone.OSUser + " " + terraformConfig.Standalone.OSGroup + " " +
+		command := "/tmp/add-servers.sh " + terraformConfig.Standalone.OSUser + " " + terraformConfig.Standalone.OSGroup + " " +
 			terraformConfig.Standalone.RKE2Version + " " + rke2ServerOnePrivateIP + " " + rke2Token + " " +
-			terraformConfig.Standalone.RancherImage + " " + terraformConfig.Standalone.RancherTagVersion + " " + registryPublicDNS + " " +
-			terraformConfig.Standalone.RegistryUsername + " " + terraformConfig.Standalone.RegistryPassword
+			terraformConfig.Standalone.RancherImage + " " + terraformConfig.Standalone.RancherTagVersion + " " + registryPublicDNS
+
+		if !terraformConfig.StandaloneRegistry.NonAuthGlobalRegistry {
+			command += " " + terraformConfig.StandaloneRegistry.RegistryUsername + " " + terraformConfig.StandaloneRegistry.RegistryPassword + " " +
+				terraformConfig.Standalone.RegistryUsername + " " + terraformConfig.Standalone.RegistryPassword
+		} else {
+			command += " \"\"" + " \"\"" + " \"\"" + " \"\""
+		}
 
 		if terraformConfig.Standalone.RancherAgentImage != "" {
 			command += " " + terraformConfig.Standalone.RancherAgentImage
+		} else {
+			command += " \"\""
 		}
-
-		command += "'"
 
 		provisionerBlockBody.SetAttributeValue(general.Inline, cty.ListVal([]cty.Value{
 			cty.StringVal("printf '" + string(script) + "' > /tmp/add-servers.sh"),

--- a/framework/set/resources/registries/rke2/init-server.sh
+++ b/framework/set/resources/registries/rke2/init-server.sh
@@ -8,9 +8,11 @@ RKE2_TOKEN=$5
 RANCHER_IMAGE=$6
 RANCHER_TAG_VERSION=$7
 REGISTRY=$8
-REGISTRY_USERNAME=$9
+REGISTRY_USERNAME=${9}
 REGISTRY_PASSWORD=${10}
-RANCHER_AGENT_IMAGE=${11}
+DOCKERHUB_USER=${11}
+DOCKERHUB_PASS=${12}
+RANCHER_AGENT_IMAGE=${13}
 
 set -e
 
@@ -22,7 +24,8 @@ system-default-registry: ${REGISTRY}
 tls-san:
   - ${RKE2_SERVER_IP}" | sudo tee /etc/rancher/rke2/config.yaml > /dev/null
 
-sudo tee /etc/rancher/rke2/registries.yaml > /dev/null << EOF
+if [ -z "${REGISTRY_USERNAME}" ] || [ -z "${REGISTRY_PASSWORD}" ]; then
+  sudo tee /etc/rancher/rke2/registries.yaml > /dev/null << EOF
 mirrors:
   "docker.io":
     endpoint:
@@ -34,6 +37,21 @@ configs:
     tls:
       insecure_skip_verify: true
 EOF
+else
+  sudo tee /etc/rancher/rke2/registries.yaml > /dev/null << EOF
+mirrors:
+  "docker.io":
+    endpoint:
+      - "https://${REGISTRY}"
+    rewrite:
+      "^rancher/(.*)": "${REGISTRY}/rancher/\$1"
+configs:
+  "${REGISTRY}":
+    auth:
+      username: "${REGISTRY_USERNAME}"
+      password: "${REGISTRY_PASSWORD}"
+EOF
+fi
 
 ARCH=$(uname -m)
 if [[ $ARCH == "x86_64" ]]; then
@@ -72,6 +90,11 @@ sudo tee /etc/docker/daemon.json > /dev/null << EOF
 EOF
 
 sudo systemctl restart docker && sudo systemctl daemon-reload
+
+if [ -n "${REGISTRY_USERNAME}" ] && [ -n "${REGISTRY_PASSWORD}" ]; then
+  sudo docker login https://registry-1.docker.io -u "${DOCKERHUB_USER}" -p "${DOCKERHUB_PASS}"
+  sudo docker login https://${REGISTRY} -u "${REGISTRY_USERNAME}" -p "${REGISTRY_PASSWORD}"
+fi
 
 if [ -n "$RANCHER_AGENT_IMAGE" ]; then
   sudo docker pull ${REGISTRY}/${RANCHER_IMAGE}:${RANCHER_TAG_VERSION}

--- a/modules/registries/aws/outputs.tf
+++ b/modules/registries/aws/outputs.tf
@@ -10,6 +10,10 @@ output "global_registry_public_dns" {
   value = aws_instance.global_registry.public_dns
 }
 
+output "global_registry_route_53_fqdn" {
+  value = aws_route53_record.global-mew-tfp-registry.fqdn
+}
+
 output "ecr_registry_public_dns" {
   value = aws_instance.ecr_registry.public_dns
 }

--- a/tests/infrastructure/registries/setup_all_registries.go
+++ b/tests/infrastructure/registries/setup_all_registries.go
@@ -25,6 +25,8 @@ const (
 	globalRegistryPublicDNS  = "global_registry_public_dns"
 	ecrRegistryPublicDNS     = "ecr_registry_public_dns"
 
+	globalRegistryRoute53FQDN = "global_registry_route_53_fqdn"
+
 	authRegistry    = "auth_registry"
 	nonAuthRegistry = "non_auth_registry"
 	globalRegistry  = "global_registry"
@@ -76,6 +78,7 @@ func SetupAllRegistries(t *testing.T, provider string) error {
 	authRegistryPublicDNS := terraform.Output(t, terraformOptions, authRegistryPublicDNS)
 	nonAuthRegistryPublicDNS := terraform.Output(t, terraformOptions, nonAuthRegistryPublicDNS)
 	globalRegistryPublicDNS := terraform.Output(t, terraformOptions, globalRegistryPublicDNS)
+	globalRegistryRoute53FQDN := terraform.Output(t, terraformOptions, globalRegistryRoute53FQDN)
 	ecrRegistryPublicDNS := terraform.Output(t, terraformOptions, ecrRegistryPublicDNS)
 
 	file = sanity.OpenFile(file, keyPath)
@@ -94,7 +97,7 @@ func SetupAllRegistries(t *testing.T, provider string) error {
 
 	file = sanity.OpenFile(file, keyPath)
 	logrus.Infof("Creating authenticated registry...")
-	file, err = registry.CreateAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, authRegistryPublicDNS)
+	file, err = registry.CreateAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, authRegistryPublicDNS, globalRegistryRoute53FQDN)
 	require.NoError(t, err)
 
 	terraform.InitAndApply(t, terraformOptions)

--- a/tests/infrastructure/registries/setup_auth_registry.go
+++ b/tests/infrastructure/registries/setup_auth_registry.go
@@ -57,7 +57,7 @@ func SetupAuthenticatedRegistry(t *testing.T, provider string) error {
 
 	file = sanity.OpenFile(file, keyPath)
 	logrus.Infof("Creating authenticated registry...")
-	file, err = registry.CreateAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, authRegistryPublicDNS)
+	file, err = registry.CreateAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, authRegistryPublicDNS, globalRegistryRoute53FQDN)
 	require.NoError(t, err)
 
 	terraform.InitAndApply(t, terraformOptions)


### PR DESCRIPTION
This pull request adds functionality to allow authenticated registries to be configured as the system default registry. This improves system flexibility by enabling secure registries to be used as defaults for image pulls and other registry operations.