### PR TITLE
Renaming NonAuthRegistryFQDN to UnauthRegistryFQDN missed from last refactor

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -172,7 +172,7 @@ type StandaloneRegistry struct {
 	ECRPassword                string `json:"ecrPassword,omitempty" yaml:"ecrPassword,omitempty"`
 	Enabled                    bool   `json:"enabled,omitempty" yaml:"enabled,omitempty" default:"false"`
 	GlobalRegistryFQDN         string `json:"globalRegistryFQDN,omitempty" yaml:"globalRegistryFQDN,omitempty"`
-	NonAuthRegistryFQDN        string `json:"nonAuthRegistryFQDN,omitempty" yaml:"nonAuthRegistryFQDN,omitempty"`
+	UnauthRegistryFQDN         string `json:"unauthRegistryFQDN,omitempty" yaml:"unauthRegistryFQDN,omitempty"`
 	RegistryName               string `json:"registryName,omitempty" yaml:"registryName,omitempty"`
 	RegistryPassword           string `json:"registryPassword,omitempty" yaml:"registryPassword,omitempty"`
 	RegistryUsername           string `json:"registryUsername,omitempty" yaml:"registryUsername,omitempty"`

--- a/tests/infrastructure/ranchers/setup/registry/rancher.go
+++ b/tests/infrastructure/ranchers/setup/registry/rancher.go
@@ -62,7 +62,7 @@ func SetupRegistryRancher(t *testing.T, session *session.Session, moduleKeyPath 
 	_, keyPath := rancher2.SetKeyPath(moduleKeyPath, terratestConfig.PathToRepo, terraformConfig.Provider)
 	standaloneTerraformOptions := framework.Setup(t, terraformConfig, terratestConfig, keyPath)
 
-	authRegistry, nonAuthRegistry, globalRegistry, err := registries.CreateMainTF(t, standaloneTerraformOptions, keyPath, rancherConfig, terraformConfig, terratestConfig)
+	authRegistry, unauthRegistry, globalRegistry, err := registries.CreateMainTF(t, standaloneTerraformOptions, keyPath, rancherConfig, terraformConfig, terratestConfig)
 	require.NoError(t, err)
 
 	client, err := ranchersetup.PostRancherSetup(t, standaloneTerraformOptions, rancherConfig, session, terraformConfig.Standalone.RancherHostname, keyPath, false)
@@ -93,5 +93,5 @@ func SetupRegistryRancher(t *testing.T, session *session.Session, moduleKeyPath 
 	err = pods.VerifyClusterPods(client, cluster)
 	require.NoError(t, err)
 
-	return client, authRegistry, nonAuthRegistry, globalRegistry, standaloneTerraformOptions, terraformOptions, cattleConfig
+	return client, authRegistry, unauthRegistry, globalRegistry, standaloneTerraformOptions, terraformOptions, cattleConfig
 }


### PR DESCRIPTION
This pull request completes a missed update from the previous refactor by renaming all remaining instances of NonAuthRegistryFQDN to UnauthRegistryFQDN to maintain naming consistency throughout the codebase.