### PR TITLE
Fix empty vSphere config during imported cluster creation

### DIFF
--- a/framework/set/provisioning/imported/rke2k3s/getProviderIPAddresses.go
+++ b/framework/set/provisioning/imported/rke2k3s/getProviderIPAddresses.go
@@ -32,6 +32,11 @@ func getProviderIPAddresses(terraformConfig *config.TerraformConfig, terratestCo
 		vsphere.CreateVsphereComputeCluster(rootBody, terraformConfig, dataCenterValue)
 		rootBody.AppendNewline()
 
+		if terraformConfig.VsphereConfig.Pool != "" {
+			vsphere.CreateVsphereResourcePool(rootBody, terraformConfig, dataCenterValue)
+			rootBody.AppendNewline()
+		}
+
 		vsphere.CreateVsphereNetwork(rootBody, terraformConfig, dataCenterValue)
 		rootBody.AppendNewline()
 

--- a/framework/set/resources/providers/vsphere/createResources.go
+++ b/framework/set/resources/providers/vsphere/createResources.go
@@ -55,6 +55,11 @@ func CreateVsphereResources(file *os.File, newFile *hclwrite.File, tfBlockBody, 
 	CreateVsphereComputeCluster(rootBody, terraformConfig, dataCenterValue)
 	rootBody.AppendNewline()
 
+	if terraformConfig.VsphereConfig.Pool != "" {
+		CreateVsphereResourcePool(rootBody, terraformConfig, dataCenterValue)
+		rootBody.AppendNewline()
+	}
+
 	CreateVsphereNetwork(rootBody, terraformConfig, dataCenterValue)
 	rootBody.AppendNewline()
 

--- a/tests/extensions/provisioning/provision.go
+++ b/tests/extensions/provisioning/provision.go
@@ -1,10 +1,13 @@
 package provisioning
 
 import (
+	"errors"
 	"os"
 	"strings"
 	"testing"
 
+	"github.com/gruntwork-io/terratest/modules/retry"
+	"github.com/gruntwork-io/terratest/modules/shell"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/rancher/shepherd/clients/rancher"
@@ -37,7 +40,19 @@ func Provision(t *testing.T, client, standardUserClient *rancher.Client, rancher
 		GoogleDriverImport(t, terraformOptions)
 	}
 
-	terraform.InitAndApply(t, terraformOptions)
+	output, err := terraform.InitAndApplyE(t, terraformOptions)
+	if err != nil {
+		if output == "" {
+			var fatalErr retry.FatalError
+			var cmdErr *shell.ErrWithCmdOutput
+			if errors.As(err, &fatalErr) {
+				if errors.As(fatalErr.Underlying, &cmdErr) {
+					output = cmdErr.Output.Combined()
+				}
+			}
+		}
+		require.NoError(t, err, "terraform apply failed. Output:\n%s", filterTerraformOutput(output))
+	}
 
 	var clusterObjects []*steveV1.SteveAPIObject
 	for _, clusterName := range clusterNames {
@@ -48,4 +63,19 @@ func Provision(t *testing.T, client, standardUserClient *rancher.Client, rancher
 	}
 
 	return clusterObjects, customClusterName
+}
+
+// filterTerraformOutput retains only error-relevant lines from terraform output,
+func filterTerraformOutput(output string) string {
+	var filtered []string
+	for _, line := range strings.Split(output, "\n") {
+		lower := strings.ToLower(line)
+		if strings.Contains(lower, "error") || strings.Contains(lower, "failed") {
+			filtered = append(filtered, line)
+		}
+	}
+	if len(filtered) == 0 {
+		return output
+	}
+	return strings.Join(filtered, "\n")
 }


### PR DESCRIPTION
## Summary
Fixes an issue where the vSphere configuration could be empty when creating imported clusters.
## Changes
- Ensure the vSphere config is populated correctly during imported cluster creation
- Prevent imported cluster creation from proceeding with an empty vSphere configuration