### PR TITLE
Enhance non-authenticated registries to use a secure private registry

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -161,21 +161,23 @@ type Standalone struct {
 }
 
 type StandaloneRegistry struct {
-	AssetsPath            string `json:"assetsPath,omitempty" yaml:"assetsPath,omitempty"`
-	Authenticated         bool   `json:"authenticated,omitempty" yaml:"authenticated,omitempty"`
-	AuthRegistryFQDN      string `json:"authRegistryFQDN,omitempty" yaml:"authRegistryFQDN,omitempty"`
-	ECRFQDN               string `json:"ecrFQDN,omitempty" yaml:"ecrFQDN,omitempty"`
-	ECRURI                string `json:"ecrURI,omitempty" yaml:"ecrURI,omitempty"`
-	ECRUsername           string `json:"ecrUsername,omitempty" yaml:"ecrUsername,omitempty"`
-	ECRPassword           string `json:"ecrPassword,omitempty" yaml:"ecrPassword,omitempty"`
-	Enabled               bool   `json:"enabled,omitempty" yaml:"enabled,omitempty" default:"false"`
-	GlobalRegistryFQDN    string `json:"globalRegistryFQDN,omitempty" yaml:"globalRegistryFQDN,omitempty"`
-	NonAuthRegistryFQDN   string `json:"nonAuthRegistryFQDN,omitempty" yaml:"nonAuthRegistryFQDN,omitempty"`
-	NonAuthGlobalRegistry bool   `json:"nonAuthGlobalRegistry,omitempty" yaml:"nonAuthGlobalRegistry,omitempty" default:"true"`
-	RegistryName          string `json:"registryName,omitempty" yaml:"registryName,omitempty"`
-	RegistryPassword      string `json:"registryPassword,omitempty" yaml:"registryPassword,omitempty"`
-	RegistryUsername      string `json:"registryUsername,omitempty" yaml:"registryUsername,omitempty"`
-	UpgradedAssetsPath    string `json:"upgradedAssetsPath,omitempty" yaml:"upgradedAssetsPath,omitempty"`
+	AssetsPath                  string `json:"assetsPath,omitempty" yaml:"assetsPath,omitempty"`
+	Authenticated               bool   `json:"authenticated,omitempty" yaml:"authenticated,omitempty"`
+	AuthRegistryFQDN            string `json:"authRegistryFQDN,omitempty" yaml:"authRegistryFQDN,omitempty"`
+	CreateAuthGlobalRegistry    bool   `json:"createAuthGlobalRegistry,omitempty" yaml:"createAuthGlobalRegistry,omitempty" default:"false"`
+	CreateNonAuthGlobalRegistry bool   `json:"createNonAuthGlobalRegistry,omitempty" yaml:"createNonAuthGlobalRegistry,omitempty" default:"false"`
+	ECRFQDN                     string `json:"ecrFQDN,omitempty" yaml:"ecrFQDN,omitempty"`
+	ECRURI                      string `json:"ecrURI,omitempty" yaml:"ecrURI,omitempty"`
+	ECRUsername                 string `json:"ecrUsername,omitempty" yaml:"ecrUsername,omitempty"`
+	ECRPassword                 string `json:"ecrPassword,omitempty" yaml:"ecrPassword,omitempty"`
+	Enabled                     bool   `json:"enabled,omitempty" yaml:"enabled,omitempty" default:"false"`
+	GlobalRegistryFQDN          string `json:"globalRegistryFQDN,omitempty" yaml:"globalRegistryFQDN,omitempty"`
+	NonAuthRegistryFQDN         string `json:"nonAuthRegistryFQDN,omitempty" yaml:"nonAuthRegistryFQDN,omitempty"`
+	RegistryName                string `json:"registryName,omitempty" yaml:"registryName,omitempty"`
+	RegistryPassword            string `json:"registryPassword,omitempty" yaml:"registryPassword,omitempty"`
+	RegistryUsername            string `json:"registryUsername,omitempty" yaml:"registryUsername,omitempty"`
+	UpgradedAssetsPath          string `json:"upgradedAssetsPath,omitempty" yaml:"upgradedAssetsPath,omitempty"`
+	UseAuthGlobalRegistry       bool   `json:"useAuthGlobalRegistry,omitempty" yaml:"useAuthGlobalRegistry,omitempty" default:"true"`
 }
 
 type TerraformConfig struct {

--- a/framework/set/resources/airgap/createMainTF.go
+++ b/framework/set/resources/airgap/createMainTF.go
@@ -76,7 +76,7 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 
 	logrus.Infof("Creating registry...")
 	file = sanity.OpenFile(file, keyPath)
-	file, err = registry.CreateNonAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, registryPublicDNS, nonAuthRegistry)
+	file, err = registry.CreateNonAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, registryPublicDNS, nonAuthRegistry, registryPublicDNS, true)
 	if err != nil {
 		return "", "", err
 	}

--- a/framework/set/resources/providers/aws/createResources.go
+++ b/framework/set/resources/providers/aws/createResources.go
@@ -35,28 +35,36 @@ func CreateAWSResources(file *os.File, newFile *hclwrite.File, tfBlockBody, root
 	if terraformConfig.Standalone.RancherHostname != "" && terraformConfig.Provider != providers.EKS {
 		ports := []int64{80, 443, 6443, 9345}
 		for _, port := range ports {
-			CreateTargetGroupAttachments(rootBody, terraformConfig, aws.LoadBalancerTargetGroupAttachment, getTargetGroupAttachment(port, false), port, false)
+			CreateTargetGroupAttachments(rootBody, terraformConfig, aws.LoadBalancerTargetGroupAttachment, getTargetGroupAttachment(port, false), port, terraformConfig.ResourcePrefix, false)
 			rootBody.AppendNewline()
 		}
 
-		CreateLoadBalancer(rootBody, terraformConfig, false)
+		CreateLoadBalancer(rootBody, terraformConfig, terraformConfig.ResourcePrefix, false)
 		rootBody.AppendNewline()
 
 		for _, port := range ports {
-			CreateTargetGroups(rootBody, terraformConfig, port, false)
+			CreateTargetGroups(rootBody, terraformConfig, port, terraformConfig.ResourcePrefix, false)
 			rootBody.AppendNewline()
 
-			CreateLoadBalancerListeners(rootBody, terraformConfig, port, false)
+			CreateLoadBalancerListeners(rootBody, terraformConfig, port, terraformConfig.ResourcePrefix, false)
 			rootBody.AppendNewline()
 		}
 
-		CreateRoute53Record(rootBody, terraformConfig, false)
+		CreateRoute53Record(rootBody, terraformConfig, terraformConfig.ResourcePrefix, false)
 		rootBody.AppendNewline()
 	}
 
-	// Create a second pair of networking so that the authenticated global registry can reference it for certificates later.
-	if terraformConfig.StandaloneRegistry != nil && !terraformConfig.StandaloneRegistry.NonAuthGlobalRegistry {
-		globalRegistryResources(rootBody, terraformConfig)
+	// Create a second pair of networking so that the global registry can reference it for certificates later.
+	if terraformConfig.StandaloneRegistry != nil && !terraformConfig.StandaloneRegistry.Enabled {
+		globalRegistryResources(rootBody, terraformConfig, "auth")
+
+		if terraformConfig.StandaloneRegistry.CreateAuthGlobalRegistry {
+			globalRegistryResources(rootBody, terraformConfig, "auth-global")
+		}
+
+		if terraformConfig.StandaloneRegistry.CreateNonAuthGlobalRegistry {
+			globalRegistryResources(rootBody, terraformConfig, "nauth-global")
+		}
 	}
 
 	var err error
@@ -162,22 +170,22 @@ func CreateIPv6AWSResources(file *os.File, newFile *hclwrite.File, tfBlockBody, 
 	if terraformConfig.Standalone.CertManagerVersion != "" {
 		ports := []int64{80, 443, 6443, 9345}
 		for _, port := range ports {
-			CreateTargetGroupAttachments(rootBody, terraformConfig, aws.LoadBalancerTargetGroupAttachment, getTargetGroupAttachment(port, false), port, false)
+			CreateTargetGroupAttachments(rootBody, terraformConfig, aws.LoadBalancerTargetGroupAttachment, getTargetGroupAttachment(port, false), port, terraformConfig.ResourcePrefix, false)
 			rootBody.AppendNewline()
 		}
 
-		CreateLoadBalancer(rootBody, terraformConfig, false)
+		CreateLoadBalancer(rootBody, terraformConfig, terraformConfig.ResourcePrefix, false)
 		rootBody.AppendNewline()
 
 		for _, port := range ports {
-			CreateTargetGroups(rootBody, terraformConfig, port, false)
+			CreateTargetGroups(rootBody, terraformConfig, port, terraformConfig.ResourcePrefix, false)
 			rootBody.AppendNewline()
 
-			CreateLoadBalancerListeners(rootBody, terraformConfig, port, false)
+			CreateLoadBalancerListeners(rootBody, terraformConfig, port, terraformConfig.ResourcePrefix, false)
 			rootBody.AppendNewline()
 		}
 
-		CreateRoute53Record(rootBody, terraformConfig, false)
+		CreateRoute53Record(rootBody, terraformConfig, terraformConfig.ResourcePrefix, false)
 		rootBody.AppendNewline()
 	}
 
@@ -218,26 +226,24 @@ func getTargetGroupAttachment(port int64, internal bool) string {
 	}
 }
 
-func globalRegistryResources(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig) {
-	terraformConfig.ResourcePrefix = "global-" + terraformConfig.ResourcePrefix
-
-	ports := []int64{80, 443, 6443, 9345}
+func globalRegistryResources(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, prefix string) {
+	ports := []int64{80, 443}
 	for _, port := range ports {
-		CreateTargetGroupAttachments(rootBody, terraformConfig, aws.LoadBalancerTargetGroupAttachment, getTargetGroupAttachment(port, false), port, true)
+		CreateTargetGroupAttachments(rootBody, terraformConfig, aws.LoadBalancerTargetGroupAttachment, getTargetGroupAttachment(port, false), port, prefix, true)
 		rootBody.AppendNewline()
 	}
 
-	CreateLoadBalancer(rootBody, terraformConfig, true)
+	CreateLoadBalancer(rootBody, terraformConfig, prefix, true)
 	rootBody.AppendNewline()
 
 	for _, port := range ports {
-		CreateTargetGroups(rootBody, terraformConfig, port, true)
+		CreateTargetGroups(rootBody, terraformConfig, port, prefix, true)
 		rootBody.AppendNewline()
 
-		CreateLoadBalancerListeners(rootBody, terraformConfig, port, true)
+		CreateLoadBalancerListeners(rootBody, terraformConfig, port, prefix, true)
 		rootBody.AppendNewline()
 	}
 
-	CreateRoute53Record(rootBody, terraformConfig, true)
+	CreateRoute53Record(rootBody, terraformConfig, prefix, true)
 	rootBody.AppendNewline()
 }

--- a/framework/set/resources/providers/aws/instances.go
+++ b/framework/set/resources/providers/aws/instances.go
@@ -14,7 +14,9 @@ import (
 )
 
 const (
-	ecrRegistry = "ecr_registry"
+	auth     = "auth"
+	ecr      = "ecr"
+	registry = "registry"
 )
 
 // CreateAWSInstances is a function that will set the AWS instances configurations in the main.tf file.
@@ -58,7 +60,7 @@ func CreateAWSInstances(rootBody *hclwrite.Body, terraformConfig *config.Terrafo
 	rootBlockDevice := configBlockBody.AppendNewBlock(aws.RootBlockDevice, nil)
 	rootBlockDeviceBody := rootBlockDevice.Body()
 
-	if strings.Contains(hostnamePrefix, general.Registry) {
+	if strings.Contains(hostnamePrefix, general.Registry) || strings.Contains(hostnamePrefix, auth) || strings.Contains(hostnamePrefix, ecr) {
 		rootBlockDeviceBody.SetAttributeValue(aws.VolumeSize, cty.NumberIntVal(terraformConfig.AWSConfig.RegistryRootSize))
 	} else {
 		rootBlockDeviceBody.SetAttributeValue(aws.VolumeSize, cty.NumberIntVal(terraformConfig.AWSConfig.AWSRootSize))

--- a/framework/set/resources/providers/aws/listeners.go
+++ b/framework/set/resources/providers/aws/listeners.go
@@ -18,15 +18,15 @@ const (
 )
 
 // CreateLoadBalancerListeners is a function that will set the load balancer listeners configurations in the main.tf file.
-func CreateLoadBalancerListeners(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, port int64, authGlobalRegistry bool) {
+func CreateLoadBalancerListeners(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, port int64, prefix string, globalRegistry bool) {
 	var listenersGroupBlockBody *hclwrite.Body
 	var loadBalancerExpression string
 
-	if authGlobalRegistry {
-		listenersGroupBlock := rootBody.AppendNewBlock(general.Resource, []string{aws.LoadBalancerListener, terraformConfig.ResourcePrefix + "_" + strconv.FormatInt(port, 10)})
+	if globalRegistry {
+		listenersGroupBlock := rootBody.AppendNewBlock(general.Resource, []string{aws.LoadBalancerListener, prefix + "_" + strconv.FormatInt(port, 10)})
 		listenersGroupBlockBody = listenersGroupBlock.Body()
 
-		loadBalancerExpression = aws.LoadBalancer + "." + terraformConfig.ResourcePrefix + ".arn"
+		loadBalancerExpression = aws.LoadBalancer + "." + prefix + ".arn"
 	} else {
 		listenersGroupBlock := rootBody.AppendNewBlock(general.Resource, []string{aws.LoadBalancerListener, aws.LoadBalancerListener + "_" + strconv.FormatInt(port, 10)})
 		listenersGroupBlockBody = listenersGroupBlock.Body()
@@ -48,8 +48,8 @@ func CreateLoadBalancerListeners(rootBody *hclwrite.Body, terraformConfig *confi
 	defaultActionBlockBody.SetAttributeValue(general.Type, cty.StringVal(forward))
 
 	var targetGroupExpression string
-	if authGlobalRegistry {
-		targetGroupExpression = aws.LoadBalancerTargetGroup + "." + terraformConfig.ResourcePrefix + "-" + aws.TargetGroupPrefix + strconv.FormatInt(port, 10) + ".arn"
+	if globalRegistry {
+		targetGroupExpression = aws.LoadBalancerTargetGroup + "." + prefix + "-" + aws.TargetGroupPrefix + strconv.FormatInt(port, 10) + ".arn"
 	} else {
 		targetGroupExpression = aws.LoadBalancerTargetGroup + "." + aws.TargetGroupPrefix + strconv.FormatInt(port, 10) + ".arn"
 	}

--- a/framework/set/resources/providers/aws/loadbalancer.go
+++ b/framework/set/resources/providers/aws/loadbalancer.go
@@ -18,11 +18,11 @@ const (
 )
 
 // CreateLoadBalancer is a function that will set the load balancer configurations in the main.tf file.
-func CreateLoadBalancer(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, authGlobalRegistry bool) {
+func CreateLoadBalancer(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, prefix string, globalRegistry bool) {
 	var loadBalancerBlockBody *hclwrite.Body
 
-	if authGlobalRegistry {
-		loadBalancerBlock := rootBody.AppendNewBlock(general.Resource, []string{aws.LoadBalancer, terraformConfig.ResourcePrefix})
+	if globalRegistry {
+		loadBalancerBlock := rootBody.AppendNewBlock(general.Resource, []string{aws.LoadBalancer, prefix})
 		loadBalancerBlockBody = loadBalancerBlock.Body()
 	} else {
 		loadBalancerBlock := rootBody.AppendNewBlock(general.Resource, []string{aws.LoadBalancer, aws.LoadBalancer})
@@ -38,7 +38,12 @@ func CreateLoadBalancer(rootBody *hclwrite.Body, terraformConfig *config.Terrafo
 
 	subnetList := format.ListOfStrings([]string{terraformConfig.AWSConfig.AWSSubnetID})
 	loadBalancerBlockBody.SetAttributeRaw(aws.Subnets, subnetList)
-	loadBalancerBlockBody.SetAttributeValue(name, cty.StringVal(terraformConfig.ResourcePrefix))
+
+	if globalRegistry {
+		loadBalancerBlockBody.SetAttributeValue(name, cty.StringVal(prefix+"-"+terraformConfig.ResourcePrefix))
+	} else {
+		loadBalancerBlockBody.SetAttributeValue(name, cty.StringVal(terraformConfig.ResourcePrefix))
+	}
 }
 
 // CreateInternalLoadBalancer is a function that will set the internal load balancer configurations in the main.tf file.

--- a/framework/set/resources/providers/aws/route53.go
+++ b/framework/set/resources/providers/aws/route53.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"strings"
+
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/rancher/tfp-automation/config"
@@ -20,15 +22,17 @@ const (
 )
 
 // CreateRoute53Record is a function that will set the AWS Route 53 record configuration in the main.tf file.
-func CreateRoute53Record(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, authGlobalRegistry bool) {
+func CreateRoute53Record(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, prefix string, globalRegistry bool) {
 	var routeRecordBlockBody *hclwrite.Body
 	var zoneIDExpression string
 
-	if authGlobalRegistry {
-		routeRecordBlock := rootBody.AppendNewBlock(general.Resource, []string{aws.Route53Record, terraformConfig.ResourcePrefix})
+	if globalRegistry {
+		route53ResourceName := strings.ReplaceAll(prefix, "-", "_")
+
+		routeRecordBlock := rootBody.AppendNewBlock(general.Resource, []string{aws.Route53Record, route53ResourceName})
 		routeRecordBlockBody = routeRecordBlock.Body()
 
-		zoneIDExpression = general.Data + "." + aws.Route53Zone + "." + terraformConfig.ResourcePrefix + "." + zoneID
+		zoneIDExpression = general.Data + "." + aws.Route53Zone + "." + prefix + "." + zoneID
 	} else {
 		routeRecordBlock := rootBody.AppendNewBlock(general.Resource, []string{aws.Route53Record, aws.Route53Record})
 		routeRecordBlockBody = routeRecordBlock.Body()
@@ -41,17 +45,24 @@ func CreateRoute53Record(rootBody *hclwrite.Body, terraformConfig *config.Terraf
 	}
 
 	routeRecordBlockBody.SetAttributeRaw(zoneID, values)
-	routeRecordBlockBody.SetAttributeValue(name, cty.StringVal(terraformConfig.ResourcePrefix))
+
+	if globalRegistry {
+		routeRecordBlockBody.SetAttributeValue(name, cty.StringVal(prefix+"-"+terraformConfig.ResourcePrefix))
+	} else {
+		routeRecordBlockBody.SetAttributeValue(name, cty.StringVal(terraformConfig.ResourcePrefix))
+	}
+
 	routeRecordBlockBody.SetAttributeValue(general.Type, cty.StringVal(CNAME))
 	routeRecordBlockBody.SetAttributeValue(ttl, cty.NumberIntVal(300))
 
 	var loadBalancerExpression string
 
-	if authGlobalRegistry {
-		loadBalancerExpression = "[" + aws.LoadBalancer + "." + terraformConfig.ResourcePrefix + "." + dnsName + "]"
+	if globalRegistry {
+		loadBalancerExpression = "[" + aws.LoadBalancer + "." + prefix + "." + dnsName + "]"
 	} else {
 		loadBalancerExpression = "[" + aws.LoadBalancer + "." + aws.LoadBalancer + "." + dnsName + "]"
 	}
+
 	values = hclwrite.Tokens{
 		{Type: hclsyntax.TokenIdent, Bytes: []byte(loadBalancerExpression)},
 	}
@@ -62,8 +73,8 @@ func CreateRoute53Record(rootBody *hclwrite.Body, terraformConfig *config.Terraf
 
 	var zoneBlock *hclwrite.Block
 	var zoneBlockBody *hclwrite.Body
-	if authGlobalRegistry {
-		zoneBlock = rootBody.AppendNewBlock(general.Data, []string{aws.Route53Zone, terraformConfig.ResourcePrefix})
+	if globalRegistry {
+		zoneBlock = rootBody.AppendNewBlock(general.Data, []string{aws.Route53Zone, prefix})
 		zoneBlockBody = zoneBlock.Body()
 	} else {
 		zoneBlock = rootBody.AppendNewBlock(general.Data, []string{aws.Route53Zone, selected})

--- a/framework/set/resources/providers/aws/targetGroupAttachments.go
+++ b/framework/set/resources/providers/aws/targetGroupAttachments.go
@@ -19,11 +19,11 @@ const (
 
 // CreateTargetGroupAttachments is a function that will set the target group attachments configurations in the main.tf file.
 func CreateTargetGroupAttachments(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, lbTargetGroupAttachment,
-	targetGroupAttachmentServer string, port int64, authGlobalRegistry bool) {
+	targetGroupAttachmentServer string, port int64, prefix string, globalRegistry bool) {
 	var targetGroupBlockBody *hclwrite.Body
 
-	if authGlobalRegistry {
-		targetGroupBlock := rootBody.AppendNewBlock(general.Resource, []string{lbTargetGroupAttachment, terraformConfig.ResourcePrefix + "-" + targetGroupAttachmentServer})
+	if globalRegistry {
+		targetGroupBlock := rootBody.AppendNewBlock(general.Resource, []string{lbTargetGroupAttachment, prefix + "-" + targetGroupAttachmentServer})
 		targetGroupBlockBody = targetGroupBlock.Body()
 	} else {
 		targetGroupBlock := rootBody.AppendNewBlock(general.Resource, []string{lbTargetGroupAttachment, targetGroupAttachmentServer})
@@ -39,8 +39,8 @@ func CreateTargetGroupAttachments(rootBody *hclwrite.Body, terraformConfig *conf
 
 	var targetGroupExpression string
 
-	if authGlobalRegistry {
-		targetGroupExpression = aws.LoadBalancerTargetGroup + "." + terraformConfig.ResourcePrefix + "-" + aws.TargetGroupPrefix + fmt.Sprint(port) + ".arn"
+	if globalRegistry {
+		targetGroupExpression = aws.LoadBalancerTargetGroup + "." + prefix + "-" + aws.TargetGroupPrefix + fmt.Sprint(port) + ".arn"
 		values = hclwrite.Tokens{
 			{Type: hclsyntax.TokenIdent, Bytes: []byte(targetGroupExpression)},
 		}
@@ -53,8 +53,8 @@ func CreateTargetGroupAttachments(rootBody *hclwrite.Body, terraformConfig *conf
 
 	targetGroupBlockBody.SetAttributeRaw(aws.TargetGroupARN, values)
 
-	if authGlobalRegistry {
-		globalRegistryExpression := aws.AwsInstance + `.global_registry.id`
+	if globalRegistry {
+		globalRegistryExpression := aws.AwsInstance + `.` + prefix + `.id`
 		values = hclwrite.Tokens{
 			{Type: hclsyntax.TokenIdent, Bytes: []byte(globalRegistryExpression)},
 		}

--- a/framework/set/resources/providers/aws/targetGroups.go
+++ b/framework/set/resources/providers/aws/targetGroups.go
@@ -25,11 +25,11 @@ const (
 )
 
 // CreateTargetGroups is a function that will set the target group configurations in the main.tf file.
-func CreateTargetGroups(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, port int64, authGlobalRegistry bool) {
+func CreateTargetGroups(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, port int64, prefix string, globalRegistry bool) {
 	var targetGroupBlockBody *hclwrite.Body
 
-	if authGlobalRegistry {
-		targetGroupBlock := rootBody.AppendNewBlock(general.Resource, []string{aws.LoadBalancerTargetGroup, terraformConfig.ResourcePrefix + "-" + aws.TargetGroupPrefix + strconv.FormatInt(port, 10)})
+	if globalRegistry {
+		targetGroupBlock := rootBody.AppendNewBlock(general.Resource, []string{aws.LoadBalancerTargetGroup, prefix + "-" + aws.TargetGroupPrefix + strconv.FormatInt(port, 10)})
 		targetGroupBlockBody = targetGroupBlock.Body()
 	} else {
 		targetGroupBlock := rootBody.AppendNewBlock(general.Resource, []string{aws.LoadBalancerTargetGroup, aws.TargetGroupPrefix + strconv.FormatInt(port, 10)})
@@ -41,7 +41,12 @@ func CreateTargetGroups(rootBody *hclwrite.Body, terraformConfig *config.Terrafo
 	targetGroupBlockBody.SetAttributeValue(aws.VpcId, cty.StringVal(terraformConfig.AWSConfig.AWSVpcID))
 	targetGroupBlockBody.SetAttributeValue(aws.TargetType, cty.StringVal(terraformConfig.AWSConfig.TargetType))
 	targetGroupBlockBody.SetAttributeValue(aws.IPAddressType, cty.StringVal(terraformConfig.AWSConfig.IPAddressType))
-	targetGroupBlockBody.SetAttributeValue(name, cty.StringVal(terraformConfig.ResourcePrefix+"-tg-"+strconv.FormatInt(port, 10)))
+
+	if globalRegistry {
+		targetGroupBlockBody.SetAttributeValue(name, cty.StringVal(prefix+"-"+terraformConfig.ResourcePrefix+"-"+strconv.FormatInt(port, 10)))
+	} else {
+		targetGroupBlockBody.SetAttributeValue(name, cty.StringVal(terraformConfig.ResourcePrefix+"-tg-"+strconv.FormatInt(port, 10)))
+	}
 
 	healthCheckGroupBlock := targetGroupBlockBody.AppendNewBlock(aws.HealthCheck, nil)
 	healthCheckGroupBlockBody := healthCheckGroupBlock.Body()

--- a/framework/set/resources/registries/createMainTF.go
+++ b/framework/set/resources/registries/createMainTF.go
@@ -18,17 +18,21 @@ import (
 )
 
 const (
-	authRegistryPublicDNS    = "auth_registry_public_dns"
-	nonAuthRegistryPublicDNS = "non_auth_registry_public_dns"
-	globalRegistryPublicDNS  = "global_registry_public_dns"
-	ecrRegistryPublicDNS     = "ecr_registry_public_dns"
+	authRegistryPublicDNS          = "auth_registry_public_dns"
+	nonAuthRegistryPublicDNS       = "non_auth_registry_public_dns"
+	authGlobalRegistryPublicDNS    = "auth_global_registry_public_dns"
+	nonAuthGlobalRegistryPublicDNS = "nauth_global_registry_public_dns"
+	ecrRegistryPublicDNS           = "ecr_registry_public_dns"
 
-	globalRegistryRoute53FQDN = "global_registry_route_53_fqdn"
+	authRegistryRoute53FQDN          = "auth_registry_route_53_fqdn"
+	authGlobalRegistryRoute53FQDN    = "auth_global_registry_route_53_fqdn"
+	nonAuthGlobalRegistryRoute53FQDN = "nauth_global_registry_route_53_fqdn"
 
-	authRegistry    = "auth_registry"
-	nonAuthRegistry = "non_auth_registry"
-	globalRegistry  = "global_registry"
-	ecrRegistry     = "ecr_registry"
+	authRegistry          = "auth"
+	nonAuthRegistry       = "non_auth"
+	authGlobalRegistry    = "auth-global"
+	nonAuthGlobalRegistry = "nauth-global"
+	ecrRegistry           = "ecr"
 
 	serverOne            = "server1"
 	serverTwo            = "server2"
@@ -54,7 +58,7 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 	tfBlock := rootBody.AppendNewBlock(terraformConst, nil)
 	tfBlockBody := tfBlock.Body()
 
-	instances := []string{serverOne, serverTwo, serverThree, authRegistry, nonAuthRegistry, globalRegistry, ecrRegistry}
+	instances := []string{serverOne, serverTwo, serverThree, authRegistry, nonAuthRegistry, authGlobalRegistry, nonAuthGlobalRegistry, ecrRegistry}
 
 	providerTunnel := providers.TunnelToProvider(terraformConfig.Provider)
 	file, err := providerTunnel.CreateNonAirgap(file, newFile, tfBlockBody, rootBody, terraformConfig, terratestConfig, instances)
@@ -71,8 +75,11 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 
 	authRegistryPublicDNS := terraform.Output(t, terraformOptions, authRegistryPublicDNS)
 	nonAuthRegistryPublicDNS := terraform.Output(t, terraformOptions, nonAuthRegistryPublicDNS)
-	globalRegistryPublicDNS := terraform.Output(t, terraformOptions, globalRegistryPublicDNS)
-	globalRegistryRoute53FQDN := terraform.Output(t, terraformOptions, globalRegistryRoute53FQDN)
+	authGlobalRegistryPublicDNS := terraform.Output(t, terraformOptions, authGlobalRegistryPublicDNS)
+	nonAuthGlobalRegistryPublicDNS := terraform.Output(t, terraformOptions, nonAuthGlobalRegistryPublicDNS)
+	authRegistryRoute53FQDN := terraform.Output(t, terraformOptions, authRegistryRoute53FQDN)
+	nonAuthGlobalRegistryRoute53FQDN := terraform.Output(t, terraformOptions, nonAuthGlobalRegistryRoute53FQDN)
+	authGlobalRegistryRoute53FQDN := terraform.Output(t, terraformOptions, authGlobalRegistryRoute53FQDN)
 	ecrRegistryPublicDNS := terraform.Output(t, terraformOptions, ecrRegistryPublicDNS)
 	serverOnePublicDNS := terraform.Output(t, terraformOptions, serverOnePublicDNS)
 	serverOnePrivateIP := terraform.Output(t, terraformOptions, serverOnePrivateIP)
@@ -81,7 +88,7 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 
 	file = sanity.OpenFile(file, keyPath)
 	logrus.Infof("Creating non-authenticated registry...")
-	file, err = registry.CreateNonAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, nonAuthRegistryPublicDNS, nonAuthRegistry)
+	file, err = registry.CreateNonAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, nonAuthRegistryPublicDNS, nonAuthRegistry, nonAuthGlobalRegistryRoute53FQDN, false)
 	if err != nil {
 		logrus.Fatalf("Error creating unauthenticated registry: %v", err)
 	}
@@ -95,13 +102,13 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 
 	file = sanity.OpenFile(file, keyPath)
 	logrus.Infof("Creating global registry...")
-	if terraformConfig.StandaloneRegistry.NonAuthGlobalRegistry {
-		file, err = registry.CreateNonAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, globalRegistryPublicDNS, globalRegistry)
+	if !terraformConfig.StandaloneRegistry.UseAuthGlobalRegistry {
+		file, err = registry.CreateNonAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, nonAuthGlobalRegistryPublicDNS, nonAuthGlobalRegistry, nonAuthGlobalRegistryRoute53FQDN, true)
 		if err != nil {
 			logrus.Fatalf("Error creating global registry: %v", err)
 		}
 	} else {
-		file, err = registry.CreateAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, globalRegistryPublicDNS, globalRegistryRoute53FQDN)
+		file, err = registry.CreateAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, authGlobalRegistryPublicDNS, authGlobalRegistry, authGlobalRegistryRoute53FQDN, true)
 		if err != nil {
 			logrus.Fatalf("Error creating global registry: %v", err)
 		}
@@ -116,7 +123,7 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 
 	file = sanity.OpenFile(file, keyPath)
 	logrus.Infof("Creating authenticated registry...")
-	file, err = registry.CreateAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, authRegistryPublicDNS, globalRegistryRoute53FQDN)
+	file, err = registry.CreateAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, authRegistryPublicDNS, authRegistry, authRegistryRoute53FQDN, true)
 	if err != nil {
 		logrus.Fatalf("Error creating authenticated registry: %v", err)
 	}
@@ -144,8 +151,11 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 
 	// Needed so that when building the local cluster and setting up Rancher, we use the correct registry images based on
 	// whether the global registry is authenticated or not.
-	if !terraformConfig.StandaloneRegistry.NonAuthGlobalRegistry {
-		globalRegistryPublicDNS = globalRegistryRoute53FQDN
+	var globalRegistryPublicDNS string
+	if !terraformConfig.StandaloneRegistry.UseAuthGlobalRegistry {
+		globalRegistryPublicDNS = nonAuthGlobalRegistryRoute53FQDN
+	} else {
+		globalRegistryPublicDNS = authGlobalRegistryRoute53FQDN
 	}
 
 	file = sanity.OpenFile(file, keyPath)
@@ -177,5 +187,5 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 		return "", "", "", err
 	}
 
-	return authRegistryPublicDNS, nonAuthRegistryPublicDNS, globalRegistryPublicDNS, nil
+	return authRegistryRoute53FQDN, nonAuthRegistryPublicDNS, globalRegistryPublicDNS, nil
 }

--- a/framework/set/resources/registries/createRegistry/auth-registry.sh
+++ b/framework/set/resources/registries/createRegistry/auth-registry.sh
@@ -49,11 +49,21 @@ create_registry() {
         sudo mkdir -p /home/${USER}/auth
         sudo htpasswd -Bbn ${REGISTRY_USER} ${REGISTRY_PASS} | sudo tee /home/${USER}/auth/htpasswd
 
-        sudo mkdir -p /home/${USER}/certs
-        sudo mv $FULL_CHAIN_PATH /home/${USER}/certs/domain.crt
-        sudo mv $CERT_KEY_PATH /home/${USER}/certs/domain.key
-        sudo chmod 644 /home/${USER}/certs/domain.crt
-        sudo chmod 600 /home/${USER}/certs/domain.key
+        if [ -n "${ROUTE53_FQDN}" ]; then
+            sudo mkdir -p /home/${USER}/certs
+            sudo mv $FULL_CHAIN_PATH /home/${USER}/certs/domain.crt
+            sudo mv $CERT_KEY_PATH /home/${USER}/certs/domain.key
+            sudo chmod 644 /home/${USER}/certs/domain.crt
+            sudo chmod 600 /home/${USER}/certs/domain.key
+        else
+            echo "Creating a self-signed certificate..."
+            sudo mkdir -p /home/${USER}/certs
+            sudo openssl req -newkey rsa:4096 -nodes -sha256 \
+                -keyout /home/${USER}/certs/domain.key \
+                -addext "subjectAltName = DNS:${REGISTRY_ENDPOINT}" \
+                -x509 -days 365 -out /home/${USER}/certs/domain.crt \
+                -subj "/C=US/ST=CA/L=SUSE/O=Dis/CN=${REGISTRY_ENDPOINT}"
+        fi
 
         echo "Copying the certificate to the /etc/docker/certs.d/${REGISTRY_ENDPOINT} directory..."
         sudo mkdir -p /etc/docker/certs.d/${REGISTRY_ENDPOINT}
@@ -70,6 +80,18 @@ create_registry() {
             -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt \
             -e REGISTRY_HTTP_TLS_KEY=/certs/domain.key \
             -p 443:443 registry:2
+    fi
+
+    if [ -n "${ROUTE53_FQDN}" ]; then
+        echo "Waiting for registry ${REGISTRY_ENDPOINT} to become available..."
+        for i in $(seq 1 30); do
+            if curl -sk --max-time 5 -u "${REGISTRY_USER}:${REGISTRY_PASS}" https://${REGISTRY_ENDPOINT}/v2/ | grep -q '{}'; then
+                echo "Registry is up!"
+                break
+            fi
+            echo "Attempt $i: registry is not ready, retrying in 10s..."
+            sleep 10
+        done
     fi
 
     echo "Logging into private registry ${REGISTRY_ENDPOINT}..."

--- a/framework/set/resources/registries/createRegistry/createRegistry.go
+++ b/framework/set/resources/registries/createRegistry/createRegistry.go
@@ -24,7 +24,8 @@ const (
 
 // CreateAuthenticatedRegistry is a helper function that will create an authenticated registry.
 func CreateAuthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
-	terratestConfig *config.TerratestConfig, rke2AuthRegistryPublicDNS, rke2AuthRegistryRoute53FQDN string) (*os.File, error) {
+	terratestConfig *config.TerratestConfig, rke2AuthRegistryPublicDNS, registryType, rke2AuthRegistryRoute53FQDN string,
+	useSecureFQDN bool) (*os.File, error) {
 	userDir, _ := rancher2.SetKeyPath(keypath.RegistryKeyPath, terratestConfig.PathToRepo, terraformConfig.Provider)
 
 	scriptPath := filepath.Join(userDir, terratestConfig.PathToRepo, "/framework/set/resources/registries/createRegistry/auth-registry.sh")
@@ -47,14 +48,14 @@ func CreateAuthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootBody
 	encodedFullChain := base64.StdEncoding.EncodeToString((privateFullChain))
 	encodedCertKey := base64.StdEncoding.EncodeToString((privateCertKey))
 
-	_, provisionerBlockBody := rke2.SSHNullResource(rootBody, terraformConfig, rke2AuthRegistryPublicDNS, authRegistry)
+	_, provisionerBlockBody := rke2.SSHNullResource(rootBody, terraformConfig, rke2AuthRegistryPublicDNS, registryType)
 
 	command := "/tmp/auth-registry.sh " + terraformConfig.Standalone.CertManagerVersion + " " + terraformConfig.StandaloneRegistry.RegistryName + " " + terraformConfig.StandaloneRegistry.RegistryUsername + " " +
 		terraformConfig.StandaloneRegistry.RegistryPassword + " " + terraformConfig.Standalone.RegistryUsername + " " + terraformConfig.Standalone.RegistryPassword + " " +
 		rke2AuthRegistryPublicDNS + " " + terraformConfig.Standalone.RancherTagVersion + " " + terraformConfig.StandaloneRegistry.AssetsPath + " " +
 		terraformConfig.Standalone.OSUser + " " + terraformConfig.Standalone.RancherImage + " " + encodedFullChain + " " + encodedCertKey
 
-	if !terraformConfig.StandaloneRegistry.NonAuthGlobalRegistry {
+	if useSecureFQDN {
 		command += " " + rke2AuthRegistryRoute53FQDN
 	} else {
 		command += " \"\""
@@ -83,7 +84,8 @@ func CreateAuthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootBody
 
 // CreateNonAuthenticatedRegistry is a helper function that will create a non-authenticated registry.
 func CreateNonAuthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
-	terratestConfig *config.TerratestConfig, rke2NonAuthRegistryPublicDNS, registryType string) (*os.File, error) {
+	terratestConfig *config.TerratestConfig, rke2NonAuthRegistryPublicDNS, registryType, rke2NonAuthRegistryRoute53FQDN string,
+	globalRegistry bool) (*os.File, error) {
 	userDir, _ := rancher2.SetKeyPath(keypath.RegistryKeyPath, terratestConfig.PathToRepo, terraformConfig.Provider)
 
 	scriptPath := filepath.Join(userDir, terratestConfig.PathToRepo, "/framework/set/resources/registries/createRegistry/non-auth-registry.sh")
@@ -103,16 +105,28 @@ func CreateNonAuthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootB
 			terraformConfig.Standalone.UpgradedRancherTagVersion + " " + terraformConfig.StandaloneRegistry.UpgradedAssetsPath + " " +
 			terraformConfig.Standalone.OSUser + " " + terraformConfig.Standalone.UpgradedRancherImage
 
+		if globalRegistry {
+			command += " " + rke2NonAuthRegistryRoute53FQDN
+		} else {
+			command += " \"\""
+		}
+
 		if terraformConfig.Standalone.RancherAgentImage != "" {
 			command += " " + terraformConfig.Standalone.RancherAgentImage
 		} else {
 			command += " \"\""
 		}
 	} else {
-		command = "bash -c '/tmp/non-auth-registry.sh " + terraformConfig.StandaloneRegistry.RegistryName + " " + terraformConfig.Standalone.CertManagerVersion + " " +
+		command = "/tmp/non-auth-registry.sh " + terraformConfig.StandaloneRegistry.RegistryName + " " + terraformConfig.Standalone.CertManagerVersion + " " +
 			terraformConfig.Standalone.RegistryUsername + " " + terraformConfig.Standalone.RegistryPassword + " " + rke2NonAuthRegistryPublicDNS + " " +
 			terraformConfig.Standalone.RancherTagVersion + " " + terraformConfig.StandaloneRegistry.AssetsPath + " " + terraformConfig.Standalone.OSUser + " " +
 			terraformConfig.Standalone.RancherImage
+
+		if globalRegistry {
+			command += " " + rke2NonAuthRegistryRoute53FQDN
+		} else {
+			command += " \"\""
+		}
 
 		if terraformConfig.Standalone.RancherAgentImage != "" {
 			command += " " + terraformConfig.Standalone.RancherAgentImage

--- a/framework/set/resources/registries/createRegistry/non-auth-registry.sh
+++ b/framework/set/resources/registries/createRegistry/non-auth-registry.sh
@@ -9,9 +9,15 @@ RANCHER_VERSION=$6
 ASSET_DIR=$7
 USER=$8
 RANCHER_IMAGE=$9
-RANCHER_AGENT_IMAGE=${10}
+ROUTE53_FQDN=${10}
+RANCHER_AGENT_IMAGE=${11}
 
 set -e
+
+REGISTRY_ENDPOINT="${HOST}"
+if [ -n "${ROUTE53_FQDN}" ]; then
+    REGISTRY_ENDPOINT="${ROUTE53_FQDN}"
+fi
 
 docker_login() {
     echo "Logging into Docker Hub..."
@@ -27,13 +33,13 @@ create_registry() {
         sudo mkdir -p /home/${USER}/certs
         sudo openssl req -newkey rsa:4096 -nodes -sha256 \
             -keyout /home/${USER}/certs/domain.key \
-            -addext "subjectAltName = DNS:${HOST}" \
+            -addext "subjectAltName = DNS:${REGISTRY_ENDPOINT}" \
             -x509 -days 365 -out /home/${USER}/certs/domain.crt \
-            -subj "/C=US/ST=CA/L=SUSE/O=Dis/CN=${HOST}"
+            -subj "/C=US/ST=CA/L=SUSE/O=Dis/CN=${REGISTRY_ENDPOINT}"
 
-        echo "Copying the certificate to the /etc/docker/certs.d/${HOST} directory..."
-        sudo mkdir -p /etc/docker/certs.d/${HOST}
-        sudo cp /home/${USER}/certs/domain.crt /etc/docker/certs.d/${HOST}/ca.crt
+        echo "Copying the certificate to the /etc/docker/certs.d/${REGISTRY_ENDPOINT} directory..."
+        sudo mkdir -p /etc/docker/certs.d/${REGISTRY_ENDPOINT}
+        sudo cp /home/${USER}/certs/domain.crt /etc/docker/certs.d/${REGISTRY_ENDPOINT}/ca.crt
 
         echo "Creating a private registry..."
         sudo docker run -d --restart=always --name "${REGISTRY_NAME}" \
@@ -42,6 +48,18 @@ create_registry() {
             -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt \
             -e REGISTRY_HTTP_TLS_KEY=/certs/domain.key \
             -p 443:443 registry:2
+    fi
+
+    if [ -n "${ROUTE53_FQDN}" ]; then
+        echo "Waiting for registry ${REGISTRY_ENDPOINT} to become available..."
+        for i in $(seq 1 30); do
+            if curl -sk --max-time 5 https://${REGISTRY_ENDPOINT}/v2/ | grep -q '{}'; then
+                echo "Registry is up!"
+                break
+            fi
+            echo "Attempt $i: registry is not ready, retrying in 10s..."
+            sleep 10
+        done
     fi
 }
 
@@ -91,8 +109,8 @@ cert_manager_images() {
 
     for IMAGE in "${CERT_MANAGER_IMAGES[@]}"; do
         sudo docker pull ${IMAGE}
-        sudo docker tag ${IMAGE} ${HOST}/${IMAGE}
-        sudo docker push ${HOST}/${IMAGE}
+        sudo docker tag ${IMAGE} ${REGISTRY_ENDPOINT}/${IMAGE}
+        sudo docker push ${REGISTRY_ENDPOINT}/${IMAGE}
     done
 }
 
@@ -113,8 +131,8 @@ copy_images() {
     # So we need to omit that from the source.
     if [[ -n "${RANCHER_AGENT_IMAGE}" ]]; then
         IMAGE_TAG=$(grep -m1 'rancher/rancher-agent:' /home/${USER}/rancher-images.txt | rev | cut -d: -f1 | rev)
-        crane copy "${RANCHER_IMAGE}:${IMAGE_TAG}" "${HOST}/${RANCHER_IMAGE}:${IMAGE_TAG}" --insecure &
-        crane copy "${RANCHER_AGENT_IMAGE}:${IMAGE_TAG}" "${HOST}/${RANCHER_AGENT_IMAGE}:${IMAGE_TAG}" --insecure &
+        crane copy "${RANCHER_IMAGE}:${IMAGE_TAG}" "${REGISTRY_ENDPOINT}/${RANCHER_IMAGE}:${IMAGE_TAG}" --insecure &
+        crane copy "${RANCHER_AGENT_IMAGE}:${IMAGE_TAG}" "${REGISTRY_ENDPOINT}/${RANCHER_AGENT_IMAGE}:${IMAGE_TAG}" --insecure &
     fi
 
     PARALLEL_ACTIONS=10
@@ -122,7 +140,7 @@ copy_images() {
 
     while read -r IMAGE; do
         [[ -z "$IMAGE" ]] && continue
-        crane copy "docker.io/${IMAGE}" "${HOST}/${IMAGE}" --insecure &
+        crane copy "docker.io/${IMAGE}" "${REGISTRY_ENDPOINT}/${IMAGE}" --insecure &
 
         COUNTER=$((COUNTER+1))
         if (( COUNTER % PARALLEL_ACTIONS == 0 )); then
@@ -135,7 +153,7 @@ copy_images() {
     COUNTER=0
     while read -r IMAGE; do
         [[ -z "$IMAGE" ]] && continue
-        crane copy "docker.io/${IMAGE}" "${HOST}/${IMAGE}" --insecure &
+        crane copy "docker.io/${IMAGE}" "${REGISTRY_ENDPOINT}/${IMAGE}" --insecure &
 
         COUNTER=$((COUNTER+1))
         if (( COUNTER % PARALLEL_ACTIONS == 0 )); then
@@ -160,7 +178,7 @@ copy_windows_images() {
         mapfile -t VERSIONS < <(grep -oP "${PATTERN}:\\K[^ ]+" /home/${USER}/rancher-images.txt | tail -n 30)
         for VERSION in "${VERSIONS[@]}"; do
             SRC_IMAGE="docker.io/rancher/${IMAGE_PATTERNS[$PATTERN]}:${VERSION}"
-            DEST_IMAGE="${HOST}/rancher/${IMAGE_PATTERNS[$PATTERN]}:${VERSION}"
+            DEST_IMAGE="${REGISTRY_ENDPOINT}/rancher/${IMAGE_PATTERNS[$PATTERN]}:${VERSION}"
 
             crane copy "${SRC_IMAGE}" "${DEST_IMAGE}" --insecure --platform all &
             COUNTER=$((COUNTER+1))
@@ -171,7 +189,7 @@ copy_windows_images() {
             if [ "${PATTERN}" == "rke2-runtime" ]; then
                 WINS_SUFFIX="-windows-amd64"
                 SRC_IMAGE="docker.io/rancher/${IMAGE_PATTERNS[$PATTERN]}:${VERSION}${WINS_SUFFIX}"
-                DEST_IMAGE="${HOST}/rancher/${IMAGE_PATTERNS[$PATTERN]}:${VERSION}${WINS_SUFFIX}"
+                DEST_IMAGE="${REGISTRY_ENDPOINT}/rancher/${IMAGE_PATTERNS[$PATTERN]}:${VERSION}${WINS_SUFFIX}"
 
                 crane copy "${SRC_IMAGE}" "${DEST_IMAGE}" --insecure --platform all &
 
@@ -188,7 +206,7 @@ copy_windows_images() {
     COUNTER=0
     mapfile -t WINDOWS_IMAGES < /home/${USER}/rancher-windows-images.txt
     for IMAGE in "${WINDOWS_IMAGES[@]}"; do
-        crane copy "docker.io/${IMAGE}" "${HOST}/${IMAGE}" --insecure --platform all &
+        crane copy "docker.io/${IMAGE}" "${REGISTRY_ENDPOINT}/${IMAGE}" --insecure --platform all &
 
         COUNTER=$((COUNTER+1))
         if (( COUNTER % PARALLEL_ACTIONS == 0 )); then
@@ -208,7 +226,7 @@ verify_images() {
     mapfile -t IMAGES < /home/${USER}/rancher-images.txt
     for IMAGE in "${IMAGES[@]}"; do
         {
-            TARGET_IMAGE=${HOST}/${IMAGE}
+            TARGET_IMAGE=${REGISTRY_ENDPOINT}/${IMAGE}
             if sudo docker manifest inspect ${TARGET_IMAGE} >/dev/null 2>&1; then
                 echo "${IMAGE} exists"
             else
@@ -238,12 +256,12 @@ verify_windows_images() {
     mapfile -t WINDOWS_IMAGES < /home/${USER}/rancher-windows-images.txt
     for IMAGE in "${WINDOWS_IMAGES[@]}"; do
         {
-            TARGET_IMAGE=${HOST}/${IMAGE}
+            TARGET_IMAGE=${REGISTRY_ENDPOINT}/${IMAGE}
             if sudo docker manifest inspect ${TARGET_IMAGE} >/dev/null 2>&1; then
                 echo "${IMAGE} exists"
             else
                 echo "${IMAGE} is missing, fixing..."
-                crane copy "docker.io/${IMAGE}" "${HOST}/${IMAGE}" --insecure &
+                crane copy "docker.io/${IMAGE}" "${REGISTRY_ENDPOINT}/${IMAGE}" --insecure &
                 echo "${IMAGE} pushed successfully."
             fi
         } &

--- a/framework/set/resources/registries/rancher/createRancher.go
+++ b/framework/set/resources/registries/rancher/createRancher.go
@@ -38,7 +38,7 @@ func CreateRancher(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Bod
 		terraformConfig.Standalone.RancherTagVersion + " " + terraformConfig.Standalone.ChartVersion + " " +
 		terraformConfig.Standalone.BootstrapPassword + " " + terraformConfig.Standalone.RancherImage + " " + registryPublicDNS
 
-	if !terraformConfig.StandaloneRegistry.NonAuthGlobalRegistry {
+	if terraformConfig.StandaloneRegistry.UseAuthGlobalRegistry {
 		command += " " + terraformConfig.StandaloneRegistry.RegistryUsername + " " + terraformConfig.StandaloneRegistry.RegistryPassword + " " +
 			terraformConfig.Standalone.RegistryUsername + " " + terraformConfig.Standalone.RegistryPassword
 	} else {

--- a/framework/set/resources/registries/rke2/createCluster.go
+++ b/framework/set/resources/registries/rke2/createCluster.go
@@ -75,7 +75,7 @@ func createRKE2Server(rootBody *hclwrite.Body, terraformConfig *config.Terraform
 		terraformConfig.Standalone.RKE2Version + " " + rke2ServerOnePrivateIP + " " + rke2Token + " " +
 		terraformConfig.Standalone.RancherImage + " " + terraformConfig.Standalone.RancherTagVersion + " " + registryPublicDNS
 
-	if !terraformConfig.StandaloneRegistry.NonAuthGlobalRegistry {
+	if terraformConfig.StandaloneRegistry.UseAuthGlobalRegistry {
 		command += " " + terraformConfig.StandaloneRegistry.RegistryUsername + " " + terraformConfig.StandaloneRegistry.RegistryPassword + " " +
 			terraformConfig.Standalone.RegistryUsername + " " + terraformConfig.Standalone.RegistryPassword
 	} else {
@@ -109,7 +109,7 @@ func addRKE2ServerNodes(rootBody *hclwrite.Body, terraformConfig *config.Terrafo
 			terraformConfig.Standalone.RKE2Version + " " + rke2ServerOnePrivateIP + " " + rke2Token + " " +
 			terraformConfig.Standalone.RancherImage + " " + terraformConfig.Standalone.RancherTagVersion + " " + registryPublicDNS
 
-		if !terraformConfig.StandaloneRegistry.NonAuthGlobalRegistry {
+		if terraformConfig.StandaloneRegistry.UseAuthGlobalRegistry {
 			command += " " + terraformConfig.StandaloneRegistry.RegistryUsername + " " + terraformConfig.StandaloneRegistry.RegistryPassword + " " +
 				terraformConfig.Standalone.RegistryUsername + " " + terraformConfig.Standalone.RegistryPassword
 		} else {

--- a/framework/set/resources/upgrade/createMainTF.go
+++ b/framework/set/resources/upgrade/createMainTF.go
@@ -47,7 +47,7 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 	switch {
 	case terraformConfig.Standalone.UpgradeAirgapRancher:
 		logrus.Infof("Updating private registry...")
-		_, err := registry.CreateNonAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, registryNode, nonAuthRegistry)
+		_, err := registry.CreateNonAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, registryNode, nonAuthRegistry, registryNode, true)
 		if err != nil {
 			return err
 		}

--- a/modules/registries/aws/outputs.tf
+++ b/modules/registries/aws/outputs.tf
@@ -1,21 +1,33 @@
 output "auth_registry_public_dns" {
-  value = aws_instance.auth_registry.public_dns
+  value = aws_instance.auth.public_dns
 }
 
 output "non_auth_registry_public_dns" {
-  value = aws_instance.non_auth_registry.public_dns
+  value = aws_instance.non_auth.public_dns
 }
 
-output "global_registry_public_dns" {
-  value = aws_instance.global_registry.public_dns
+output "auth_global_registry_public_dns" {
+  value = aws_instance.auth-global.public_dns
 }
 
-output "global_registry_route_53_fqdn" {
-  value = aws_route53_record.global-mew-tfp-registry.fqdn
+output "nauth_global_registry_public_dns" {
+  value = aws_instance.nauth-global.public_dns
+}
+
+output "auth_registry_route_53_fqdn" {
+  value = aws_route53_record.auth.fqdn
+}
+
+output "auth_global_registry_route_53_fqdn" {
+  value = aws_route53_record.auth_global.fqdn
+}
+
+output "nauth_global_registry_route_53_fqdn" {
+  value = aws_route53_record.nauth_global.fqdn
 }
 
 output "ecr_registry_public_dns" {
-  value = aws_instance.ecr_registry.public_dns
+  value = aws_instance.ecr.public_dns
 }
 
 output "server1_public_dns" {

--- a/tests/infrastructure/clusters/setup_airgap_rke2_cluster.go
+++ b/tests/infrastructure/clusters/setup_airgap_rke2_cluster.go
@@ -60,7 +60,7 @@ func CreateAirgappedRKE2Cluster(t *testing.T, provider string) error {
 
 	file = sanity.OpenFile(file, keyPath)
 	logrus.Infof("Creating registry...")
-	file, err = registry.CreateNonAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, registryPublicIP, nonAuthRegistry)
+	file, err = registry.CreateNonAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, registryPublicIP, nonAuthRegistry, registryPublicIP, false)
 	require.NoError(t, err)
 
 	terraform.InitAndApply(t, terraformOptions)

--- a/tests/infrastructure/clusters/setup_rke2_cluster.go
+++ b/tests/infrastructure/clusters/setup_rke2_cluster.go
@@ -27,7 +27,8 @@ const (
 	serverOnePublicIP = "server1_public_ip"
 	registryPublicIP  = "registry_public_ip"
 
-	nonAuthRegistry = "non_auth_registry"
+	nonAuthRegistry                  = "non_auth_registry"
+	nonAuthGlobalRegistryRoute53FQDN = "nauth_global_registry_route_53_fqdn"
 
 	serverOnePrivateIP   = "server1_private_ip"
 	serverTwoPublicIP    = "server2_public_ip"

--- a/tests/infrastructure/registries/setup_all_registries.go
+++ b/tests/infrastructure/registries/setup_all_registries.go
@@ -25,7 +25,8 @@ const (
 	globalRegistryPublicDNS  = "global_registry_public_dns"
 	ecrRegistryPublicDNS     = "ecr_registry_public_dns"
 
-	globalRegistryRoute53FQDN = "global_registry_route_53_fqdn"
+	authGlobalRegistryRoute53FQDN    = "auth_global_registry_route_53_fqdn"
+	nonAuthGlobalRegistryRoute53FQDN = "nauth_global_registry_route_53_fqdn"
 
 	authRegistry    = "auth_registry"
 	nonAuthRegistry = "non_auth_registry"
@@ -78,26 +79,25 @@ func SetupAllRegistries(t *testing.T, provider string) error {
 	authRegistryPublicDNS := terraform.Output(t, terraformOptions, authRegistryPublicDNS)
 	nonAuthRegistryPublicDNS := terraform.Output(t, terraformOptions, nonAuthRegistryPublicDNS)
 	globalRegistryPublicDNS := terraform.Output(t, terraformOptions, globalRegistryPublicDNS)
-	globalRegistryRoute53FQDN := terraform.Output(t, terraformOptions, globalRegistryRoute53FQDN)
 	ecrRegistryPublicDNS := terraform.Output(t, terraformOptions, ecrRegistryPublicDNS)
 
 	file = sanity.OpenFile(file, keyPath)
 	logrus.Infof("Creating non-authenticated registry...")
-	file, err = registry.CreateNonAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, nonAuthRegistryPublicDNS, nonAuthRegistry)
+	file, err = registry.CreateNonAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, nonAuthRegistryPublicDNS, nonAuthRegistry, "", false)
 	require.NoError(t, err)
 
 	terraform.InitAndApply(t, terraformOptions)
 
 	file = sanity.OpenFile(file, keyPath)
 	logrus.Infof("Creating global registry...")
-	file, err = registry.CreateNonAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, globalRegistryPublicDNS, globalRegistry)
+	file, err = registry.CreateNonAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, globalRegistryPublicDNS, globalRegistry, "", false)
 	require.NoError(t, err)
 
 	terraform.InitAndApply(t, terraformOptions)
 
 	file = sanity.OpenFile(file, keyPath)
 	logrus.Infof("Creating authenticated registry...")
-	file, err = registry.CreateAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, authRegistryPublicDNS, globalRegistryRoute53FQDN)
+	file, err = registry.CreateAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, authRegistryPublicDNS, authRegistry, authRegistryPublicDNS, false)
 	require.NoError(t, err)
 
 	terraform.InitAndApply(t, terraformOptions)

--- a/tests/infrastructure/registries/setup_auth_registry.go
+++ b/tests/infrastructure/registries/setup_auth_registry.go
@@ -57,7 +57,7 @@ func SetupAuthenticatedRegistry(t *testing.T, provider string) error {
 
 	file = sanity.OpenFile(file, keyPath)
 	logrus.Infof("Creating authenticated registry...")
-	file, err = registry.CreateAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, authRegistryPublicDNS, globalRegistryRoute53FQDN)
+	file, err = registry.CreateAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, authRegistryPublicDNS, authRegistry, authRegistryPublicDNS, false)
 	require.NoError(t, err)
 
 	terraform.InitAndApply(t, terraformOptions)

--- a/tests/infrastructure/registries/setup_non_auth_registry.go
+++ b/tests/infrastructure/registries/setup_non_auth_registry.go
@@ -57,7 +57,7 @@ func SetupNonAuthenticatedRegistry(t *testing.T, provider string) error {
 
 	file = sanity.OpenFile(file, keyPath)
 	logrus.Infof("Creating non-authenticated registry...")
-	file, err = registry.CreateNonAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, nonAuthRegistryPublicDNS, nonAuthRegistry)
+	file, err = registry.CreateNonAuthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, nonAuthRegistryPublicDNS, nonAuthRegistry, "", false)
 	require.NoError(t, err)
 
 	terraform.InitAndApply(t, terraformOptions)


### PR DESCRIPTION
This pull request updates the handling of non-authenticated registries to ensure that connections are established using a secure private registry. This enhancement improves overall security and reliability when interacting with registries that do not require authentication.