### PR TITLE
Add poll when creating an etcd snapshot to avoid a panic

### DIFF
--- a/.github/workflows/local-cluster-k8s-upgrade-test.yaml
+++ b/.github/workflows/local-cluster-k8s-upgrade-test.yaml
@@ -845,6 +845,7 @@ jobs:
               registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_13 }}"
+              upgradeLocalCluster: true
               upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
               upgradedRancherChartRepository: "${{ env.UPGRADED_RANCHER_HELM_CHART_URL }}"
               upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"

--- a/tests/extensions/provisioning/upgradeLocalCluster.go
+++ b/tests/extensions/provisioning/upgradeLocalCluster.go
@@ -31,9 +31,9 @@ func UpgradeLocalCluster(client *rancher.Client, terraformConfig *config.Terrafo
 	}
 
 	var clusterType string
-	if terraformConfig.Standalone.K3SVersion != "" {
+	if terraformConfig.LocalCluster == "k3s" {
 		clusterType = extClusters.K3SClusterType.String()
-	} else if terraformConfig.Standalone.RKE2Version != "" {
+	} else if terraformConfig.LocalCluster == "rke2" {
 		clusterType = extClusters.RKE2ClusterType.String()
 	}
 
@@ -43,14 +43,14 @@ func UpgradeLocalCluster(client *rancher.Client, terraformConfig *config.Terrafo
 	}
 
 	var updatedCluster *management.Cluster
-	if terraformConfig.Standalone.K3SVersion != "" {
+	if terraformConfig.LocalCluster == "k3s" {
 		updatedCluster = &management.Cluster{
 			K3sConfig: &management.K3sConfig{
 				Version: version[0],
 			},
 			Name: clusterResp.Name,
 		}
-	} else if terraformConfig.Standalone.RKE2Version != "" {
+	} else if terraformConfig.LocalCluster == "rke2" {
 		updatedCluster = &management.Cluster{
 			Rke2Config: &management.Rke2Config{
 				Version: version[0],
@@ -85,9 +85,9 @@ func UpgradeLocalCluster(client *rancher.Client, terraformConfig *config.Terrafo
 		return err
 	}
 
-	if terraformConfig.Standalone.K3SVersion != "" {
+	if terraformConfig.LocalCluster == "k3s" {
 		logrus.Infof("Cluster has been upgraded to: %s", updatedClusterResp.K3sConfig.Version)
-	} else if terraformConfig.Standalone.RKE2Version != "" {
+	} else if terraformConfig.LocalCluster == "rke2" {
 		logrus.Infof("Cluster has been upgraded to: %s", updatedClusterResp.Rke2Config.Version)
 	}
 

--- a/tests/rancher2/snapshot/snapshot.go
+++ b/tests/rancher2/snapshot/snapshot.go
@@ -111,7 +111,13 @@ func snapshotV2Prov(t *testing.T, client *rancher.Client, rancherConfig *rancher
 	postWorkloadName := namegen.AppendRandomString(postWorkload)
 	postDeploymentResp, postServiceResp := createWorkloads(t, client, clusterID, podTemplate, postWorkloadName, isCattleLabeled, DeploymentSteveType)
 
-	snapshotID, err := getSnapshots(client, terraformConfig.ResourcePrefix)
+	var snapshotID []steveV1.SteveAPIObject
+	err = kwait.PollUntilContextTimeout(context.TODO(), timeouts.FiveSecondTimeout, timeouts.FiveMinuteTimeout, true, func(ctx context.Context) (bool, error) {
+		snapshotID, err = getSnapshots(client, terraformConfig.ResourcePrefix)
+		require.NoError(t, err)
+
+		return len(snapshotID) > 0, nil
+	})
 	require.NoError(t, err)
 
 	return snapshotID[0].Name, postDeploymentResp, postServiceResp, err


### PR DESCRIPTION
This pull request adds a polling mechanism when creating an etcd snapshot to prevent potential panics. By introducing this safeguard, the snapshot creation process becomes more reliable and robust.