### PR TITLE
Use correct upgraded rancher agent image when updating airgap private registry

### DIFF
--- a/framework/set/resources/registries/createRegistry/createRegistry.go
+++ b/framework/set/resources/registries/createRegistry/createRegistry.go
@@ -125,7 +125,7 @@ func CreateUnauthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootBo
 		}
 
 		if terraformConfig.Standalone.RancherAgentImage != "" {
-			command += " " + terraformConfig.Standalone.RancherAgentImage
+			command += " " + terraformConfig.Standalone.UpgradedRancherAgentImage
 		} else {
 			command += " \"\""
 		}


### PR DESCRIPTION
This pull request ensures that when performing upgrades in airgap environments with a private registry, the Rancher agent image is correctly updated. This prevents issues related to improper agent image usage during the upgrade process.