### PR TITLE
Add cluster type airgap-k3s to the GUI

### DIFF
--- a/tests/infrastructure/cli/cli.go
+++ b/tests/infrastructure/cli/cli.go
@@ -25,6 +25,7 @@ import (
 
 var setupClusterFuncs = map[string]func(*testing.T, string) error{
 	"--airgap-rke2": clusters.CreateAirgappedRKE2Cluster,
+	"--airgap-k3s":  clusters.CreateAirgappedK3SCluster,
 	"--dual-rke2":   clusters.CreateDualStackRKE2Cluster,
 	"--dual-k3s":    clusters.CreateDualStackK3SCluster,
 	"--ipv6-rke2":   clusters.CreateIPv6RKE2Cluster,

--- a/tests/infrastructure/clusters/setup_airgap_k3s_cluster.go
+++ b/tests/infrastructure/clusters/setup_airgap_k3s_cluster.go
@@ -1,0 +1,76 @@
+package clusters
+
+import (
+	"os"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	shepherdConfig "github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/keypath"
+	"github.com/rancher/tfp-automation/framework"
+	"github.com/rancher/tfp-automation/framework/set/resources/airgap/k3s"
+	"github.com/rancher/tfp-automation/framework/set/resources/providers"
+	"github.com/rancher/tfp-automation/framework/set/resources/rancher2"
+	registry "github.com/rancher/tfp-automation/framework/set/resources/registries/createRegistry"
+	"github.com/rancher/tfp-automation/framework/set/resources/sanity"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+// CreateAirgappedK3SCluster is a function that creates an airgap K3S cluster, either via CLI or web application
+func CreateAirgappedK3SCluster(t *testing.T, provider string) error {
+	os.Getenv("CLOUD_PROVIDER_VERSION")
+
+	configPath := os.Getenv("CATTLE_TEST_CONFIG")
+	cattleConfig := shepherdConfig.LoadConfigFromFile(configPath)
+	_, terraformConfig, terratestConfig, _ := config.LoadTFPConfigs(cattleConfig)
+
+	if provider != "" {
+		terraformConfig.Provider = provider
+	}
+
+	_, keyPath := rancher2.SetKeyPath(keypath.AirgapK3SKeyPath, terratestConfig.PathToRepo, terraformConfig.Provider)
+	terraformOptions := framework.Setup(t, terraformConfig, terratestConfig, keyPath)
+
+	var file *os.File
+	file = sanity.OpenFile(file, keyPath)
+	defer file.Close()
+
+	newFile := hclwrite.NewEmptyFile()
+	rootBody := newFile.Body()
+
+	tfBlock := rootBody.AppendNewBlock(terraformConst, nil)
+	tfBlockBody := tfBlock.Body()
+
+	instances := []string{serverOne, serverTwo, serverThree}
+
+	providerTunnel := providers.TunnelToProvider(terraformConfig.Provider)
+	file, err := providerTunnel.CreateNonAirgap(file, newFile, tfBlockBody, rootBody, terraformConfig, terratestConfig, instances)
+	require.NoError(t, err)
+
+	terraform.InitAndApply(t, terraformOptions)
+
+	registryPublicIP := terraform.Output(t, terraformOptions, registryPublicIP)
+	bastionPublicIP := terraform.Output(t, terraformOptions, bastionPublicIP)
+	serverOnePrivateIP := terraform.Output(t, terraformOptions, serverOnePrivateIP)
+	serverTwoPrivateIP := terraform.Output(t, terraformOptions, serverTwoPrivateIP)
+	serverThreePrivateIP := terraform.Output(t, terraformOptions, serverThreePrivateIP)
+
+	file = sanity.OpenFile(file, keyPath)
+	logrus.Infof("Creating registry...")
+	file, err = registry.CreateUnauthenticatedRegistry(file, newFile, rootBody, terraformConfig, terratestConfig, registryPublicIP, unauthRegistry, unauthGlobalRegistryRoute53FQDN, false)
+	require.NoError(t, err)
+
+	terraform.InitAndApply(t, terraformOptions)
+
+	file = sanity.OpenFile(file, keyPath)
+	logrus.Infof("Creating airgap K3S cluster...")
+	file, err = k3s.CreateAirgapK3SCluster(file, newFile, rootBody, terraformConfig, terratestConfig, bastionPublicIP, registryPublicIP, serverOnePrivateIP, serverTwoPrivateIP, serverThreePrivateIP)
+	require.NoError(t, err)
+
+	terraform.InitAndApply(t, terraformOptions)
+
+	return nil
+}

--- a/tests/infrastructure/handlers/provider_handlers.go
+++ b/tests/infrastructure/handlers/provider_handlers.go
@@ -17,7 +17,7 @@ func ProviderHandler(w http.ResponseWriter, r *http.Request) {
 
 		if clustertype != "" {
 			switch clustertype {
-			case "airgap-rke2", "dual-rke2", "dual-k3s", "ipv6-rke2", "ipv6-k3s", "proxy-rke2", "proxy-k3s":
+			case "airgap-rke2", "airgap-k3s", "dual-rke2", "dual-k3s", "ipv6-rke2", "ipv6-k3s", "proxy-rke2", "proxy-k3s":
 				installOptions = []string{"aws"}
 			default:
 				installOptions = []string{"aws", "linode", "vsphere"}

--- a/tests/infrastructure/templates/clustertype.tmpl
+++ b/tests/infrastructure/templates/clustertype.tmpl
@@ -28,6 +28,9 @@
                             <input type="radio" class="form-radio" name="clustertype" value="airgap-rke2" required /> Airgap RKE2
                         </label>
                         <label class="form-label-radio">
+                            <input type="radio" class="form-radio" name="clustertype" value="airgap-k3s" required /> Airgap K3S
+                        </label>
+                        <label class="form-label-radio">
                             <input type="radio" class="form-radio" name="clustertype" value="dual-rke2" required /> Dualstack RKE2
                         </label>
                         <label class="form-label-radio">

--- a/tests/infrastructure/templates/provider.tmpl
+++ b/tests/infrastructure/templates/provider.tmpl
@@ -46,7 +46,7 @@
                     <input type="hidden" id="provider-input" name="provider" required />
                     <div class="provider-select-grid">
                         {{if or (eq .RancherType "airgap") (eq .RancherType "dual") (eq .RancherType "ipv6") (eq .RancherType "registry") (eq .RancherType "proxy")
-                            (eq .ClusterType "airgap-rke2") (eq .ClusterType "dual-rke2") (eq .ClusterType "dual-k3s") (eq .ClusterType "ipv6-rke2") 
+                            (eq .ClusterType "airgap-rke2") (eq .ClusterType "airgap-k3s") (eq .ClusterType "dual-rke2") (eq .ClusterType "dual-k3s") (eq .ClusterType "ipv6-rke2") 
                             (eq .ClusterType "ipv6-k3s") (eq .ClusterType "proxy-rke2") (eq .ClusterType "proxy-k3s") (eq .RegistryType "registries-all")
                             (eq .RegistryType "registries-auth") (eq .RegistryType "registries-nonauth") (eq .RegistryType "registries-ecr") }}
                             <label id="label-aws" class="provider-img-label" onclick="selectProvider('aws')">

--- a/tests/infrastructure/web/web.go
+++ b/tests/infrastructure/web/web.go
@@ -25,6 +25,7 @@ import (
 
 var setupClusterFuncs = map[string]func(*testing.T, string) error{
 	"airgap-rke2": clusters.CreateAirgappedRKE2Cluster,
+	"airgap-k3s":  clusters.CreateAirgappedK3SCluster,
 	"dual-rke2":   clusters.CreateDualStackRKE2Cluster,
 	"dual-k3s":    clusters.CreateDualStackK3SCluster,
 	"ipv6-rke2":   clusters.CreateIPv6RKE2Cluster,


### PR DESCRIPTION
This PR updates the GUI to add support for selecting and managing the "airgap-k3s" cluster type. This enhancement allows users to configure airgap-k3s clusters through the interface.