### PR TITLE
Add support to setup Rancher using a K3s local cluster

### DIFF
--- a/.github/workflows/community-prime-upgrade-test.yaml
+++ b/.github/workflows/community-prime-upgrade-test.yaml
@@ -18,6 +18,14 @@ on:
         required: false
         default: false
         type: boolean
+      local_cluster_type:
+        description: "Local cluster type to setup Rancher"
+        required: true
+        default: "rke2"
+        type: choice
+        options:
+          - k3s
+          - rke2
   workflow_call:
     inputs:
       rancher_version:
@@ -150,6 +158,7 @@ jobs:
             defaultClusterRoleForProjectMembers: "true"
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             enableNetworkPolicy: false
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-path }}"
@@ -197,7 +206,6 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_14 }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.OS_USER }}"

--- a/.github/workflows/day2-ops-rancher2.yaml
+++ b/.github/workflows/day2-ops-rancher2.yaml
@@ -20,6 +20,14 @@ on:
         required: false
         default: false
         type: boolean
+      local_cluster_type:
+        description: "Local cluster type to setup Rancher"
+        required: true
+        default: "rke2"
+        type: choice
+        options:
+          - k3s
+          - rke2
   workflow_call:
     inputs:
       rancher_version:
@@ -181,6 +189,7 @@ jobs:
             defaultClusterRoleForProjectMembers: "true"
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             enableNetworkPolicy: false
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-path }}"
@@ -228,7 +237,6 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.OS_USER }}"
@@ -490,6 +498,7 @@ jobs:
             defaultClusterRoleForProjectMembers: "true"
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             enableNetworkPolicy: false
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-path }}"
@@ -546,7 +555,6 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.OS_USER }}"
@@ -809,6 +817,7 @@ jobs:
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             enableNetworkPolicy: false
             generateV3Token: true
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-path }}"
@@ -856,7 +865,6 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_13 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.OS_USER }}"

--- a/.github/workflows/kdm-test.yaml
+++ b/.github/workflows/kdm-test.yaml
@@ -13,6 +13,14 @@ on:
         required: false
         default: false
         type: boolean
+      local_cluster_type:
+        description: "Local cluster type to setup Rancher"
+        required: true
+        default: "rke2"
+        type: choice
+        options:
+          - k3s
+          - rke2
   workflow_call:
     inputs:
       rancher_version:
@@ -171,6 +179,7 @@ jobs:
             cni: "${{ secrets.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
@@ -212,8 +221,8 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
@@ -454,6 +463,7 @@ jobs:
             cni: "${{ secrets.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
@@ -495,8 +505,8 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
@@ -737,6 +747,7 @@ jobs:
             cni: "${{ secrets.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             generateV3Token: true
             provider: "${{ vars.PROVIDER_AMAZON }}"
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
@@ -779,8 +790,8 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_13 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"

--- a/.github/workflows/local-cluster-k8s-upgrade-test.yaml
+++ b/.github/workflows/local-cluster-k8s-upgrade-test.yaml
@@ -20,6 +20,14 @@ on:
         required: false
         default: false
         type: boolean
+      local_cluster_type:
+        description: "Local cluster type to setup Rancher"
+        required: true
+        default: "rke2"
+        type: choice
+        options:
+          - k3s
+          - rke2
 
 permissions:
   id-token: write
@@ -171,6 +179,7 @@ jobs:
             defaultClusterRoleForProjectMembers: "true"
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             enableNetworkPolicy: false
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-path }}"
@@ -218,8 +227,8 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_14 }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
@@ -470,6 +479,7 @@ jobs:
             defaultClusterRoleForProjectMembers: "true"
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             enableNetworkPolicy: false
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-path }}"
@@ -517,8 +527,8 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_14 }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
@@ -770,6 +780,7 @@ jobs:
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             enableNetworkPolicy: false
             generateV3Token: true
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-path }}"
@@ -817,8 +828,8 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_13 }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_13 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"

--- a/.github/workflows/mcm-test.yaml
+++ b/.github/workflows/mcm-test.yaml
@@ -20,6 +20,14 @@ on:
         required: false
         default: false
         type: boolean
+      local_cluster_type:
+        description: "Local cluster type to setup Rancher"
+        required: true
+        default: "rke2"
+        type: choice
+        options:
+          - k3s
+          - rke2
   workflow_call:
     inputs:
       rancher_version:
@@ -168,6 +176,7 @@ jobs:
             cni: "${{ secrets.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-path }}"
@@ -198,8 +207,8 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
               featureFlags:
                 mcm: "false"
               osUser: "${{ secrets.OS_USER }}"
@@ -424,6 +433,7 @@ jobs:
             cni: "${{ secrets.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-path }}"
@@ -454,8 +464,8 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
               featureFlags:
                 mcm: "false"
               osUser: "${{ secrets.OS_USER }}"
@@ -680,6 +690,7 @@ jobs:
             cni: "${{ secrets.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-path }}"
@@ -710,8 +721,8 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_13 }}${{ vars.K3S_VERSION_SUFFIX }}"
               featureFlags:
                 mcm: "false"
               osUser: "${{ secrets.OS_USER }}"

--- a/.github/workflows/post-release-sanity-upgrade.yaml
+++ b/.github/workflows/post-release-sanity-upgrade.yaml
@@ -13,6 +13,14 @@ on:
         required: false
         default: false
         type: boolean
+      local_cluster_type:
+        description: "Local cluster type to setup Rancher"
+        required: true
+        default: "rke2"
+        type: choice
+        options:
+          - k3s
+          - rke2
   workflow_call:
     inputs:
       rancher_version:
@@ -179,6 +187,7 @@ jobs:
             cni: "${{ secrets.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
@@ -227,8 +236,8 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_14 }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
@@ -238,7 +247,7 @@ jobs:
               registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
               registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
               repo: "${{ secrets.RANCHER_REPO }}"
-              rke2Version: "${{ vars.RKE2_VERSION_2_14 }}"
+              rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
               upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
               upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
               upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
@@ -446,6 +455,7 @@ jobs:
             cni: "${{ secrets.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
@@ -494,8 +504,8 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_14 }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
@@ -715,6 +725,7 @@ jobs:
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             generateV3Token: true
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
@@ -763,8 +774,8 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_14 }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
@@ -985,6 +996,7 @@ jobs:
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             generateV3Token: true
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
@@ -1033,8 +1045,8 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_13 }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_13 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"

--- a/.github/workflows/post-release-sanity.yaml
+++ b/.github/workflows/post-release-sanity.yaml
@@ -13,6 +13,14 @@ on:
         required: false
         default: false
         type: boolean
+      local_cluster_type:
+        description: "Local cluster type to setup Rancher"
+        required: true
+        default: "rke2"
+        type: choice
+        options:
+          - k3s
+          - rke2
   workflow_call:
     inputs:
       rancher_version:
@@ -178,6 +186,7 @@ jobs:
             cni: "${{ secrets.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
@@ -226,8 +235,8 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
@@ -439,6 +448,7 @@ jobs:
             cni: "${{ secrets.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
@@ -487,8 +497,8 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
@@ -702,6 +712,7 @@ jobs:
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             generateV3Token: true
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
@@ -750,8 +761,8 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
@@ -965,6 +976,7 @@ jobs:
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             generateV3Token: true
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
@@ -1013,8 +1025,8 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_13 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"

--- a/.github/workflows/prime-community-upgrade-test.yaml
+++ b/.github/workflows/prime-community-upgrade-test.yaml
@@ -13,6 +13,14 @@ on:
         required: false
         default: false
         type: boolean
+      local_cluster_type:
+        description: "Local cluster type to setup Rancher"
+        required: true
+        default: "rke2"
+        type: choice
+        options:
+          - k3s
+          - rke2
   workflow_call:
     inputs:
       rancher_version:
@@ -163,6 +171,7 @@ jobs:
             defaultClusterRoleForProjectMembers: "true"
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             enableNetworkPolicy: false
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-path }}"
@@ -210,7 +219,6 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_14 }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.OS_USER }}"
@@ -460,6 +468,7 @@ jobs:
             defaultClusterRoleForProjectMembers: "true"
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             enableNetworkPolicy: false
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-path }}"
@@ -507,7 +516,6 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_14 }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.OS_USER }}"

--- a/.github/workflows/sanity-aks-test.yaml
+++ b/.github/workflows/sanity-aks-test.yaml
@@ -228,7 +228,6 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               osUser: "${{ secrets.AZURE_SSH_USER }}"
               osGroup: "${{ secrets.AZURE_SSH_USER }}"
@@ -501,7 +500,6 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               osUser: "${{ secrets.AZURE_SSH_USER }}"
               osGroup: "${{ secrets.AZURE_SSH_USER }}"
@@ -775,7 +773,6 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               osUser: "${{ secrets.AZURE_SSH_USER }}"
               osGroup: "${{ secrets.AZURE_SSH_USER }}"

--- a/.github/workflows/sanity-arm64-test.yaml
+++ b/.github/workflows/sanity-arm64-test.yaml
@@ -20,6 +20,14 @@ on:
         required: false
         default: false
         type: boolean
+      local_cluster_type:
+        description: "Local cluster type to setup Rancher"
+        required: true
+        default: "rke2"
+        type: choice
+        options:
+          - k3s
+          - rke2
 
 permissions:
   id-token: write
@@ -172,6 +180,7 @@ jobs:
             defaultClusterRoleForProjectMembers: "true"
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             enableNetworkPolicy: false
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-path }}"
@@ -219,7 +228,6 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
@@ -474,6 +482,7 @@ jobs:
             defaultClusterRoleForProjectMembers: "true"
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             enableNetworkPolicy: false
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-path }}"
@@ -521,7 +530,6 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
@@ -777,6 +785,7 @@ jobs:
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             enableNetworkPolicy: false
             generateV3Token: true
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-path }}"
@@ -824,7 +833,6 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"

--- a/.github/workflows/sanity-dualstack-test.yaml
+++ b/.github/workflows/sanity-dualstack-test.yaml
@@ -20,6 +20,14 @@ on:
         required: false
         default: false
         type: boolean
+      local_cluster_type:
+        description: "Local cluster type to setup Rancher"
+        required: true
+        default: "rke2"
+        type: choice
+        options:
+          - k3s
+          - rke2
   workflow_call:
     inputs:
       rancher_version:
@@ -182,6 +190,7 @@ jobs:
             defaultClusterRoleForProjectMembers: "true"
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             enableNetworkPolicy: false
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-path }}"
@@ -230,8 +239,8 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.DUAL_STACK_OS_USER }}"
               osGroup: "${{ secrets.DUAL_STACK_OS_GROUP }}"
               rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
@@ -476,6 +485,7 @@ jobs:
             defaultClusterRoleForProjectMembers: "true"
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             enableNetworkPolicy: false
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-path }}"
@@ -524,8 +534,8 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.DUAL_STACK_OS_USER }}"
               osGroup: "${{ secrets.DUAL_STACK_OS_GROUP }}"
               rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
@@ -770,6 +780,7 @@ jobs:
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             enableNetworkPolicy: false
             generateV3Token: true
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-path }}"
@@ -818,8 +829,8 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_13 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.DUAL_STACK_OS_USER }}"
               osGroup: "${{ secrets.DUAL_STACK_OS_GROUP }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"

--- a/.github/workflows/sanity-dualstack-upgrade-test.yaml
+++ b/.github/workflows/sanity-dualstack-upgrade-test.yaml
@@ -20,6 +20,14 @@ on:
         required: false
         default: false
         type: boolean
+      local_cluster_type:
+        description: "Local cluster type to setup Rancher"
+        required: true
+        default: "rke2"
+        type: choice
+        options:
+          - k3s
+          - rke2
   workflow_call:
     inputs:
       rancher_version:
@@ -184,6 +192,7 @@ jobs:
             defaultClusterRoleForProjectMembers: "true"
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             enableNetworkPolicy: false
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-path }}"
@@ -232,8 +241,8 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_14 }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.DUAL_STACK_OS_USER }}"
               osGroup: "${{ secrets.DUAL_STACK_OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
@@ -495,6 +504,7 @@ jobs:
             defaultClusterRoleForProjectMembers: "true"
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             enableNetworkPolicy: false
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-path }}"
@@ -543,8 +553,8 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_14 }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.DUAL_STACK_OS_USER }}"
               osGroup: "${{ secrets.DUAL_STACK_OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
@@ -806,6 +816,7 @@ jobs:
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             enableNetworkPolicy: false
             generateV3Token: true
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-path }}"
@@ -854,8 +865,8 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_13 }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_13 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.DUAL_STACK_OS_USER }}"
               osGroup: "${{ secrets.DUAL_STACK_OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"

--- a/.github/workflows/sanity-eks-test.yaml
+++ b/.github/workflows/sanity-eks-test.yaml
@@ -227,7 +227,6 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
@@ -506,7 +505,6 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
@@ -786,7 +784,6 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"

--- a/.github/workflows/sanity-gke-test.yaml
+++ b/.github/workflows/sanity-gke-test.yaml
@@ -216,7 +216,6 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
@@ -477,7 +476,6 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
@@ -739,7 +737,6 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"

--- a/.github/workflows/sanity-ipv6-hosted-cluster-test.yaml
+++ b/.github/workflows/sanity-ipv6-hosted-cluster-test.yaml
@@ -232,7 +232,6 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               osUser: "${{ secrets.IPV6_OS_USER }}"
               osGroup: "${{ secrets.IPV6_OS_GROUP }}"
@@ -529,7 +528,6 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               osUser: "${{ secrets.IPV6_OS_USER }}"
               osGroup: "${{ secrets.IPV6_OS_GROUP }}"

--- a/.github/workflows/sanity-ipv6-test.yaml
+++ b/.github/workflows/sanity-ipv6-test.yaml
@@ -20,6 +20,14 @@ on:
         required: false
         default: false
         type: boolean
+      local_cluster_type:
+        description: "Local cluster type to setup Rancher"
+        required: true
+        default: "rke2"
+        type: choice
+        options:
+          - k3s
+          - rke2
   workflow_call:
     inputs:
       rancher_version:
@@ -182,6 +190,7 @@ jobs:
             defaultClusterRoleForProjectMembers: "true"
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             enableNetworkPolicy: false
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-path }}"
@@ -230,8 +239,8 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.IPV6_OS_USER }}"
               osGroup: "${{ secrets.IPV6_OS_GROUP }}"
               rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
@@ -476,6 +485,7 @@ jobs:
             defaultClusterRoleForProjectMembers: "true"
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             enableNetworkPolicy: false
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-path }}"
@@ -524,8 +534,8 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.IPV6_OS_USER }}"
               osGroup: "${{ secrets.IPV6_OS_GROUP }}"
               rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
@@ -770,6 +780,7 @@ jobs:
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             enableNetworkPolicy: false
             generateV3Token: true
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-path }}"
@@ -818,8 +829,8 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_13 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.IPV6_OS_USER }}"
               osGroup: "${{ secrets.IPV6_OS_GROUP }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"

--- a/.github/workflows/sanity-ipv6-upgrade-test.yaml
+++ b/.github/workflows/sanity-ipv6-upgrade-test.yaml
@@ -20,6 +20,14 @@ on:
         required: false
         default: false
         type: boolean
+      local_cluster_type:
+        description: "Local cluster type to setup Rancher"
+        required: true
+        default: "rke2"
+        type: choice
+        options:
+          - k3s
+          - rke2
   workflow_call:
     inputs:
       rancher_version:
@@ -184,6 +192,7 @@ jobs:
             defaultClusterRoleForProjectMembers: "true"
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             enableNetworkPolicy: false
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-path }}"
@@ -232,8 +241,8 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_14 }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.IPV6_OS_USER }}"
               osGroup: "${{ secrets.IPV6_OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
@@ -495,6 +504,7 @@ jobs:
             defaultClusterRoleForProjectMembers: "true"
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             enableNetworkPolicy: false
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-path }}"
@@ -543,8 +553,8 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_14 }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.IPV6_OS_USER }}"
               osGroup: "${{ secrets.IPV6_OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
@@ -806,6 +816,7 @@ jobs:
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             enableNetworkPolicy: false
             generateV3Token: true
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-path }}"
@@ -854,8 +865,8 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_13 }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_13 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.IPV6_OS_USER }}"
               osGroup: "${{ secrets.IPV6_OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"

--- a/.github/workflows/sanity-mixed-arch-test.yaml
+++ b/.github/workflows/sanity-mixed-arch-test.yaml
@@ -20,6 +20,14 @@ on:
         required: false
         default: false
         type: boolean
+      local_cluster_type:
+        description: "Local cluster type to setup Rancher"
+        required: true
+        default: "rke2"
+        type: choice
+        options:
+          - k3s
+          - rke2
 
 permissions:
   id-token: write
@@ -171,6 +179,7 @@ jobs:
             defaultClusterRoleForProjectMembers: "true"
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             enableNetworkPolicy: false
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             mixedArchitecture: true
             provider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
@@ -222,8 +231,8 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
@@ -476,6 +485,7 @@ jobs:
             defaultClusterRoleForProjectMembers: "true"
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             enableNetworkPolicy: false
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             mixedArchitecture: true
             provider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
@@ -527,8 +537,8 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"

--- a/.github/workflows/sanity-test.yaml
+++ b/.github/workflows/sanity-test.yaml
@@ -36,6 +36,14 @@ on:
         type: choice
         options:
           - aws
+      local_cluster_type:
+        description: "Local cluster type to setup Rancher"
+        required: true
+        default: "rke2"
+        type: choice
+        options:
+          - k3s
+          - rke2
   workflow_call:
     inputs:
       rancher_version:
@@ -269,6 +277,7 @@ jobs:
             defaultClusterRoleForProjectMembers: "true"
             downstreamClusterProvider: "${{ env.DOWNSTREAM_CLUSTER_PROVIDER }}"
             enableNetworkPolicy: false
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ env.CLOUD_PROVIDER }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-path }}"
@@ -338,7 +347,6 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ env.OS_USER }}"
@@ -672,6 +680,7 @@ jobs:
             defaultClusterRoleForProjectMembers: "true"
             downstreamClusterProvider: "${{ env.DOWNSTREAM_CLUSTER_PROVIDER }}"
             enableNetworkPolicy: false
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ env.CLOUD_PROVIDER }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-path }}"
@@ -741,7 +750,6 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ env.OS_USER }}"
@@ -1073,6 +1081,7 @@ jobs:
             defaultClusterRoleForProjectMembers: "true"
             downstreamClusterProvider: "${{ env.DOWNSTREAM_CLUSTER_PROVIDER }}"
             enableNetworkPolicy: false
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             generateV3Token: true
             provider: "${{ env.CLOUD_PROVIDER }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
@@ -1143,7 +1152,6 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ env.OS_USER }}"
@@ -1478,6 +1486,7 @@ jobs:
             defaultClusterRoleForProjectMembers: "true"
             downstreamClusterProvider: "${{ env.DOWNSTREAM_CLUSTER_PROVIDER }}"
             enableNetworkPolicy: false
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             generateV3Token: true
             provider: "${{ env.CLOUD_PROVIDER }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
@@ -1548,7 +1557,6 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_13 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ env.OS_USER }}"

--- a/.github/workflows/sanity-turtles-off-test.yaml
+++ b/.github/workflows/sanity-turtles-off-test.yaml
@@ -20,6 +20,14 @@ on:
         required: false
         default: false
         type: boolean
+      local_cluster_type:
+        description: "Local cluster type to setup Rancher"
+        required: true
+        default: "rke2"
+        type: choice
+        options:
+          - k3s
+          - rke2
   workflow_call:
     inputs:
       rancher_version:
@@ -184,6 +192,7 @@ jobs:
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             enableNetworkPolicy: false
             generateV3Token: true
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-path }}"
@@ -231,7 +240,6 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_13 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.OS_USER }}"

--- a/.github/workflows/sanity-upgrade-arm64-test.yaml
+++ b/.github/workflows/sanity-upgrade-arm64-test.yaml
@@ -20,6 +20,14 @@ on:
         required: false
         default: false
         type: boolean
+      local_cluster_type:
+        description: "Local cluster type to setup Rancher"
+        required: true
+        default: "rke2"
+        type: choice
+        options:
+          - k3s
+          - rke2
 
 permissions:
   id-token: write
@@ -174,6 +182,7 @@ jobs:
             defaultClusterRoleForProjectMembers: "true"
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             enableNetworkPolicy: false
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-path }}"
@@ -221,7 +230,6 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_14 }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.OS_USER }}"
@@ -484,6 +492,7 @@ jobs:
             defaultClusterRoleForProjectMembers: "true"
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             enableNetworkPolicy: false
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-path }}"
@@ -531,7 +540,6 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_14 }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.OS_USER }}"
@@ -795,6 +803,7 @@ jobs:
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             enableNetworkPolicy: false
             generateV3Token: true
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-path }}"
@@ -842,7 +851,6 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_13 }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_13 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.OS_USER }}"

--- a/.github/workflows/sanity-upgrade-test.yaml
+++ b/.github/workflows/sanity-upgrade-test.yaml
@@ -36,6 +36,14 @@ on:
         type: choice
         options:
           - aws
+      local_cluster_type:
+        description: "Local cluster type to setup Rancher"
+        required: true
+        default: "rke2"
+        type: choice
+        options:
+          - k3s
+          - rke2
   workflow_call:
     inputs:
       rancher_version:
@@ -272,6 +280,7 @@ jobs:
             defaultClusterRoleForProjectMembers: "true"
             downstreamClusterProvider: "${{ env.CLOUD_PROVIDER }}"
             enableNetworkPolicy: false
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ env.CLOUD_PROVIDER }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-path }}"
@@ -341,7 +350,6 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_14 }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ env.OS_USER }}"
@@ -682,6 +690,7 @@ jobs:
             defaultClusterRoleForProjectMembers: "true"
             downstreamClusterProvider: "${{ env.CLOUD_PROVIDER }}"
             enableNetworkPolicy: false
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ env.CLOUD_PROVIDER }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-path }}"
@@ -751,7 +760,6 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_14 }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ env.OS_USER }}"
@@ -1090,6 +1098,7 @@ jobs:
             defaultClusterRoleForProjectMembers: "true"
             downstreamClusterProvider: "${{ env.CLOUD_PROVIDER }}"
             enableNetworkPolicy: false
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             generateV3Token: true
             provider: "${{ env.CLOUD_PROVIDER }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
@@ -1160,7 +1169,6 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_14 }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ env.OS_USER }}"
@@ -1503,6 +1511,7 @@ jobs:
             downstreamClusterProvider: "${{ env.CLOUD_PROVIDER }}"
             enableNetworkPolicy: false
             generateV3Token: true
+            localCluster: "${{ github.event.inputs.local_cluster_type }}"
             provider: "${{ env.CLOUD_PROVIDER }}"
             privateKeyPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-path }}"
@@ -1572,7 +1581,6 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              certType: "${{ vars.CERT_TYPE }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_13 }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_13 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ env.OS_USER }}"

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ terraform:
   cni: "calico"
   defaultClusterRoleForProjectMembers: "true"
   enableNetworkPolicy: false
+  localCluster: ""                          # Values - rke2 or k3s
   provider: ""                              # The following providers are supported: aws | linode | harvester
   privateKeyPath: ""
   privateFullChainPath: ""

--- a/config/config.go
+++ b/config/config.go
@@ -210,6 +210,7 @@ type TerraformConfig struct {
 	ETCD                                *rkev1.ETCD                  `json:"etcd,omitempty" yaml:"etcd,omitempty"`
 	GenerateV3Token                     bool                         `json:"generateV3Token,omitempty" yaml:"generateV3Token,omitempty" default:"false"`
 	LocalAuthEndpoint                   bool                         `json:"localAuthEndpoint,omitempty" yaml:"localAuthEndpoint,omitempty" default:"false"`
+	LocalCluster                        string                       `json:"localCluster,omitempty" yaml:"localCluster,omitempty" default:"rke2"`
 	LocalHostedCluster                  bool                         `json:"localHostedCluster,omitempty" yaml:"localHostedCluster,omitempty"`
 	ARMAchitecture                      bool                         `json:"armArchitecture,omitempty" yaml:"armArchitecture,omitempty" default:"false"`
 	MixedArchitecture                   bool                         `json:"mixedArchitecture,omitempty" yaml:"mixedArchitecture,omitempty" default:"false"`

--- a/defaults/keypath/keypath.go
+++ b/defaults/keypath/keypath.go
@@ -3,6 +3,7 @@ package keypath
 const (
 	AirgapKeyPath        = "/modules/airgap"
 	AirgapRKE2KeyPath    = "/modules/airgapRKE2"
+	AirgapK3SKeyPath     = "/modules/airgapK3S"
 	DualStackKeyPath     = "/modules/dualstack"
 	DualStackRKE2KeyPath = "/modules/dualstackRKE2"
 	DualStackK3SKeyPath  = "/modules/dualstackK3S"

--- a/framework/set/resources/airgap/createMainTF.go
+++ b/framework/set/resources/airgap/createMainTF.go
@@ -9,6 +9,7 @@ import (
 	shepherdConfig "github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/framework/cleanup"
+	"github.com/rancher/tfp-automation/framework/set/resources/airgap/k3s"
 	"github.com/rancher/tfp-automation/framework/set/resources/airgap/rancher"
 	"github.com/rancher/tfp-automation/framework/set/resources/airgap/rke2"
 	"github.com/rancher/tfp-automation/framework/set/resources/providers"
@@ -89,15 +90,23 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 	}
 
 	file = sanity.OpenFile(file, keyPath)
-	logrus.Infof("Creating RKE2 cluster...")
-	file, err = rke2.CreateAirgapRKE2Cluster(file, newFile, rootBody, terraformConfig, terratestConfig, bastionPublicDNS, registryPublicDNS, serverOnePrivateIP, serverTwoPrivateIP, serverThreePrivateIP)
-	if err != nil {
-		return "", "", err
+	if terraformConfig.LocalCluster == "k3s" {
+		logrus.Infof("Creating K3S cluster...")
+		file, err = k3s.CreateAirgapK3SCluster(file, newFile, rootBody, terraformConfig, terratestConfig, bastionPublicDNS, registryPublicDNS, serverOnePrivateIP, serverTwoPrivateIP, serverThreePrivateIP)
+		if err != nil {
+			return "", "", err
+		}
+	} else if terraformConfig.LocalCluster == "rke2" {
+		logrus.Infof("Creating RKE2 cluster...")
+		file, err = rke2.CreateAirgapRKE2Cluster(file, newFile, rootBody, terraformConfig, terratestConfig, bastionPublicDNS, registryPublicDNS, serverOnePrivateIP, serverTwoPrivateIP, serverThreePrivateIP)
+		if err != nil {
+			return "", "", err
+		}
 	}
 
 	_, err = terraform.InitAndApplyE(t, terraformOptions)
 	if err != nil && *rancherConfig.Cleanup {
-		logrus.Infof("Error while creating RKE2 cluster. Cleaning up...")
+		logrus.Infof("Error while creating local cluster. Cleaning up...")
 		cleanup.Cleanup(t, terraformOptions, keyPath)
 		return "", "", err
 	}

--- a/framework/set/resources/airgap/k3s/add-servers.sh
+++ b/framework/set/resources/airgap/k3s/add-servers.sh
@@ -3,14 +3,16 @@
 USER=$1
 GROUP=$2
 VPC_IP=$3
-RKE2_SERVER_ONE_IP=$4
-RKE2_TOKEN=$5
-REGISTRY=$6
-REGISTRY_USERNAME=$7
-REGISTRY_PASSWORD=$8
-RANCHER_IMAGE=$9
-RANCHER_TAG_VERSION=${10}
-RANCHER_AGENT_IMAGE=${11}
+K8S_VERSION=$4
+K3S_SERVER_ONE_IP=$5
+K3S_NEW_SERVER_IP=$6
+K3S_TOKEN=$7
+REGISTRY=$8
+REGISTRY_USERNAME=$9
+REGISTRY_PASSWORD=${10}
+RANCHER_IMAGE=${11}
+RANCHER_TAG_VERSION=${12}
+RANCHER_AGENT_IMAGE=${13}
 PEM_FILE=/home/$USER/airgap.pem
 MAX_SSH_RETRIES=20
 SSH_RETRY_INTERVAL_SECONDS=10
@@ -28,8 +30,9 @@ run_ssh() {
       "export USER=${USER}; \
        export GROUP=${GROUP}; \
        export VPC_IP=${VPC_IP}; \
-       export RKE2_SERVER_ONE_IP=${RKE2_SERVER_ONE_IP}; \
-       export RKE2_TOKEN=${RKE2_TOKEN}; \
+       export K3S_SERVER_ONE_IP=${K3S_SERVER_ONE_IP}; \
+       export K3S_NEW_SERVER_IP=${K3S_NEW_SERVER_IP}; \
+       export K3S_TOKEN=${K3S_TOKEN}; \
        export REGISTRY=${REGISTRY}; \
        export REGISTRY_USERNAME=${REGISTRY_USERNAME}; \
        export REGISTRY_PASSWORD=${REGISTRY_PASSWORD}; $cmd"; then
@@ -52,17 +55,17 @@ run_ssh() {
 }
 
 setup_config() {
-    sudo mkdir -p /etc/rancher/rke2
-    sudo tee /etc/rancher/rke2/config.yaml > /dev/null << EOF
-token: ${RKE2_TOKEN}
+    sudo mkdir -p /etc/rancher/k3s
+    sudo tee /etc/rancher/k3s/config.yaml > /dev/null << EOF
+token: ${K3S_TOKEN}
 system-default-registry: ${REGISTRY}
 tls-san:
-  - ${RKE2_SERVER_ONE_IP}
+  - ${K3S_SERVER_ONE_IP}
 EOF
 }
 
 setup_registry() {
-  sudo tee /etc/rancher/rke2/registries.yaml > /dev/null << EOF
+  sudo tee /etc/rancher/k3s/registries.yaml > /dev/null << EOF
 mirrors:
   "docker.io":
     endpoint:
@@ -97,35 +100,27 @@ dns=none
 EOF
 }
 
-run_ssh "${RKE2_SERVER_ONE_IP}" "sudo mv /home/${USER}/kubectl /usr/local/bin/"
+run_ssh "${K3S_NEW_SERVER_IP}" "sudo mv /home/${USER}/k3s /usr/local/bin/"
 
 configFunction=$(declare -f setup_config)
-run_ssh "${RKE2_SERVER_ONE_IP}" "${configFunction}; setup_config"
+run_ssh "${K3S_NEW_SERVER_IP}" "${configFunction}; setup_config"
 
 setupRegistryFunction=$(declare -f setup_registry)
-run_ssh "${RKE2_SERVER_ONE_IP}" "${setupRegistryFunction}; setup_registry"
+run_ssh "${K3S_NEW_SERVER_IP}" "${setupRegistryFunction}; setup_registry"
 
-run_ssh "${RKE2_SERVER_ONE_IP}" "sudo INSTALL_RKE2_ARTIFACT_PATH=/home/${USER} sh install.sh"
-run_ssh "${RKE2_SERVER_ONE_IP}" "sudo systemctl enable rke2-server"
-run_ssh "${RKE2_SERVER_ONE_IP}" "sudo systemctl start rke2-server"
+run_ssh "${K3S_NEW_SERVER_IP}" "sudo INSTALL_K3S_VERSION=${K8S_VERSION} K3S_TOKEN=${K3S_TOKEN} INSTALL_K3S_EXEC=\"server --server https://${K3S_SERVER_ONE_IP}:6443\" INSTALL_K3S_SKIP_DOWNLOAD=true sh install.sh"
 
 setupDaemonFunction=$(declare -f setup_docker_daemon)
-run_ssh "${RKE2_SERVER_ONE_IP}" "${setupDaemonFunction}; setup_docker_daemon"
-run_ssh "${RKE2_SERVER_ONE_IP}" "sudo systemctl restart docker && sudo systemctl daemon-reload"
+run_ssh "${K3S_NEW_SERVER_IP}" "${setupDaemonFunction}; setup_docker_daemon"
+run_ssh "${K3S_NEW_SERVER_IP}" "sudo systemctl restart docker && sudo systemctl daemon-reload"
 
 setupNetworkingFunction=$(declare -f setup_networking)
-run_ssh "${RKE2_SERVER_ONE_IP}" "${setupNetworkingFunction}; setup_networking"
+run_ssh "${K3S_NEW_SERVER_IP}" "${setupNetworkingFunction}; setup_networking"
 
 if [ -n "$RANCHER_AGENT_IMAGE" ]; then
-  run_ssh "${RKE2_SERVER_ONE_IP}" "sudo docker pull ${REGISTRY}/${RANCHER_IMAGE}:${RANCHER_TAG_VERSION}"
-  run_ssh "${RKE2_SERVER_ONE_IP}" "sudo docker pull ${REGISTRY}/${RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}"
-  run_ssh "${RKE2_SERVER_ONE_IP}" "sudo systemctl restart rke2-server"
+  run_ssh "${K3S_NEW_SERVER_IP}" "sudo docker pull ${REGISTRY}/${RANCHER_IMAGE}:${RANCHER_TAG_VERSION}"
+  run_ssh "${K3S_NEW_SERVER_IP}" "sudo docker pull ${REGISTRY}/${RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}"
+  run_ssh "${K3S_NEW_SERVER_IP}" "sudo systemctl restart k3s"
 fi
 
-run_ssh "${RKE2_SERVER_ONE_IP}" "sudo mkdir -p /home/${USER}/.kube"
-run_ssh "${RKE2_SERVER_ONE_IP}" "sudo cp /etc/rancher/rke2/rke2.yaml /home/${USER}/.kube/config"
-run_ssh "${RKE2_SERVER_ONE_IP}" "sudo chown -R ${USER}:${GROUP} /home/${USER}/.kube"
-
-ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ${PEM_FILE} ${USER}@${RKE2_SERVER_ONE_IP} "sudo cat /home/${USER}/.kube/config" > ~/.kube/config
-sed -i "s|server: https://127.0.0.1:6443|server: https://${RKE2_SERVER_ONE_IP}:6443|" ~/.kube/config
 kubectl get nodes

--- a/framework/set/resources/airgap/k3s/createAirgapCluster.go
+++ b/framework/set/resources/airgap/k3s/createAirgapCluster.go
@@ -25,15 +25,15 @@ const (
 	token          = "token"
 )
 
-// CreateIPv6K3SCluster is a helper function that will create the K3S cluster.
-func CreateIPv6K3SCluster(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
-	terratestConfig *config.TerratestConfig, k3sBastionPublicIP, k3sServerOnePublicIP, k3sServerTwoPublicIP,
-	k3sServerThreePublicIP, k3sServerOnePrivateIP, k3sServerTwoPrivateIP, k3sServerThreePrivateIP string) (*os.File, error) {
-	userDir, _ := rancher2.SetKeyPath(keypath.IPv6KeyPath, terratestConfig.PathToRepo, terraformConfig.Provider)
+// CreateAirgapK3SCluster is a helper function that will create the K3S cluster.
+func CreateAirgapK3SCluster(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig,
+	terratestConfig *config.TerratestConfig, k3sBastionPublicDNS, registryPublicDNS, k3sServerOnePrivateIP, k3sServerTwoPrivateIP,
+	k3sServerThreePrivateIP string) (*os.File, error) {
+	userDir, _ := rancher2.SetKeyPath(keypath.AirgapK3SKeyPath, terratestConfig.PathToRepo, terraformConfig.Provider)
 
 	bastionScriptPath := filepath.Join(userDir, terratestConfig.PathToRepo, "/framework/set/resources/airgap/k3s/bastion.sh")
-	serverScriptPath := filepath.Join(userDir, terratestConfig.PathToRepo, "/framework/set/resources/ipv6/k3s/init-server.sh")
-	newServersScriptPath := filepath.Join(userDir, terratestConfig.PathToRepo, "/framework/set/resources/ipv6/k3s/add-servers.sh")
+	serverScriptPath := filepath.Join(userDir, terratestConfig.PathToRepo, "/framework/set/resources/airgap/k3s/init-server.sh")
+	newServersScriptPath := filepath.Join(userDir, terratestConfig.PathToRepo, "/framework/set/resources/airgap/k3s/add-servers.sh")
 
 	bastionScriptContent, err := os.ReadFile(bastionScriptPath)
 	if err != nil {
@@ -57,7 +57,7 @@ func CreateIPv6K3SCluster(file *os.File, newFile *hclwrite.File, rootBody *hclwr
 
 	encodedPEMFile := base64.StdEncoding.EncodeToString([]byte(privateKey))
 
-	_, provisionerBlockBody := rke2.SSHNullResource(rootBody, terraformConfig, k3sBastionPublicIP, k3sBastion)
+	_, provisionerBlockBody := rke2.SSHNullResource(rootBody, terraformConfig, k3sBastionPublicDNS, k3sBastion)
 
 	command := "/tmp/bastion.sh " + terraformConfig.Standalone.K3SVersion + " " + k3sServerOnePrivateIP + " " +
 		k3sServerTwoPrivateIP + " " + k3sServerThreePrivateIP + " " + terraformConfig.Standalone.OSUser + " " + encodedPEMFile
@@ -70,8 +70,8 @@ func CreateIPv6K3SCluster(file *os.File, newFile *hclwrite.File, rootBody *hclwr
 
 	k3sToken := namegen.AppendRandomString(token)
 
-	createIPv6K3SServer(rootBody, terraformConfig, k3sBastionPublicIP, k3sServerOnePrivateIP, k3sServerOnePublicIP, k3sToken, serverOneScriptContent)
-	addIPv6K3SServerNodes(rootBody, terraformConfig, k3sBastionPublicIP, k3sServerOnePublicIP, k3sServerOnePrivateIP, k3sServerTwoPrivateIP, k3sServerThreePrivateIP, k3sToken, newServersScriptContent)
+	createAirgappedK3SServer(rootBody, terraformConfig, k3sBastionPublicDNS, k3sServerOnePrivateIP, k3sToken, registryPublicDNS, serverOneScriptContent)
+	addAirgappedK3SServerNodes(rootBody, terraformConfig, k3sBastionPublicDNS, k3sServerOnePrivateIP, k3sServerTwoPrivateIP, k3sServerThreePrivateIP, k3sToken, registryPublicDNS, newServersScriptContent)
 
 	_, err = file.Write(newFile.Bytes())
 	if err != nil {
@@ -82,15 +82,19 @@ func CreateIPv6K3SCluster(file *os.File, newFile *hclwrite.File, rootBody *hclwr
 	return file, nil
 }
 
-// createIPv6K3SServer is a helper function that will create the K3S server.
-func createIPv6K3SServer(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, k3sBastionPublicIP, k3sServerOnePrivateIP,
-	k3sServerOnePublicIP, k3sToken string, script []byte) {
-	nullResourceBlockBody, provisionerBlockBody := rke2.SSHNullResource(rootBody, terraformConfig, k3sBastionPublicIP, k3sServerOne)
+// createAirgappedK3SServer is a helper function that will create the K3S server.
+func createAirgappedK3SServer(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, k3sBastionPublicDNS, k3sServerOnePrivateIP,
+	k3sToken, registryPublicDNS string, script []byte) {
+	nullResourceBlockBody, provisionerBlockBody := rke2.SSHNullResource(rootBody, terraformConfig, k3sBastionPublicDNS, k3sServerOne)
 
 	command := "/tmp/init-server.sh " + terraformConfig.Standalone.OSUser + " " + terraformConfig.Standalone.OSGroup + " " +
-		terraformConfig.Standalone.K3SVersion + " " + k3sServerOnePublicIP + " " + k3sServerOnePrivateIP + " " +
-		terraformConfig.Standalone.RegistryUsername + " " + terraformConfig.Standalone.RegistryPassword + " " + k3sToken + " " +
-		terraformConfig.AWSConfig.ClusterCIDR + " " + terraformConfig.AWSConfig.ServiceCIDR
+		terraformConfig.AWSConfig.AWSVpcIP + " " + terraformConfig.Standalone.K3SVersion + " " + k3sServerOnePrivateIP + " " + k3sToken + " " +
+		registryPublicDNS + " " + terraformConfig.Standalone.RegistryUsername + " " + terraformConfig.Standalone.RegistryPassword + " " +
+		terraformConfig.Standalone.RancherImage + " " + terraformConfig.Standalone.RancherTagVersion
+
+	if terraformConfig.Standalone.RancherAgentImage != "" {
+		command += " " + terraformConfig.Standalone.RancherAgentImage
+	}
 
 	provisionerBlockBody.SetAttributeValue(general.Inline, cty.ListVal([]cty.Value{
 		cty.StringVal("printf '" + string(script) + "' > /tmp/init-server.sh"),
@@ -106,21 +110,25 @@ func createIPv6K3SServer(rootBody *hclwrite.Body, terraformConfig *config.Terraf
 	nullResourceBlockBody.SetAttributeRaw(general.DependsOn, server)
 }
 
-// addIPv6K3SServerNodes is a helper function that will add additional K3S server nodes to the initial K3S IPv6 server.
-func addIPv6K3SServerNodes(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, k3sBastionPublicIP, k3sServerOnePublicIP,
-	k3sServerOnePrivateIP, k3sServerTwoPrivateIP, k3sServerThreePrivateIP, k3sToken string, script []byte) {
-	privateIPInstances := []string{k3sServerTwoPrivateIP, k3sServerThreePrivateIP}
+// addAirgappedK3SServerNodes is a helper function that will add additional K3S server nodes to the initial K3S airgapped server.
+func addAirgappedK3SServerNodes(rootBody *hclwrite.Body, terraformConfig *config.TerraformConfig, k3sBastionPublicDNS, k3sServerOnePrivateIP, k3sServerTwoPrivateIP,
+	k3sServerThreePrivateIP, k3sToken, registryPublicDNS string, script []byte) {
+	instances := []string{k3sServerTwoPrivateIP, k3sServerThreePrivateIP}
 	hosts := []string{k3sServerTwo, k3sServerThree}
 
-	for i, privateInstance := range privateIPInstances {
+	for i, instance := range instances {
 		host := hosts[i]
-
-		nullResourceBlockBody, provisionerBlockBody := rke2.SSHNullResource(rootBody, terraformConfig, k3sBastionPublicIP, host)
+		nullResourceBlockBody, provisionerBlockBody := rke2.SSHNullResource(rootBody, terraformConfig, k3sBastionPublicDNS, host)
 
 		command := "/tmp/add-servers.sh " + terraformConfig.Standalone.OSUser + " " + terraformConfig.Standalone.OSGroup + " " +
-			terraformConfig.Standalone.K3SVersion + " " + k3sServerOnePublicIP + " " + k3sServerOnePrivateIP + " " + privateInstance + " " +
-			terraformConfig.Standalone.RegistryUsername + " " + terraformConfig.Standalone.RegistryPassword + " " + k3sToken + " " +
-			terraformConfig.AWSConfig.ClusterCIDR + " " + terraformConfig.AWSConfig.ServiceCIDR
+			terraformConfig.AWSConfig.AWSVpcIP + " " + terraformConfig.Standalone.K3SVersion + " " + k3sServerOnePrivateIP + " " +
+			instance + " " + k3sToken + " " + registryPublicDNS + " " + terraformConfig.Standalone.RegistryUsername + " " +
+			terraformConfig.Standalone.RegistryPassword + " " + terraformConfig.Standalone.RancherImage + " " +
+			terraformConfig.Standalone.RancherTagVersion
+
+		if terraformConfig.Standalone.RancherAgentImage != "" {
+			command += " " + terraformConfig.Standalone.RancherAgentImage
+		}
 
 		provisionerBlockBody.SetAttributeValue(general.Inline, cty.ListVal([]cty.Value{
 			cty.StringVal("printf '" + string(script) + "' > /tmp/add-servers.sh"),

--- a/framework/set/resources/airgap/k3s/init-server.sh
+++ b/framework/set/resources/airgap/k3s/init-server.sh
@@ -3,14 +3,15 @@
 USER=$1
 GROUP=$2
 VPC_IP=$3
-RKE2_SERVER_ONE_IP=$4
-RKE2_TOKEN=$5
-REGISTRY=$6
-REGISTRY_USERNAME=$7
-REGISTRY_PASSWORD=$8
-RANCHER_IMAGE=$9
-RANCHER_TAG_VERSION=${10}
-RANCHER_AGENT_IMAGE=${11}
+K8S_VERSION=$4
+K3S_SERVER_ONE_IP=$5
+K3S_TOKEN=$6
+REGISTRY=$7
+REGISTRY_USERNAME=$8
+REGISTRY_PASSWORD=$9
+RANCHER_IMAGE=${10}
+RANCHER_TAG_VERSION=${11}
+RANCHER_AGENT_IMAGE=${12}
 PEM_FILE=/home/$USER/airgap.pem
 MAX_SSH_RETRIES=20
 SSH_RETRY_INTERVAL_SECONDS=10
@@ -28,8 +29,8 @@ run_ssh() {
       "export USER=${USER}; \
        export GROUP=${GROUP}; \
        export VPC_IP=${VPC_IP}; \
-       export RKE2_SERVER_ONE_IP=${RKE2_SERVER_ONE_IP}; \
-       export RKE2_TOKEN=${RKE2_TOKEN}; \
+       export K3S_SERVER_ONE_IP=${K3S_SERVER_ONE_IP}; \
+       export K3S_TOKEN=${K3S_TOKEN}; \
        export REGISTRY=${REGISTRY}; \
        export REGISTRY_USERNAME=${REGISTRY_USERNAME}; \
        export REGISTRY_PASSWORD=${REGISTRY_PASSWORD}; $cmd"; then
@@ -52,17 +53,18 @@ run_ssh() {
 }
 
 setup_config() {
-    sudo mkdir -p /etc/rancher/rke2
-    sudo tee /etc/rancher/rke2/config.yaml > /dev/null << EOF
-token: ${RKE2_TOKEN}
+    sudo mkdir -p /etc/rancher/k3s
+    sudo tee /etc/rancher/k3s/config.yaml > /dev/null << EOF
+token: ${K3S_TOKEN}
 system-default-registry: ${REGISTRY}
+cluster-init: true
 tls-san:
-  - ${RKE2_SERVER_ONE_IP}
+  - ${K3S_SERVER_ONE_IP}
 EOF
 }
 
 setup_registry() {
-  sudo tee /etc/rancher/rke2/registries.yaml > /dev/null << EOF
+  sudo tee /etc/rancher/k3s/registries.yaml > /dev/null << EOF
 mirrors:
   "docker.io":
     endpoint:
@@ -97,35 +99,34 @@ dns=none
 EOF
 }
 
-run_ssh "${RKE2_SERVER_ONE_IP}" "sudo mv /home/${USER}/kubectl /usr/local/bin/"
+run_ssh "${K3S_SERVER_ONE_IP}" "sudo mv /home/${USER}/kubectl /usr/local/bin/"
+run_ssh "${K3S_SERVER_ONE_IP}" "sudo mv /home/${USER}/k3s /usr/local/bin/"
 
 configFunction=$(declare -f setup_config)
-run_ssh "${RKE2_SERVER_ONE_IP}" "${configFunction}; setup_config"
+run_ssh "${K3S_SERVER_ONE_IP}" "${configFunction}; setup_config"
 
 setupRegistryFunction=$(declare -f setup_registry)
-run_ssh "${RKE2_SERVER_ONE_IP}" "${setupRegistryFunction}; setup_registry"
+run_ssh "${K3S_SERVER_ONE_IP}" "${setupRegistryFunction}; setup_registry"
 
-run_ssh "${RKE2_SERVER_ONE_IP}" "sudo INSTALL_RKE2_ARTIFACT_PATH=/home/${USER} sh install.sh"
-run_ssh "${RKE2_SERVER_ONE_IP}" "sudo systemctl enable rke2-server"
-run_ssh "${RKE2_SERVER_ONE_IP}" "sudo systemctl start rke2-server"
+run_ssh "${K3S_SERVER_ONE_IP}" "sudo INSTALL_K3S_VERSION=${K8S_VERSION} K3S_TOKEN=${K3S_TOKEN} INSTALL_K3S_EXEC=server INSTALL_K3S_SKIP_DOWNLOAD=true sh install.sh"
 
 setupDaemonFunction=$(declare -f setup_docker_daemon)
-run_ssh "${RKE2_SERVER_ONE_IP}" "${setupDaemonFunction}; setup_docker_daemon"
-run_ssh "${RKE2_SERVER_ONE_IP}" "sudo systemctl restart docker && sudo systemctl daemon-reload"
+run_ssh "${K3S_SERVER_ONE_IP}" "${setupDaemonFunction}; setup_docker_daemon"
+run_ssh "${K3S_SERVER_ONE_IP}" "sudo systemctl restart docker && sudo systemctl daemon-reload"
 
 setupNetworkingFunction=$(declare -f setup_networking)
-run_ssh "${RKE2_SERVER_ONE_IP}" "${setupNetworkingFunction}; setup_networking"
+run_ssh "${K3S_SERVER_ONE_IP}" "${setupNetworkingFunction}; setup_networking"
 
 if [ -n "$RANCHER_AGENT_IMAGE" ]; then
-  run_ssh "${RKE2_SERVER_ONE_IP}" "sudo docker pull ${REGISTRY}/${RANCHER_IMAGE}:${RANCHER_TAG_VERSION}"
-  run_ssh "${RKE2_SERVER_ONE_IP}" "sudo docker pull ${REGISTRY}/${RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}"
-  run_ssh "${RKE2_SERVER_ONE_IP}" "sudo systemctl restart rke2-server"
+  run_ssh "${K3S_SERVER_ONE_IP}" "sudo docker pull ${REGISTRY}/${RANCHER_IMAGE}:${RANCHER_TAG_VERSION}"
+  run_ssh "${K3S_SERVER_ONE_IP}" "sudo docker pull ${REGISTRY}/${RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}"
+  run_ssh "${K3S_SERVER_ONE_IP}" "sudo systemctl restart k3s"
 fi
 
-run_ssh "${RKE2_SERVER_ONE_IP}" "sudo mkdir -p /home/${USER}/.kube"
-run_ssh "${RKE2_SERVER_ONE_IP}" "sudo cp /etc/rancher/rke2/rke2.yaml /home/${USER}/.kube/config"
-run_ssh "${RKE2_SERVER_ONE_IP}" "sudo chown -R ${USER}:${GROUP} /home/${USER}/.kube"
+run_ssh "${K3S_SERVER_ONE_IP}" "sudo mkdir -p /home/${USER}/.kube"
+run_ssh "${K3S_SERVER_ONE_IP}" "sudo cp /etc/rancher/k3s/k3s.yaml /home/${USER}/.kube/config"
+run_ssh "${K3S_SERVER_ONE_IP}" "sudo chown -R ${USER}:${GROUP} /home/${USER}/.kube"
 
-ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ${PEM_FILE} ${USER}@${RKE2_SERVER_ONE_IP} "sudo cat /home/${USER}/.kube/config" > ~/.kube/config
-sed -i "s|server: https://127.0.0.1:6443|server: https://${RKE2_SERVER_ONE_IP}:6443|" ~/.kube/config
+ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ${PEM_FILE} ${USER}@${K3S_SERVER_ONE_IP} "sudo cat /home/${USER}/.kube/config" > ~/.kube/config
+sed -i "s|server: https://127.0.0.1:6443|server: https://${K3S_SERVER_ONE_IP}:6443|" ~/.kube/config
 kubectl get nodes

--- a/framework/set/resources/airgap/rke2/add-servers.sh
+++ b/framework/set/resources/airgap/rke2/add-servers.sh
@@ -13,23 +13,44 @@ RANCHER_IMAGE=${10}
 RANCHER_TAG_VERSION=${11}
 RANCHER_AGENT_IMAGE=${12}
 PEM_FILE=/home/$USER/airgap.pem
+MAX_SSH_RETRIES=20
+SSH_RETRY_INTERVAL_SECONDS=10
 
 set -e
 
 run_ssh() {
   local server="$1"
   local cmd="$2"
-  
-  ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i "$PEM_FILE" "$USER@$server" \
-  "export USER=${USER}; \
-   export GROUP=${GROUP}; \
-   export VPC_IP=${VPC_IP}; \
-   export RKE2_SERVER_ONE_IP=${RKE2_SERVER_ONE_IP}; \
-   export RKE2_NEW_SERVER_IP=${RKE2_NEW_SERVER_IP}; \
-   export RKE2_TOKEN=${RKE2_TOKEN}; \
-   export REGISTRY=${REGISTRY}; \
-   export REGISTRY_USERNAME=${REGISTRY_USERNAME}; \
-   export REGISTRY_PASSWORD=${REGISTRY_PASSWORD}; $cmd"
+  local attempt=1
+  local rc=0
+
+  while [ "$attempt" -le "$MAX_SSH_RETRIES" ]; do
+    if ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes -o ConnectTimeout=20 -o ServerAliveInterval=30 -o ServerAliveCountMax=10 -i "$PEM_FILE" "$USER@$server" \
+      "export USER=${USER}; \
+       export GROUP=${GROUP}; \
+       export VPC_IP=${VPC_IP}; \
+       export RKE2_SERVER_ONE_IP=${RKE2_SERVER_ONE_IP}; \
+       export RKE2_NEW_SERVER_IP=${RKE2_NEW_SERVER_IP}; \
+       export RKE2_TOKEN=${RKE2_TOKEN}; \
+       export REGISTRY=${REGISTRY}; \
+       export REGISTRY_USERNAME=${REGISTRY_USERNAME}; \
+       export REGISTRY_PASSWORD=${REGISTRY_PASSWORD}; $cmd"; then
+      return 0
+    else
+      rc=$?
+    fi
+
+    if [ "$attempt" -eq "$MAX_SSH_RETRIES" ]; then
+      echo "SSH command failed after ${MAX_SSH_RETRIES} attempts (exit ${rc})" >&2
+      return "$rc"
+    fi
+
+    echo "SSH command failed on attempt ${attempt}/${MAX_SSH_RETRIES} (exit ${rc}), retrying in ${SSH_RETRY_INTERVAL_SECONDS}s..." >&2
+    sleep "$SSH_RETRY_INTERVAL_SECONDS"
+    attempt=$((attempt + 1))
+  done
+
+  return "$rc"
 }
 
 setup_config() {

--- a/framework/set/resources/airgap/rke2/createAirgapCluster.go
+++ b/framework/set/resources/airgap/rke2/createAirgapCluster.go
@@ -59,11 +59,13 @@ func CreateAirgapRKE2Cluster(file *os.File, newFile *hclwrite.File, rootBody *hc
 
 	_, provisionerBlockBody := rke2.SSHNullResource(rootBody, terraformConfig, rke2BastionPublicDNS, rke2Bastion)
 
+	command := "/tmp/bastion.sh " + terraformConfig.Standalone.RKE2Version + " " + rke2ServerOnePrivateIP + " " +
+		rke2ServerTwoPrivateIP + " " + rke2ServerThreePrivateIP + " " + terraformConfig.Standalone.OSUser + " " + encodedPEMFile
+
 	provisionerBlockBody.SetAttributeValue(general.Inline, cty.ListVal([]cty.Value{
 		cty.StringVal("echo '" + string(bastionScriptContent) + "' > /tmp/bastion.sh"),
 		cty.StringVal("chmod +x /tmp/bastion.sh"),
-		cty.StringVal("bash -c '/tmp/bastion.sh " + terraformConfig.Standalone.RKE2Version + " " + rke2ServerOnePrivateIP + " " +
-			rke2ServerTwoPrivateIP + " " + rke2ServerThreePrivateIP + " " + terraformConfig.Standalone.OSUser + " " + encodedPEMFile + "'"),
+		cty.StringVal(command),
 	}))
 
 	rke2Token := namegen.AppendRandomString(token)
@@ -85,7 +87,7 @@ func createAirgappedRKE2Server(rootBody *hclwrite.Body, terraformConfig *config.
 	rke2Token, registryPublicDNS string, script []byte) {
 	nullResourceBlockBody, provisionerBlockBody := rke2.SSHNullResource(rootBody, terraformConfig, rke2BastionPublicDNS, rke2ServerOne)
 
-	command := "bash -c '/tmp/init-server.sh " + terraformConfig.Standalone.OSUser + " " + terraformConfig.Standalone.OSGroup + " " +
+	command := "/tmp/init-server.sh " + terraformConfig.Standalone.OSUser + " " + terraformConfig.Standalone.OSGroup + " " +
 		terraformConfig.AWSConfig.AWSVpcIP + " " + rke2ServerOnePrivateIP + " " + rke2Token + " " + registryPublicDNS + " " +
 		terraformConfig.Standalone.RegistryUsername + " " + terraformConfig.Standalone.RegistryPassword + " " + terraformConfig.Standalone.RancherImage + " " +
 		terraformConfig.Standalone.RancherTagVersion
@@ -93,8 +95,6 @@ func createAirgappedRKE2Server(rootBody *hclwrite.Body, terraformConfig *config.
 	if terraformConfig.Standalone.RancherAgentImage != "" {
 		command += " " + terraformConfig.Standalone.RancherAgentImage
 	}
-
-	command += "'"
 
 	provisionerBlockBody.SetAttributeValue(general.Inline, cty.ListVal([]cty.Value{
 		cty.StringVal("printf '" + string(script) + "' > /tmp/init-server.sh"),
@@ -120,7 +120,7 @@ func addAirgappedRKE2ServerNodes(rootBody *hclwrite.Body, terraformConfig *confi
 		host := hosts[i]
 		nullResourceBlockBody, provisionerBlockBody := rke2.SSHNullResource(rootBody, terraformConfig, rke2BastionPublicDNS, host)
 
-		command := "bash -c '/tmp/add-servers.sh " + terraformConfig.Standalone.OSUser + " " + terraformConfig.Standalone.OSGroup + " " +
+		command := "/tmp/add-servers.sh " + terraformConfig.Standalone.OSUser + " " + terraformConfig.Standalone.OSGroup + " " +
 			terraformConfig.AWSConfig.AWSVpcIP + " " + rke2ServerOnePrivateIP + " " + instance + " " + rke2Token + " " + registryPublicDNS + " " +
 			terraformConfig.Standalone.RegistryUsername + " " + terraformConfig.Standalone.RegistryPassword + " " + terraformConfig.Standalone.RancherImage + " " +
 			terraformConfig.Standalone.RancherTagVersion
@@ -128,8 +128,6 @@ func addAirgappedRKE2ServerNodes(rootBody *hclwrite.Body, terraformConfig *confi
 		if terraformConfig.Standalone.RancherAgentImage != "" {
 			command += " " + terraformConfig.Standalone.RancherAgentImage
 		}
-
-		command += "'"
 
 		provisionerBlockBody.SetAttributeValue(general.Inline, cty.ListVal([]cty.Value{
 			cty.StringVal("printf '" + string(script) + "' > /tmp/add-servers.sh"),

--- a/framework/set/resources/dualstack/createMainTF.go
+++ b/framework/set/resources/dualstack/createMainTF.go
@@ -9,6 +9,7 @@ import (
 	shepherdConfig "github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/framework/cleanup"
+	"github.com/rancher/tfp-automation/framework/set/resources/dualstack/k3s"
 	"github.com/rancher/tfp-automation/framework/set/resources/dualstack/rke2"
 	tunnel "github.com/rancher/tfp-automation/framework/set/resources/providers"
 	"github.com/rancher/tfp-automation/framework/set/resources/sanity"
@@ -64,15 +65,23 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 	serverThreePublicIP := terraform.Output(t, terraformOptions, serverThreePublicIP)
 
 	file = sanity.OpenFile(file, keyPath)
-	logrus.Infof("Creating RKE2 cluster...")
-	file, err = rke2.CreateRKE2Cluster(file, newFile, rootBody, terraformConfig, terratestConfig, serverOnePublicIP, serverOnePrivateIP, serverTwoPublicIP, serverThreePublicIP)
-	if err != nil {
-		return "", err
+	if terraformConfig.LocalCluster == "k3s" {
+		logrus.Infof("Creating K3S cluster...")
+		file, err = k3s.CreateK3SCluster(file, newFile, rootBody, terraformConfig, terratestConfig, serverOnePublicIP, serverOnePrivateIP, serverTwoPublicIP, serverThreePublicIP)
+		if err != nil {
+			return "", err
+		}
+	} else if terraformConfig.LocalCluster == "rke2" {
+		logrus.Infof("Creating RKE2 cluster...")
+		file, err = rke2.CreateRKE2Cluster(file, newFile, rootBody, terraformConfig, terratestConfig, serverOnePublicIP, serverOnePrivateIP, serverTwoPublicIP, serverThreePublicIP)
+		if err != nil {
+			return "", err
+		}
 	}
 
 	_, err = terraform.InitAndApplyE(t, terraformOptions)
 	if err != nil && *rancherConfig.Cleanup {
-		logrus.Infof("Error while creating RKE2 cluster. Cleaning up...")
+		logrus.Infof("Error while creating local cluster. Cleaning up...")
 		cleanup.Cleanup(t, terraformOptions, keyPath)
 		return "", err
 	}

--- a/framework/set/resources/ipv6/createMainTF.go
+++ b/framework/set/resources/ipv6/createMainTF.go
@@ -9,6 +9,7 @@ import (
 	shepherdConfig "github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/framework/cleanup"
+	"github.com/rancher/tfp-automation/framework/set/resources/ipv6/k3s"
 	"github.com/rancher/tfp-automation/framework/set/resources/ipv6/rke2"
 	"github.com/rancher/tfp-automation/framework/set/resources/providers"
 	"github.com/rancher/tfp-automation/framework/set/resources/sanity"
@@ -71,16 +72,25 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 	serverThreePublicIP := terraform.Output(t, terraformOptions, serverThreePublicIP)
 
 	file = sanity.OpenFile(file, keyPath)
-	logrus.Infof("Creating RKE2 cluster...")
-	file, err = rke2.CreateIPv6RKE2Cluster(file, newFile, rootBody, terraformConfig, terratestConfig, bastionPublicIP, serverOnePublicIP, serverTwoPublicIP, serverThreePublicIP,
-		serverOnePrivateIP, serverTwoPrivateIP, serverThreePrivateIP)
-	if err != nil {
-		return "", err
+	if terraformConfig.LocalCluster == "k3s" {
+		logrus.Infof("Creating K3S cluster...")
+		file, err = k3s.CreateIPv6K3SCluster(file, newFile, rootBody, terraformConfig, terratestConfig, bastionPublicIP, serverOnePublicIP, serverTwoPublicIP, serverThreePublicIP,
+			serverOnePrivateIP, serverTwoPrivateIP, serverThreePrivateIP)
+		if err != nil {
+			return "", err
+		}
+	} else if terraformConfig.LocalCluster == "rke2" {
+		logrus.Infof("Creating RKE2 cluster...")
+		file, err = rke2.CreateIPv6RKE2Cluster(file, newFile, rootBody, terraformConfig, terratestConfig, bastionPublicIP, serverOnePublicIP, serverTwoPublicIP, serverThreePublicIP,
+			serverOnePrivateIP, serverTwoPrivateIP, serverThreePrivateIP)
+		if err != nil {
+			return "", err
+		}
 	}
 
 	_, err = terraform.InitAndApplyE(t, terraformOptions)
 	if err != nil && *rancherConfig.Cleanup {
-		logrus.Infof("Error while creating RKE2 cluster. Cleaning up...")
+		logrus.Infof("Error while creating local cluster. Cleaning up...")
 		cleanup.Cleanup(t, terraformOptions, keyPath)
 		return "", err
 	}

--- a/framework/set/resources/proxy/createMainTF.go
+++ b/framework/set/resources/proxy/createMainTF.go
@@ -10,6 +10,8 @@ import (
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/framework/cleanup"
 	tunnel "github.com/rancher/tfp-automation/framework/set/resources/providers"
+	"github.com/rancher/tfp-automation/framework/set/resources/proxy/k3s"
+	k3sSquid "github.com/rancher/tfp-automation/framework/set/resources/proxy/k3s/squid"
 	"github.com/rancher/tfp-automation/framework/set/resources/proxy/rancher"
 	"github.com/rancher/tfp-automation/framework/set/resources/proxy/rke2"
 	"github.com/rancher/tfp-automation/framework/set/resources/proxy/rke2/squid"
@@ -72,9 +74,16 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 
 	file = sanity.OpenFile(file, keyPath)
 	logrus.Infof("Creating squid proxy...")
-	file, err = squid.CreateSquidProxy(file, newFile, rootBody, terraformConfig, terratestConfig, bastionPublicDNS, serverOnePrivateIP, serverTwoPrivateIP, serverThreePrivateIP)
-	if err != nil {
-		return "", "", err
+	if terraformConfig.LocalCluster == "k3s" {
+		file, err = k3sSquid.CreateSquidProxy(file, newFile, rootBody, terraformConfig, terratestConfig, bastionPublicDNS, serverOnePrivateIP, serverTwoPrivateIP, serverThreePrivateIP)
+		if err != nil {
+			return "", "", err
+		}
+	} else if terraformConfig.LocalCluster == "rke2" {
+		file, err = squid.CreateSquidProxy(file, newFile, rootBody, terraformConfig, terratestConfig, bastionPublicDNS, serverOnePrivateIP, serverTwoPrivateIP, serverThreePrivateIP)
+		if err != nil {
+			return "", "", err
+		}
 	}
 
 	_, err = terraform.InitAndApplyE(t, terraformOptions)
@@ -85,15 +94,23 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 	}
 
 	file = sanity.OpenFile(file, keyPath)
-	logrus.Infof("Creating RKE2 cluster...")
-	file, err = rke2.CreateRKE2Cluster(file, newFile, rootBody, terraformConfig, terratestConfig, bastionPublicDNS, bastionPrivateIP, serverOnePrivateIP, serverTwoPrivateIP, serverThreePrivateIP)
-	if err != nil {
-		return "", "", err
+	if terraformConfig.LocalCluster == "k3s" {
+		logrus.Infof("Creating K3S cluster...")
+		file, err = k3s.CreateK3SCluster(file, newFile, rootBody, terraformConfig, terratestConfig, bastionPublicDNS, bastionPrivateIP, serverOnePrivateIP, serverTwoPrivateIP, serverThreePrivateIP)
+		if err != nil {
+			return "", "", err
+		}
+	} else if terraformConfig.LocalCluster == "rke2" {
+		logrus.Infof("Creating RKE2 cluster...")
+		file, err = rke2.CreateRKE2Cluster(file, newFile, rootBody, terraformConfig, terratestConfig, bastionPublicDNS, bastionPrivateIP, serverOnePrivateIP, serverTwoPrivateIP, serverThreePrivateIP)
+		if err != nil {
+			return "", "", err
+		}
 	}
 
 	_, err = terraform.InitAndApplyE(t, terraformOptions)
 	if err != nil && *rancherConfig.Cleanup {
-		logrus.Infof("Error while creating RKE2 cluster. Cleaning up...")
+		logrus.Infof("Error while creating local cluster. Cleaning up...")
 		cleanup.Cleanup(t, terraformOptions, keyPath)
 		return "", "", err
 	}

--- a/framework/set/resources/sanity/createMainTF.go
+++ b/framework/set/resources/sanity/createMainTF.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rancher/tfp-automation/defaults/configs"
 	"github.com/rancher/tfp-automation/defaults/providers"
 	"github.com/rancher/tfp-automation/framework/cleanup"
+	"github.com/rancher/tfp-automation/framework/set/resources/k3s"
 	tunnel "github.com/rancher/tfp-automation/framework/set/resources/providers"
 	"github.com/rancher/tfp-automation/framework/set/resources/rke2"
 	"github.com/rancher/tfp-automation/framework/set/resources/sanity/rancher"
@@ -82,15 +83,23 @@ func CreateMainTF(t *testing.T, terraformOptions *terraform.Options, keyPath str
 	serverThreePublicIP := terraform.Output(t, terraformOptions, serverThreePublicIP)
 
 	file = OpenFile(file, keyPath)
-	logrus.Infof("Creating RKE2 cluster...")
-	file, err = rke2.CreateRKE2Cluster(file, newFile, rootBody, terraformConfig, terratestConfig, serverOnePublicIP, serverOnePrivateIP, serverTwoPublicIP, serverThreePublicIP)
-	if err != nil {
-		return "", err
+	if terraformConfig.LocalCluster == "k3s" {
+		logrus.Infof("Creating K3S cluster...")
+		file, err = k3s.CreateK3SCluster(file, newFile, rootBody, terraformConfig, terratestConfig, serverOnePublicIP, serverOnePrivateIP, serverTwoPublicIP, serverThreePublicIP)
+		if err != nil {
+			return "", err
+		}
+	} else if terraformConfig.LocalCluster == "rke2" {
+		logrus.Infof("Creating RKE2 cluster...")
+		file, err = rke2.CreateRKE2Cluster(file, newFile, rootBody, terraformConfig, terratestConfig, serverOnePublicIP, serverOnePrivateIP, serverTwoPublicIP, serverThreePublicIP)
+		if err != nil {
+			return "", err
+		}
 	}
 
 	_, err = terraform.InitAndApplyE(t, terraformOptions)
 	if err != nil && *rancherConfig.Cleanup {
-		logrus.Infof("Error while creating RKE2 cluster. Cleaning up...")
+		logrus.Infof("Error while creating local cluster. Cleaning up...")
 		cleanup.Cleanup(t, terraformOptions, keyPath)
 		return "", err
 	}

--- a/framework/set/resources/sanity/rancher/createRancher.go
+++ b/framework/set/resources/sanity/rancher/createRancher.go
@@ -51,7 +51,8 @@ func CreateRancher(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Bod
 		terraformConfig.Standalone.Repo + " " + terraformConfig.Standalone.CertManagerVersion + " " +
 		terraformConfig.Standalone.RancherHostname + " " + terraformConfig.Standalone.RancherTagVersion + " " +
 		terraformConfig.Standalone.ChartVersion + " " + terraformConfig.Standalone.BootstrapPassword + " " +
-		terraformConfig.Standalone.RancherImage + " " + encodedFullChain + " " + encodedCertKey
+		terraformConfig.Standalone.RancherImage + " " + encodedFullChain + " " + encodedCertKey + " " +
+		terraformConfig.LocalCluster
 
 	if terraformConfig.Standalone.RancherAgentImage != "" {
 		command += " " + terraformConfig.Standalone.RancherAgentImage

--- a/framework/set/resources/sanity/rancher/setup.sh
+++ b/framework/set/resources/sanity/rancher/setup.sh
@@ -10,10 +10,11 @@ BOOTSTRAP_PASSWORD=$7
 RANCHER_IMAGE=$8
 FULL_CHAIN_FILE=$9
 CERT_KEY_FILE=${10}
-RANCHER_AGENT_IMAGE=${11}
-TURTLES=${12}
-MCM=${13}
-PARTNER_RC=${14}
+LOCAL_CLUSTER_TYPE=${11}
+RANCHER_AGENT_IMAGE=${12}
+TURTLES=${13}
+MCM=${14}
+PARTNER_RC=${15}
 
 USER=$(whoami)
 
@@ -279,7 +280,13 @@ ipv6_cordns_update() {
         [[ "${ID}" == "opensuse-leap" || "${ID}" == "sles" ]] && sudo zypper install  -y jq
 
         echo "Updating CoreDNS configmap for IPv6"
-        kubectl -n kube-system get cm rke2-coredns-rke2-coredns -o json  \
+        if [[ "$LOCAL_CLUSTER_TYPE" == "rke2" ]]; then
+            COREDNS_NAME="rke2-coredns-rke2-coredns"
+        elif [[ "$LOCAL_CLUSTER_TYPE" == "k3s" ]]; then
+            COREDNS_NAME="coredns"
+        fi
+
+        kubectl -n kube-system get cm ${COREDNS_NAME} -o json  \
         | jq '.data.Corefile |= sub("forward\\s+\\.\\s+/etc/resolv\\.conf"; "forward  . 2001:4860:4860::8888")' \
         | kubectl apply -f -
         

--- a/modules/airgapK3S/aws/main.tf
+++ b/modules/airgapK3S/aws/main.tf
@@ -1,0 +1,1 @@
+// Leave blank - main.tf will be set during testing

--- a/modules/airgapK3S/aws/outputs.tf
+++ b/modules/airgapK3S/aws/outputs.tf
@@ -1,0 +1,19 @@
+output "registry_public_ip" {
+  value = aws_instance.registry.public_ip
+}
+
+output "bastion_public_ip" {
+    value = aws_instance.bastion.public_ip
+}
+
+output "server1_private_ip" {
+  value = aws_instance.server1.private_ip
+}
+
+output "server2_private_ip" {
+  value = aws_instance.server2.private_ip
+}
+
+output "server3_private_ip" {
+  value = aws_instance.server3.private_ip
+}

--- a/tests/sanity/README.md
+++ b/tests/sanity/README.md
@@ -37,6 +37,7 @@ terraform:
   defaultClusterRoleForProjectMembers: "true"     # REQUIRED - leave value as true
   downstreamClusterProvider: ""                   # REQUIRED - can be aws, azure, linode, vsphere
   enableNetworkPolicy: false                      # REQUIRED - values are true or false -  can leave as false
+  localCluster: ""                                # REQUIRED - values are either rke2 or k3s
   mixedArchitecture:                              # OPTIONAL - set to true if you want mixed architecture
   provider: "aws"
   privateKeyPath: ""                              # REQUIRED - specify private key that will be used to access created instances


### PR DESCRIPTION
This pull request adds functionality to set up Rancher using a local K3s cluster, enabling users to deploy and manage Rancher in a lightweight, self-contained environment for testing or development.