### PR TITLE
Add v2.14 jobs for applicable Github Action workflows on a weekly schedule

### DIFF
--- a/.github/workflows/community-prime-upgrade-test.yaml
+++ b/.github/workflows/community-prime-upgrade-test.yaml
@@ -324,12 +324,12 @@ jobs:
       - name: Save test result as artifact for weekly summary
         if: always() && github.event_name == 'schedule'
         run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"community-prime-upgrade\", \"job\": \"v2-14\" }" > test-result-community-prime-upgrade-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
+          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"community-prime-upgrade\", \"job\": \"v2-54\" }" > test-result-community-prime-upgrade-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
         if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: test-result-community-prime-upgrade-test-v2-14-${{ github.run_id }}
-          path: test-result-community-prime-upgrade-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
+          name: test-result-community-prime-upgrade-test-v2-15-${{ github.run_id }}
+          path: test-result-community-prime-upgrade-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json

--- a/.github/workflows/day2-ops-rancher2.yaml
+++ b/.github/workflows/day2-ops-rancher2.yaml
@@ -674,6 +674,7 @@ jobs:
   
   v2-14:
     if: |
+      github.event_name == 'schedule' ||
       github.event.inputs.run_all_versions == 'true' ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14')) && contains(github.event.inputs.rancher_version, '-alpha') ||
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.14')) && contains(inputs.rancher_version, '-alpha')

--- a/.github/workflows/kdm-test.yaml
+++ b/.github/workflows/kdm-test.yaml
@@ -619,6 +619,7 @@ jobs:
   
   v2-14:
     if: |
+      github.event_name == 'schedule' ||
       github.event.inputs.run_all_versions == 'true' ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14'))
     name: ${{ github.event.inputs.rancher_version }}

--- a/.github/workflows/local-cluster-k8s-upgrade-test.yaml
+++ b/.github/workflows/local-cluster-k8s-upgrade-test.yaml
@@ -644,6 +644,7 @@ jobs:
   
   v2-14:
     if: |
+      github.event_name == 'schedule' ||
       github.event.inputs.run_all_versions == 'true' ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14'))
     name: ${{ vars.RELEASED_RANCHER_VERSION_2_14 }} -> ${{ github.event.inputs.rancher_version }}

--- a/.github/workflows/mcm-test.yaml
+++ b/.github/workflows/mcm-test.yaml
@@ -568,6 +568,7 @@ jobs:
   
   v2-14:
     if: |
+      github.event_name == 'schedule' ||
       github.event.inputs.run_all_versions == 'true' ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14'))
     name: ${{ github.event.inputs.rancher_version }}

--- a/.github/workflows/sanity-aks-test.yaml
+++ b/.github/workflows/sanity-aks-test.yaml
@@ -589,6 +589,7 @@ jobs:
 
   v2-14:
     if: |
+      github.event_name == 'schedule' ||
       github.event.inputs.run_all_versions == 'true' ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14'))
     name: ${{ github.event.inputs.rancher_version }}

--- a/.github/workflows/sanity-arm64-test.yaml
+++ b/.github/workflows/sanity-arm64-test.yaml
@@ -654,6 +654,7 @@ jobs:
   
   v2-14:
     if: |
+      github.event_name == 'schedule' ||
       github.event.inputs.run_all_versions == 'true' ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14'))
     name: ${{ github.event.inputs.rancher_version }}

--- a/.github/workflows/sanity-eks-test.yaml
+++ b/.github/workflows/sanity-eks-test.yaml
@@ -601,6 +601,7 @@ jobs:
 
   v2-14:
     if: |
+      github.event_name == 'schedule' ||
       github.event.inputs.run_all_versions == 'true' ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14-head'))
     name: ${{ github.event.inputs.rancher_version }}

--- a/.github/workflows/sanity-gke-test.yaml
+++ b/.github/workflows/sanity-gke-test.yaml
@@ -565,6 +565,7 @@ jobs:
 
   v2-14:
     if: |
+      github.event_name == 'schedule' ||
       github.event.inputs.run_all_versions == 'true' ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14-head'))
     name: ${{ github.event.inputs.rancher_version }}

--- a/.github/workflows/sanity-ipv6-hosted-cluster-test.yaml
+++ b/.github/workflows/sanity-ipv6-hosted-cluster-test.yaml
@@ -654,6 +654,8 @@ jobs:
 
   v2-14:
     if: |
+      github.event_name == 'schedule' ||
+      github.event.inputs.run_all_versions == 'true' ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14-head'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest

--- a/.github/workflows/sanity-test.yaml
+++ b/.github/workflows/sanity-test.yaml
@@ -878,6 +878,7 @@ jobs:
   
   v2-14:
     if: |
+      github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14')) && (contains(github.event.inputs.rancher_version, '-alpha') || contains(github.event.inputs.rancher_version, '-rc')) ||
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.14')) && (contains(inputs.rancher_version, '-alpha') || contains(inputs.rancher_version, '-rc'))
     name: ${{ github.event.inputs.rancher_version }}

--- a/.github/workflows/sanity-upgrade-arm64-test.yaml
+++ b/.github/workflows/sanity-upgrade-arm64-test.yaml
@@ -668,6 +668,7 @@ jobs:
   
   v2-14:
     if: |
+      github.event_name == 'schedule' ||
       github.event.inputs.run_all_versions == 'true' ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14'))
     name: ${{ vars.RELEASED_RANCHER_VERSION_2_14 }} -> ${{ github.event.inputs.rancher_version }}

--- a/.github/workflows/sanity-upgrade-test.yaml
+++ b/.github/workflows/sanity-upgrade-test.yaml
@@ -893,6 +893,7 @@ jobs:
 
   v2-14:
     if: |
+      github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14')) && (contains(github.event.inputs.rancher_version, '-alpha') || contains(github.event.inputs.rancher_version, '-rc')) ||
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.14')) && (contains(inputs.rancher_version, '-alpha') || contains(inputs.rancher_version, '-rc'))
     name: ${{ vars.RELEASED_RANCHER_VERSION_2_14 }} -> ${{ github.event.inputs.rancher_version }}


### PR DESCRIPTION
## Summary
Add v2.14 jobs to the applicable GitHub Actions workflows and configure them to run on a weekly schedule.
## What changed
- Added v2.14 job definitions where applicable across GitHub Actions workflows
- Updated workflow scheduling so those jobs run weekly
## Impact
This keeps v2.14 workflow coverage up to date through regular scheduled runs.