### PR TITLE
Update K3s cluster creation to use /etc/rancher/k3s/config.yaml

### DIFF
--- a/framework/set/resources/dualstack/k3s/add-servers.sh
+++ b/framework/set/resources/dualstack/k3s/add-servers.sh
@@ -42,7 +42,14 @@ retryCmd() {
 sudo hostnamectl set-hostname ${K3S_NEW_SERVER_IP}
 
 sudo mkdir -p /etc/rancher/k3s
-sudo touch /etc/rancher/k3s/registries.yaml
+
+echo "token: ${K3S_TOKEN}
+write-kubeconfig-mode: 644
+cluster-cidr: ${CLUSTER_CIDR}
+service-cidr: ${SERVICE_CIDR}
+flannel-ipv6-masq: true
+tls-san:
+  - ${K3S_SERVER_IP}" | sudo tee /etc/rancher/k3s/config.yaml > /dev/null
 
 echo "mirrors:
   docker.io:
@@ -60,4 +67,4 @@ configs:
 
 retryCmd curl -fsSL --max-time 30 -o install.sh https://get.k3s.io
 chmod +x install.sh
-retryCmd sudo INSTALL_K3S_VERSION=${K8S_VERSION} K3S_TOKEN=${K3S_TOKEN} INSTALL_K3S_EXEC="server --server https://${K3S_SERVER_IP}:6443 --cluster-cidr=${CLUSTER_CIDR} --service-cidr=${SERVICE_CIDR}" sh install.sh
+retryCmd sudo INSTALL_K3S_VERSION=${K8S_VERSION} K3S_TOKEN=${K3S_TOKEN} INSTALL_K3S_EXEC="server --server https://${K3S_SERVER_IP}:6443" sh install.sh

--- a/framework/set/resources/dualstack/k3s/init-server.sh
+++ b/framework/set/resources/dualstack/k3s/init-server.sh
@@ -55,7 +55,15 @@ echo "$(cat kubectl.sha256) kubectl" | sha256sum -c
 sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 
 sudo mkdir -p /etc/rancher/k3s
-sudo touch /etc/rancher/k3s/registries.yaml
+
+echo "token: ${K3S_TOKEN}
+write-kubeconfig-mode: 644
+cluster-cidr: ${CLUSTER_CIDR}
+service-cidr: ${SERVICE_CIDR}
+cluster-init: true
+flannel-ipv6-masq: true
+tls-san:
+  - ${K3S_SERVER_IP}" | sudo tee /etc/rancher/k3s/config.yaml > /dev/null
 
 echo "mirrors:
   docker.io:
@@ -73,7 +81,7 @@ configs:
 
 retryCmd curl -fsSL --max-time 30 -o install.sh https://get.k3s.io
 chmod +x install.sh
-retryCmd sudo INSTALL_K3S_VERSION=${K8S_VERSION} K3S_TOKEN=${K3S_TOKEN} INSTALL_K3S_EXEC="server --cluster-init --cluster-cidr=${CLUSTER_CIDR} --service-cidr=${SERVICE_CIDR}" sh install.sh
+retryCmd sudo INSTALL_K3S_VERSION=${K8S_VERSION} K3S_TOKEN=${K3S_TOKEN} INSTALL_K3S_EXEC=server sh install.sh
 
 sudo mkdir -p /home/${USER}/.kube
 sudo chown ${USER}:${GROUP} /etc/rancher/k3s/k3s.yaml

--- a/framework/set/resources/k3s/add-servers.sh
+++ b/framework/set/resources/k3s/add-servers.sh
@@ -40,7 +40,10 @@ retryCmd() {
 sudo hostnamectl set-hostname ${K3S_NEW_SERVER_IP}
 
 sudo mkdir -p /etc/rancher/k3s
-sudo touch /etc/rancher/k3s/registries.yaml
+
+echo "token: ${K3S_TOKEN}
+tls-san:
+  - ${K3S_SERVER_IP}" | sudo tee /etc/rancher/k3s/config.yaml > /dev/null
 
 echo "mirrors:
   docker.io:

--- a/framework/set/resources/k3s/init-server.sh
+++ b/framework/set/resources/k3s/init-server.sh
@@ -39,7 +39,11 @@ retryCmd() {
 sudo hostnamectl set-hostname ${K3S_SERVER_IP}
 
 sudo mkdir -p /etc/rancher/k3s
-sudo touch /etc/rancher/k3s/registries.yaml
+
+echo "token: ${K3S_TOKEN}
+cluster-init: true
+tls-san:
+  - ${K3S_SERVER_IP}" | sudo tee /etc/rancher/k3s/config.yaml > /dev/null
 
 echo "mirrors:
   docker.io:
@@ -57,7 +61,7 @@ configs:
 
 retryCmd curl -fsSL --max-time 30 -o install.sh https://get.k3s.io
 chmod +x install.sh
-retryCmd sudo INSTALL_K3S_VERSION=${K8S_VERSION} K3S_TOKEN=${K3S_TOKEN} INSTALL_K3S_EXEC="server --cluster-init" sh install.sh
+retryCmd sudo INSTALL_K3S_VERSION=${K8S_VERSION} K3S_TOKEN=${K3S_TOKEN} INSTALL_K3S_EXEC=server sh install.sh
 
 sudo mkdir -p /home/${USER}/.kube
 sudo chown ${USER}:${GROUP} /etc/rancher/k3s/k3s.yaml


### PR DESCRIPTION
This PR updates the K3s cluster creation process to utilize the /etc/rancher/k3s/config.yaml configuration file. By standardizing on this file, the configuration becomes more consistent and easier to manage, aligning with best practices for K3s deployments.