### PR TITLE
Enhance unauthenticated registries to use a secure FQDN

### DIFF
--- a/framework/set/resources/airgap/createMainTF.go
+++ b/framework/set/resources/airgap/createMainTF.go
@@ -76,7 +76,7 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 
 	logrus.Infof("Creating registry...")
 	file = sanity.OpenFile(file, keyPath)
-	file, err = registry.CreateUnauthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, registryPublicDNS, unauthRegistry, registryPublicDNS, true)
+	file, err = registry.CreateUnauthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, registryPublicDNS, unauthRegistry, registryPublicDNS, false)
 	if err != nil {
 		return "", "", err
 	}

--- a/framework/set/resources/registries/createRegistry/auth-registry.sh
+++ b/framework/set/resources/registries/createRegistry/auth-registry.sh
@@ -50,6 +50,7 @@ create_registry() {
         sudo htpasswd -Bbn ${REGISTRY_USER} ${REGISTRY_PASS} | sudo tee /home/${USER}/auth/htpasswd
 
         if [ -n "${ROUTE53_FQDN}" ]; then
+            echo "Using provided certificates for the registry..."
             sudo mkdir -p /home/${USER}/certs
             sudo mv $FULL_CHAIN_PATH /home/${USER}/certs/domain.crt
             sudo mv $CERT_KEY_PATH /home/${USER}/certs/domain.key

--- a/framework/set/resources/registries/createRegistry/createRegistry.go
+++ b/framework/set/resources/registries/createRegistry/createRegistry.go
@@ -85,7 +85,7 @@ func CreateAuthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootBody
 // CreateUnauthenticatedRegistry is a helper function that will create an unauthenticated registry.
 func CreateUnauthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
 	terratestConfig *config.TerratestConfig, rke2UnauthRegistryPublicDNS, registryType, rke2UnauthRegistryRoute53FQDN string,
-	globalRegistry bool) (*os.File, error) {
+	useSecureFQDN bool) (*os.File, error) {
 	userDir, _ := rancher2.SetKeyPath(keypath.RegistryKeyPath, terratestConfig.PathToRepo, terraformConfig.Provider)
 
 	scriptPath := filepath.Join(userDir, terratestConfig.PathToRepo, "/framework/set/resources/registries/createRegistry/unauth-registry.sh")
@@ -95,6 +95,19 @@ func CreateUnauthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootBo
 		return nil, err
 	}
 
+	privateFullChain, err := os.ReadFile(terraformConfig.PrivateFullChainPath)
+	if err != nil {
+		return nil, err
+	}
+
+	privateCertKey, err := os.ReadFile(terraformConfig.PrivateCertKeyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	encodedFullChain := base64.StdEncoding.EncodeToString((privateFullChain))
+	encodedCertKey := base64.StdEncoding.EncodeToString((privateCertKey))
+
 	_, provisionerBlockBody := rke2.SSHNullResource(rootBody, terraformConfig, rke2UnauthRegistryPublicDNS, registryType)
 
 	var command string
@@ -103,9 +116,9 @@ func CreateUnauthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootBo
 		command = "/tmp/unauth-registry.sh " + terraformConfig.StandaloneRegistry.RegistryName + " " + terraformConfig.Standalone.CertManagerVersion + " " +
 			terraformConfig.Standalone.RegistryUsername + " " + terraformConfig.Standalone.RegistryPassword + " " + rke2UnauthRegistryPublicDNS + " " +
 			terraformConfig.Standalone.UpgradedRancherTagVersion + " " + terraformConfig.StandaloneRegistry.UpgradedAssetsPath + " " +
-			terraformConfig.Standalone.OSUser + " " + terraformConfig.Standalone.UpgradedRancherImage
+			terraformConfig.Standalone.OSUser + " " + terraformConfig.Standalone.UpgradedRancherImage + " " + encodedFullChain + " " + encodedCertKey
 
-		if globalRegistry {
+		if useSecureFQDN {
 			command += " " + rke2UnauthRegistryRoute53FQDN
 		} else {
 			command += " \"\""
@@ -120,9 +133,9 @@ func CreateUnauthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootBo
 		command = "/tmp/unauth-registry.sh " + terraformConfig.StandaloneRegistry.RegistryName + " " + terraformConfig.Standalone.CertManagerVersion + " " +
 			terraformConfig.Standalone.RegistryUsername + " " + terraformConfig.Standalone.RegistryPassword + " " + rke2UnauthRegistryPublicDNS + " " +
 			terraformConfig.Standalone.RancherTagVersion + " " + terraformConfig.StandaloneRegistry.AssetsPath + " " + terraformConfig.Standalone.OSUser + " " +
-			terraformConfig.Standalone.RancherImage
+			terraformConfig.Standalone.RancherImage + " " + encodedFullChain + " " + encodedCertKey
 
-		if globalRegistry {
+		if useSecureFQDN {
 			command += " " + rke2UnauthRegistryRoute53FQDN
 		} else {
 			command += " \"\""

--- a/framework/set/resources/registries/createRegistry/unauth-registry.sh
+++ b/framework/set/resources/registries/createRegistry/unauth-registry.sh
@@ -9,10 +9,26 @@ RANCHER_VERSION=$6
 ASSET_DIR=$7
 USER=$8
 RANCHER_IMAGE=$9
-ROUTE53_FQDN=${10}
-RANCHER_AGENT_IMAGE=${11}
+FULL_CHAIN_FILE=${10}
+CERT_KEY_FILE=${11}
+ROUTE53_FQDN=${12}
+RANCHER_AGENT_IMAGE=${13}
 
 set -e
+
+if [ ! -d "/home/$USER/certs" ]; then
+    echo "Decoding certificate files..."
+    base64 -d <<< "$FULL_CHAIN_FILE" > /home/$USER/fullchain.pem
+    base64 -d <<< "$CERT_KEY_FILE" > /home/$USER/privkey.pem
+
+    chmod 600 /home/$USER/fullchain.pem
+    chmod 600 /home/$USER/privkey.pem
+else
+    echo "Certificate files already exist. Skipping decoding..."
+fi
+
+FULL_CHAIN_PATH=/home/$USER/fullchain.pem
+CERT_KEY_PATH=/home/$USER/privkey.pem
 
 REGISTRY_ENDPOINT="${HOST}"
 if [ -n "${ROUTE53_FQDN}" ]; then
@@ -29,13 +45,22 @@ create_registry() {
     if [ "$(sudo docker ps -q -f name=${REGISTRY_NAME})" ]; then
         echo "Private registry ${REGISTRY_NAME} already exists. Skipping..."
     else
-        echo "Creating a self-signed certificate..."
-        sudo mkdir -p /home/${USER}/certs
-        sudo openssl req -newkey rsa:4096 -nodes -sha256 \
-            -keyout /home/${USER}/certs/domain.key \
-            -addext "subjectAltName = DNS:${REGISTRY_ENDPOINT}" \
-            -x509 -days 365 -out /home/${USER}/certs/domain.crt \
-            -subj "/C=US/ST=CA/L=SUSE/O=Dis/CN=${REGISTRY_ENDPOINT}"
+        if [ -n "${ROUTE53_FQDN}" ]; then
+            echo "Using provided certificates for the registry..."
+            sudo mkdir -p /home/${USER}/certs
+            sudo mv $FULL_CHAIN_PATH /home/${USER}/certs/domain.crt
+            sudo mv $CERT_KEY_PATH /home/${USER}/certs/domain.key
+            sudo chmod 644 /home/${USER}/certs/domain.crt
+            sudo chmod 600 /home/${USER}/certs/domain.key
+        else
+            echo "Creating a self-signed certificate..."
+            sudo mkdir -p /home/${USER}/certs
+            sudo openssl req -newkey rsa:4096 -nodes -sha256 \
+                -keyout /home/${USER}/certs/domain.key \
+                -addext "subjectAltName = DNS:${REGISTRY_ENDPOINT}" \
+                -x509 -days 365 -out /home/${USER}/certs/domain.crt \
+                -subj "/C=US/ST=CA/L=SUSE/O=Dis/CN=${REGISTRY_ENDPOINT}"
+        fi
 
         echo "Copying the certificate to the /etc/docker/certs.d/${REGISTRY_ENDPOINT} directory..."
         sudo mkdir -p /etc/docker/certs.d/${REGISTRY_ENDPOINT}

--- a/framework/set/resources/upgrade/createMainTF.go
+++ b/framework/set/resources/upgrade/createMainTF.go
@@ -47,7 +47,7 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 	switch {
 	case terraformConfig.Standalone.UpgradeAirgapRancher:
 		logrus.Infof("Updating private registry...")
-		_, err := registry.CreateUnauthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, registryNode, unauthRegistry, registryNode, true)
+		_, err := registry.CreateUnauthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, registryNode, unauthRegistry, registryNode, false)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This pull request enhances the handling of unauthenticated registries by ensuring they use a secure Fully Qualified Domain Name (FQDN), improving overall registry security and reliability.