### PR TITLE
Add missing ingress.tls.source=secret flag in Rancher upgrade.sh script

### DIFF
--- a/framework/set/resources/sanity/rancher/upgrade.sh
+++ b/framework/set/resources/sanity/rancher/upgrade.sh
@@ -83,6 +83,7 @@ upgrade_default_rancher() {
                                                                                         --set 'extraEnv[2].name=CATTLE_BASE_UI_BRAND' \
                                                                                         --set 'extraEnv[2].value=suse' \
                                                                                         --set agentTLSMode=system-store \
+                                                                                        --set ingress.tls.source=secret \
                                                                                         --devel
 
     else
@@ -94,6 +95,7 @@ upgrade_default_rancher() {
                                                                                         --set 'extraEnv[0].name=CATTLE_SYSTEM_DEFAULT_REGISTRY' \
                                                                                         --set 'extraEnv[0].value=""' \
                                                                                         --set agentTLSMode=system-store \
+                                                                                        --set ingress.tls.source=secret \
                                                                                         --devel
     fi
 }

--- a/framework/set/resources/sanity/rancher/upgradeRancher.go
+++ b/framework/set/resources/sanity/rancher/upgradeRancher.go
@@ -32,7 +32,7 @@ func UpgradeRancher(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Bo
 
 	_, provisionerBlockBody := rke2.SSHNullResource(rootBody, terraformConfig, rke2ServerOnePublicIP, upgradeRancher)
 
-	command := "bash -c '/tmp/upgrade.sh " + terraformConfig.Standalone.UpgradedRancherChartRepository + " " +
+	command := "/tmp/upgrade.sh " + terraformConfig.Standalone.UpgradedRancherChartRepository + " " +
 		terraformConfig.Standalone.UpgradedRancherRepo + " " + terraformConfig.Standalone.RancherHostname + " " +
 		terraformConfig.Standalone.UpgradedRancherTagVersion + " " + terraformConfig.Standalone.UpgradedRancherChartVersion + " " +
 		terraformConfig.Standalone.UpgradedRancherImage
@@ -48,8 +48,6 @@ func UpgradeRancher(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Bo
 	} else {
 		command += " \"\""
 	}
-
-	command += "'"
 
 	provisionerBlockBody.SetAttributeValue(general.Inline, cty.ListVal([]cty.Value{
 		cty.StringVal("printf '" + string(scriptContent) + "' > /tmp/upgrade.sh"),


### PR DESCRIPTION
This PR adds the missing ingress.tls.source=secret flag to the Rancher upgrade.sh script, ensuring that TLS sources are correctly configured during upgrades.