### PR TITLE
Increase timeout for curl command in our terraform scripts to reduce transient failures

### DIFF
--- a/framework/set/resources/dualstack/k3s/add-agents.sh
+++ b/framework/set/resources/dualstack/k3s/add-agents.sh
@@ -56,6 +56,6 @@ configs:
       username: "${REGISTRY_USERNAME}"
       password: "${REGISTRY_PASSWORD}"" | sudo tee -a /etc/rancher/k3s/registries.yaml > /dev/null
 
-retryCmd curl -fsSL --max-time 30 -o install.sh https://get.k3s.io
+retryCmd curl -fsSL --max-time 120 -o install.sh https://get.k3s.io
 chmod +x install.sh
 retryCmd sudo INSTALL_K3S_VERSION=${K8S_VERSION} K3S_TOKEN=${K3S_TOKEN} INSTALL_K3S_EXEC="agent --server https://[${K3S_SERVER_IP}]:6443" sh install.sh

--- a/framework/set/resources/dualstack/k3s/add-servers.sh
+++ b/framework/set/resources/dualstack/k3s/add-servers.sh
@@ -65,6 +65,6 @@ configs:
       username: "${REGISTRY_USERNAME}"
       password: "${REGISTRY_PASSWORD}"" | sudo tee -a /etc/rancher/k3s/registries.yaml > /dev/null
 
-retryCmd curl -fsSL --max-time 30 -o install.sh https://get.k3s.io
+retryCmd curl -fsSL --max-time 120 -o install.sh https://get.k3s.io
 chmod +x install.sh
 retryCmd sudo INSTALL_K3S_VERSION=${K8S_VERSION} K3S_TOKEN=${K3S_TOKEN} INSTALL_K3S_EXEC="server --server https://${K3S_SERVER_IP}:6443" sh install.sh

--- a/framework/set/resources/dualstack/k3s/init-server.sh
+++ b/framework/set/resources/dualstack/k3s/init-server.sh
@@ -49,8 +49,8 @@ fi
 
 echo "Installing kubectl"
 KUBECTL_VERSION="v1.36.0"
-retryCmd curl -fsSL --max-time 30 -o kubectl https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl
-retryCmd curl -fsSL --max-time 30 -o kubectl.sha256 https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl.sha256
+retryCmd curl -fsSL --max-time 120 -o kubectl https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl
+retryCmd curl -fsSL --max-time 120 -o kubectl.sha256 https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl.sha256
 echo "$(cat kubectl.sha256) kubectl" | sha256sum -c
 sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 
@@ -79,7 +79,7 @@ configs:
       username: "${REGISTRY_USERNAME}"
       password: "${REGISTRY_PASSWORD}"" | sudo tee -a /etc/rancher/k3s/registries.yaml > /dev/null
 
-retryCmd curl -fsSL --max-time 30 -o install.sh https://get.k3s.io
+retryCmd curl -fsSL --max-time 120 -o install.sh https://get.k3s.io
 chmod +x install.sh
 retryCmd sudo INSTALL_K3S_VERSION=${K8S_VERSION} K3S_TOKEN=${K3S_TOKEN} INSTALL_K3S_EXEC=server sh install.sh
 

--- a/framework/set/resources/dualstack/rke2/add-agents.sh
+++ b/framework/set/resources/dualstack/rke2/add-agents.sh
@@ -48,9 +48,9 @@ elif [[ $ARCH == "arm64" || $ARCH == "aarch64" ]]; then
     ARCH="arm64"
 fi
 
-retryCmd curl -fsSL --max-time 30 -o /home/${USER}/rke2.linux-${ARCH}.tar.gz https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2.linux-${ARCH}.tar.gz
-retryCmd curl -fsSL --max-time 30 -o /home/${USER}/rke2-images.linux-${ARCH}.tar.zst https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2-images.linux-${ARCH}.tar.zst
-retryCmd curl -fsSL --max-time 30 -o /home/${USER}/sha256sum-${ARCH}.txt https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/sha256sum-${ARCH}.txt
+retryCmd curl -fsSL --max-time 120 -o /home/${USER}/rke2.linux-${ARCH}.tar.gz https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2.linux-${ARCH}.tar.gz
+retryCmd curl -fsSL --max-time 120 -o /home/${USER}/rke2-images.linux-${ARCH}.tar.zst https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2-images.linux-${ARCH}.tar.zst
+retryCmd curl -fsSL --max-time 120 -o /home/${USER}/sha256sum-${ARCH}.txt https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/sha256sum-${ARCH}.txt
 
 echo "Validating checksum for rke2-images.linux-${ARCH}.tar.zst"
 ZIP_NAME="rke2-images.linux-${ARCH}.tar.zst"

--- a/framework/set/resources/dualstack/rke2/add-servers.sh
+++ b/framework/set/resources/dualstack/rke2/add-servers.sh
@@ -48,9 +48,9 @@ elif [[ $ARCH == "arm64" || $ARCH == "aarch64" ]]; then
     ARCH="arm64"
 fi
 
-retryCmd curl -fsSL --max-time 30 -o /home/${USER}/rke2.linux-${ARCH}.tar.gz https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2.linux-${ARCH}.tar.gz
-retryCmd curl -fsSL --max-time 30 -o /home/${USER}/rke2-images.linux-${ARCH}.tar.zst https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2-images.linux-${ARCH}.tar.zst
-retryCmd curl -fsSL --max-time 30 -o /home/${USER}/sha256sum-${ARCH}.txt https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/sha256sum-${ARCH}.txt
+retryCmd curl -fsSL --max-time 120 -o /home/${USER}/rke2.linux-${ARCH}.tar.gz https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2.linux-${ARCH}.tar.gz
+retryCmd curl -fsSL --max-time 120 -o /home/${USER}/rke2-images.linux-${ARCH}.tar.zst https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2-images.linux-${ARCH}.tar.zst
+retryCmd curl -fsSL --max-time 120 -o /home/${USER}/sha256sum-${ARCH}.txt https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/sha256sum-${ARCH}.txt
 
 echo "Validating checksum for rke2-images.linux-${ARCH}.tar.zst"
 ZIP_NAME="rke2-images.linux-${ARCH}.tar.zst"

--- a/framework/set/resources/dualstack/rke2/init-server.sh
+++ b/framework/set/resources/dualstack/rke2/init-server.sh
@@ -50,14 +50,14 @@ fi
 
 echo "Installing kubectl"
 KUBECTL_VERSION="v1.36.0"
-retryCmd curl -fsSL --max-time 30 -o kubectl https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl
-retryCmd curl -fsSL --max-time 30 -o kubectl.sha256 https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl.sha256
+retryCmd curl -fsSL --max-time 120 -o kubectl https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl
+retryCmd curl -fsSL --max-time 120 -o kubectl.sha256 https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl.sha256
 echo "$(cat kubectl.sha256) kubectl" | sha256sum -c
 sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 
-retryCmd curl -fsSL --max-time 30 -o /home/${USER}/rke2.linux-${ARCH}.tar.gz https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2.linux-${ARCH}.tar.gz
-retryCmd curl -fsSL --max-time 30 -o /home/${USER}/rke2-images.linux-${ARCH}.tar.zst https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2-images.linux-${ARCH}.tar.zst
-retryCmd curl -fsSL --max-time 30 -o /home/${USER}/sha256sum-${ARCH}.txt https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/sha256sum-${ARCH}.txt
+retryCmd curl -fsSL --max-time 120 -o /home/${USER}/rke2.linux-${ARCH}.tar.gz https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2.linux-${ARCH}.tar.gz
+retryCmd curl -fsSL --max-time 120 -o /home/${USER}/rke2-images.linux-${ARCH}.tar.zst https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2-images.linux-${ARCH}.tar.zst
+retryCmd curl -fsSL --max-time 120 -o /home/${USER}/sha256sum-${ARCH}.txt https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/sha256sum-${ARCH}.txt
 
 echo "Validating checksum for rke2-images.linux-${ARCH}.tar.zst"
 ZIP_NAME="rke2-images.linux-${ARCH}.tar.zst"

--- a/framework/set/resources/ipv6/k3s/imported-bastion.sh
+++ b/framework/set/resources/ipv6/k3s/imported-bastion.sh
@@ -15,13 +15,13 @@ base64 -d <<< "$PEM_FILE" > /home/$USER/airgap.pem
 PEM=/home/$USER/airgap.pem
 chmod 600 $PEM
 
-curl -fsSL --max-time 30 -o k3s https://github.com/k3s-io/k3s/releases/download/${K8S_VERSION}/k3s
-curl -fsSL --max-time 30 -o k3s-images.txt https://github.com/k3s-io/k3s/releases/download/${K8S_VERSION}/k3s-images.txt
-curl -fsSL --max-time 30 -o k3s-airgap-images-amd64.tar.gz https://github.com/k3s-io/k3s/releases/download/${K8S_VERSION}/k3s-airgap-images-amd64.tar.gz
-curl -fsSL --max-time 30 -o k3s-airgap-images-arm64.tar.gz https://github.com/k3s-io/k3s/releases/download/${K8S_VERSION}/k3s-airgap-images-arm64.tar.gz
-curl -fsSL --max-time 30 -o sha256sum-amd64.txt https://github.com/k3s-io/k3s/releases/download/${K8S_VERSION}/sha256sum-amd64.txt
-curl -fsSL --max-time 30 -o sha256sum-arm64.txt https://github.com/k3s-io/k3s/releases/download/${K8S_VERSION}/sha256sum-arm64.txt
-curl -fsSL --max-time 30 -o install.sh https://get.k3s.io
+curl -fsSL --max-time 120 -o k3s https://github.com/k3s-io/k3s/releases/download/${K8S_VERSION}/k3s
+curl -fsSL --max-time 120 -o k3s-images.txt https://github.com/k3s-io/k3s/releases/download/${K8S_VERSION}/k3s-images.txt
+curl -fsSL --max-time 120 -o k3s-airgap-images-amd64.tar.gz https://github.com/k3s-io/k3s/releases/download/${K8S_VERSION}/k3s-airgap-images-amd64.tar.gz
+curl -fsSL --max-time 120 -o k3s-airgap-images-arm64.tar.gz https://github.com/k3s-io/k3s/releases/download/${K8S_VERSION}/k3s-airgap-images-arm64.tar.gz
+curl -fsSL --max-time 120 -o sha256sum-amd64.txt https://github.com/k3s-io/k3s/releases/download/${K8S_VERSION}/sha256sum-amd64.txt
+curl -fsSL --max-time 120 -o sha256sum-arm64.txt https://github.com/k3s-io/k3s/releases/download/${K8S_VERSION}/sha256sum-arm64.txt
+curl -fsSL --max-time 120 -o install.sh https://get.k3s.io
 
 chmod +x k3s
 chmod +x install.sh
@@ -47,8 +47,8 @@ echo "$CHECKSUM k3s-airgap-images-${ARCH}.tar.gz" | sha256sum -c -
 
 echo "Installing kubectl"
 KUBECTL_VERSION="v1.36.0"
-curl -fsSL --max-time 30 -o kubectl https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl
-curl -fsSL --max-time 30 -o kubectl.sha256 https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl.sha256
+curl -fsSL --max-time 120 -o kubectl https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl
+curl -fsSL --max-time 120 -o kubectl.sha256 https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl.sha256
 echo "$(cat kubectl.sha256) kubectl" | sha256sum -c
 sudo chmod +x kubectl
 

--- a/framework/set/resources/ipv6/rke2/imported-bastion.sh
+++ b/framework/set/resources/ipv6/rke2/imported-bastion.sh
@@ -15,13 +15,13 @@ base64 -d <<< "$PEM_FILE" > /home/$USER/airgap.pem
 PEM=/home/$USER/airgap.pem
 chmod 600 $PEM
 
-curl -fsSL --max-time 30 -o rke2.linux-amd64.tar.gz https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2.linux-amd64.tar.gz
-curl -fsSL --max-time 30 -o rke2.linux-arm64.tar.gz https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2.linux-arm64.tar.gz
-curl -fsSL --max-time 30 -o rke2-images.linux-amd64.tar.zst https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2-images.linux-amd64.tar.zst
-curl -fsSL --max-time 30 -o rke2-images.linux-arm64.tar.zst https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2-images.linux-arm64.tar.zst
-curl -fsSL --max-time 30 -o sha256sum-amd64.txt https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/sha256sum-amd64.txt
-curl -fsSL --max-time 30 -o sha256sum-arm64.txt https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/sha256sum-arm64.txt
-curl -fsSL --max-time 30 -o install.sh https://get.rke2.io
+curl -fsSL --max-time 120 -o rke2.linux-amd64.tar.gz https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2.linux-amd64.tar.gz
+curl -fsSL --max-time 120 -o rke2.linux-arm64.tar.gz https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2.linux-arm64.tar.gz
+curl -fsSL --max-time 120 -o rke2-images.linux-amd64.tar.zst https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2-images.linux-amd64.tar.zst
+curl -fsSL --max-time 120 -o rke2-images.linux-arm64.tar.zst https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2-images.linux-arm64.tar.zst
+curl -fsSL --max-time 120 -o sha256sum-amd64.txt https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/sha256sum-amd64.txt
+curl -fsSL --max-time 120 -o sha256sum-arm64.txt https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/sha256sum-arm64.txt
+curl -fsSL --max-time 120 -o install.sh https://get.rke2.io
 
 chmod +x install.sh
 
@@ -46,8 +46,8 @@ echo "$CHECKSUM  rke2.linux-${ARCH}.tar.gz" | sha256sum -c -
 
 echo "Installing kubectl"
 KUBECTL_VERSION="v1.36.0"
-curl -fsSL --max-time 30 -o kubectl https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl
-curl -fsSL --max-time 30 -o kubectl.sha256 https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl.sha256
+curl -fsSL --max-time 120 -o kubectl https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl
+curl -fsSL --max-time 120 -o kubectl.sha256 https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl.sha256
 echo "$(cat kubectl.sha256) kubectl" | sha256sum -c
 sudo chmod +x kubectl
 

--- a/framework/set/resources/k3s/add-agents.sh
+++ b/framework/set/resources/k3s/add-agents.sh
@@ -56,6 +56,6 @@ configs:
       username: \"${REGISTRY_USERNAME}\"
       password: \"${REGISTRY_PASSWORD}\"" | sudo tee -a /etc/rancher/k3s/registries.yaml > /dev/null
 
-retryCmd curl -fsSL --max-time 30 -o install.sh https://get.k3s.io
+retryCmd curl -fsSL --max-time 120 -o install.sh https://get.k3s.io
 chmod +x install.sh
 retryCmd sudo INSTALL_K3S_VERSION=${K8S_VERSION} K3S_TOKEN=${K3S_TOKEN} INSTALL_K3S_EXEC="agent --server https://${K3S_SERVER_IP}:6443" sh install.sh

--- a/framework/set/resources/k3s/add-servers.sh
+++ b/framework/set/resources/k3s/add-servers.sh
@@ -59,6 +59,6 @@ configs:
       username: "${REGISTRY_USERNAME}"
       password: "${REGISTRY_PASSWORD}"" | sudo tee -a /etc/rancher/k3s/registries.yaml > /dev/null
 
-retryCmd curl -fsSL --max-time 30 -o install.sh https://get.k3s.io
+retryCmd curl -fsSL --max-time 120 -o install.sh https://get.k3s.io
 chmod +x install.sh
 retryCmd sudo INSTALL_K3S_VERSION=${K8S_VERSION} K3S_TOKEN=${K3S_TOKEN} INSTALL_K3S_EXEC="server --server https://${K3S_SERVER_IP}:6443" sh install.sh

--- a/framework/set/resources/k3s/init-server.sh
+++ b/framework/set/resources/k3s/init-server.sh
@@ -59,7 +59,7 @@ configs:
       username: "${REGISTRY_USERNAME}"
       password: "${REGISTRY_PASSWORD}"" | sudo tee -a /etc/rancher/k3s/registries.yaml > /dev/null
 
-retryCmd curl -fsSL --max-time 30 -o install.sh https://get.k3s.io
+retryCmd curl -fsSL --max-time 120 -o install.sh https://get.k3s.io
 chmod +x install.sh
 retryCmd sudo INSTALL_K3S_VERSION=${K8S_VERSION} K3S_TOKEN=${K3S_TOKEN} INSTALL_K3S_EXEC=server sh install.sh
 

--- a/framework/set/resources/proxy/k3s/imported-setup.sh
+++ b/framework/set/resources/proxy/k3s/imported-setup.sh
@@ -15,13 +15,13 @@ base64 -d <<< $PEM_FILE > /home/$USER/keyfile.pem
 PEM=/home/$USER/keyfile.pem
 chmod 600 $PEM
 
-curl -fsSL --max-time 30 -o k3s https://github.com/k3s-io/k3s/releases/download/${K8S_VERSION}/k3s
-curl -fsSL --max-time 30 -o k3s-images.txt https://github.com/k3s-io/k3s/releases/download/${K8S_VERSION}/k3s-images.txt
-curl -fsSL --max-time 30 -o k3s-airgap-images-amd64.tar.gz https://github.com/k3s-io/k3s/releases/download/${K8S_VERSION}/k3s-airgap-images-amd64.tar.gz
-curl -fsSL --max-time 30 -o k3s-airgap-images-arm64.tar.gz https://github.com/k3s-io/k3s/releases/download/${K8S_VERSION}/k3s-airgap-images-arm64.tar.gz
-curl -fsSL --max-time 30 -o sha256sum-amd64.txt https://github.com/k3s-io/k3s/releases/download/${K8S_VERSION}/sha256sum-amd64.txt
-curl -fsSL --max-time 30 -o sha256sum-arm64.txt https://github.com/k3s-io/k3s/releases/download/${K8S_VERSION}/sha256sum-arm64.txt
-curl -fsSL --max-time 30 -o install.sh https://get.k3s.io
+curl -fsSL --max-time 120 -o k3s https://github.com/k3s-io/k3s/releases/download/${K8S_VERSION}/k3s
+curl -fsSL --max-time 120 -o k3s-images.txt https://github.com/k3s-io/k3s/releases/download/${K8S_VERSION}/k3s-images.txt
+curl -fsSL --max-time 120 -o k3s-airgap-images-amd64.tar.gz https://github.com/k3s-io/k3s/releases/download/${K8S_VERSION}/k3s-airgap-images-amd64.tar.gz
+curl -fsSL --max-time 120 -o k3s-airgap-images-arm64.tar.gz https://github.com/k3s-io/k3s/releases/download/${K8S_VERSION}/k3s-airgap-images-arm64.tar.gz
+curl -fsSL --max-time 120 -o sha256sum-amd64.txt https://github.com/k3s-io/k3s/releases/download/${K8S_VERSION}/sha256sum-amd64.txt
+curl -fsSL --max-time 120 -o sha256sum-arm64.txt https://github.com/k3s-io/k3s/releases/download/${K8S_VERSION}/sha256sum-arm64.txt
+curl -fsSL --max-time 120 -o install.sh https://get.k3s.io
 
 chmod +x k3s
 chmod +x install.sh
@@ -47,8 +47,8 @@ echo "$CHECKSUM k3s-airgap-images-${ARCH}.tar.gz" | sha256sum -c -
 
 echo "Installing kubectl"
 KUBECTL_VERSION="v1.36.0"
-curl -fsSL --max-time 30 -o kubectl https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl
-curl -fsSL --max-time 30 -o kubectl.sha256 https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl.sha256
+curl -fsSL --max-time 120 -o kubectl https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl
+curl -fsSL --max-time 120 -o kubectl.sha256 https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl.sha256
 echo "$(cat kubectl.sha256) kubectl" | sha256sum -c
 sudo chmod +x kubectl
 

--- a/framework/set/resources/proxy/rke2/imported-setup.sh
+++ b/framework/set/resources/proxy/rke2/imported-setup.sh
@@ -15,14 +15,14 @@ base64 -d <<< $PEM_FILE > /home/$USER/keyfile.pem
 PEM=/home/$USER/keyfile.pem
 chmod 600 $PEM
 
-curl -fsSL --max-time 30 -o rke2.linux-amd64.tar.gz https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2.linux-amd64.tar.gz
-curl -fsSL --max-time 30 -o rke2.linux-arm64.tar.gz https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2.linux-arm64.tar.gz
-curl -fsSL --max-time 30 -o rke2-images.linux-amd64.tar.zst https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2-images.linux-amd64.tar.zst
-curl -fsSL --max-time 30 -o rke2-images.linux-arm64.tar.zst https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2-images.linux-arm64.tar.zst
-curl -fsSL --max-time 30 -o sha256sum-amd64.txt https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/sha256sum-amd64.txt
-curl -fsSL --max-time 30 -o sha256sum-arm64.txt https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/sha256sum-arm64.txt
+curl -fsSL --max-time 120 -o rke2.linux-amd64.tar.gz https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2.linux-amd64.tar.gz
+curl -fsSL --max-time 120 -o rke2.linux-arm64.tar.gz https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2.linux-arm64.tar.gz
+curl -fsSL --max-time 120 -o rke2-images.linux-amd64.tar.zst https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2-images.linux-amd64.tar.zst
+curl -fsSL --max-time 120 -o rke2-images.linux-arm64.tar.zst https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2-images.linux-arm64.tar.zst
+curl -fsSL --max-time 120 -o sha256sum-amd64.txt https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/sha256sum-amd64.txt
+curl -fsSL --max-time 120 -o sha256sum-arm64.txt https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/sha256sum-arm64.txt
 
-curl -fsSL --max-time 30 -o install.sh https://get.rke2.io
+curl -fsSL --max-time 120 -o install.sh https://get.rke2.io
 chmod +x install.sh
 
 ARCH=$(uname -m)
@@ -46,8 +46,8 @@ echo "$CHECKSUM  /home/${USER}/rke2-images.linux-${ARCH}.tar.zst" | sha256sum -c
 
 echo "Installing kubectl"
 KUBECTL_VERSION="v1.36.0"
-curl -fsSL --max-time 30 -o kubectl https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl
-curl -fsSL --max-time 30 -o kubectl.sha256 https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl.sha256
+curl -fsSL --max-time 120 -o kubectl https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl
+curl -fsSL --max-time 120 -o kubectl.sha256 https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl.sha256
 echo "$(cat kubectl.sha256) kubectl" | sha256sum -c
 sudo chmod +x kubectl
 

--- a/framework/set/resources/rke2/add-agents.sh
+++ b/framework/set/resources/rke2/add-agents.sh
@@ -46,9 +46,9 @@ elif [[ $ARCH == "arm64" || $ARCH == "aarch64" ]]; then
     ARCH="arm64"
 fi
 
-retryCmd curl -fsSL --max-time 30 -o rke2.linux-${ARCH}.tar.gz https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2.linux-${ARCH}.tar.gz
-retryCmd curl -fsSL --max-time 30 -o rke2-images.linux-${ARCH}.tar.zst https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2-images.linux-${ARCH}.tar.zst
-retryCmd curl -fsSL --max-time 30 -o sha256sum-${ARCH}.txt https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/sha256sum-${ARCH}.txt
+retryCmd curl -fsSL --max-time 120 -o rke2.linux-${ARCH}.tar.gz https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2.linux-${ARCH}.tar.gz
+retryCmd curl -fsSL --max-time 120 -o rke2-images.linux-${ARCH}.tar.zst https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2-images.linux-${ARCH}.tar.zst
+retryCmd curl -fsSL --max-time 120 -o sha256sum-${ARCH}.txt https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/sha256sum-${ARCH}.txt
 
 echo "Validating checksum for rke2.linux-${ARCH}.tar.gz"
 ZIP_NAME="rke2.linux-${ARCH}.tar.gz"
@@ -90,7 +90,7 @@ configs:
       username: \"${REGISTRY_USERNAME}\"
       password: \"${REGISTRY_PASSWORD}\"" | sudo tee /etc/rancher/rke2/registries.yaml > /dev/null
 
-retryCmd curl -fsSL --max-time 30 -o install.sh https://get.rke2.io
+retryCmd curl -fsSL --max-time 120 -o install.sh https://get.rke2.io
 chmod +x install.sh
 
 retryCmd sudo INSTALL_RKE2_ARTIFACT_PATH=/home/${USER} INSTALL_RKE2_TYPE=\"agent\" sh install.sh

--- a/framework/set/resources/rke2/add-servers.sh
+++ b/framework/set/resources/rke2/add-servers.sh
@@ -46,9 +46,9 @@ elif [[ $ARCH == "arm64" || $ARCH == "aarch64" ]]; then
     ARCH="arm64"
 fi
 
-retryCmd curl -fsSL --max-time 30 -o rke2.linux-${ARCH}.tar.gz https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2.linux-${ARCH}.tar.gz
-retryCmd curl -fsSL --max-time 30 -o rke2-images.linux-${ARCH}.tar.zst https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2-images.linux-${ARCH}.tar.zst
-retryCmd curl -fsSL --max-time 30 -o sha256sum-${ARCH}.txt https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/sha256sum-${ARCH}.txt
+retryCmd curl -fsSL --max-time 120 -o rke2.linux-${ARCH}.tar.gz https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2.linux-${ARCH}.tar.gz
+retryCmd curl -fsSL --max-time 120 -o rke2-images.linux-${ARCH}.tar.zst https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2-images.linux-${ARCH}.tar.zst
+retryCmd curl -fsSL --max-time 120 -o sha256sum-${ARCH}.txt https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/sha256sum-${ARCH}.txt
 
 echo "Validating checksum for rke2.linux-${ARCH}.tar.gz"
 ZIP_NAME="rke2.linux-${ARCH}.tar.gz"
@@ -92,7 +92,7 @@ configs:
       username: "${REGISTRY_USERNAME}"
       password: "${REGISTRY_PASSWORD}"" | sudo tee /etc/rancher/rke2/registries.yaml > /dev/null
 
-retryCmd curl -fsSL --max-time 30 -o install.sh https://get.rke2.io
+retryCmd curl -fsSL --max-time 120 -o install.sh https://get.rke2.io
 chmod +x install.sh
 
 retryCmd sudo INSTALL_RKE2_ARTIFACT_PATH=/home/${USER} sh install.sh

--- a/framework/set/resources/rke2/init-server.sh
+++ b/framework/set/resources/rke2/init-server.sh
@@ -46,9 +46,9 @@ elif [[ $ARCH == "arm64" || $ARCH == "aarch64" ]]; then
     ARCH="arm64"
 fi
 
-retryCmd curl -fsSL --max-time 30 -o rke2.linux-${ARCH}.tar.gz https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2.linux-${ARCH}.tar.gz
-retryCmd curl -fsSL --max-time 30 -o rke2-images.linux-${ARCH}.tar.zst https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2-images.linux-${ARCH}.tar.zst
-retryCmd curl -fsSL --max-time 30 -o sha256sum-${ARCH}.txt https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/sha256sum-${ARCH}.txt
+retryCmd curl -fsSL --max-time 120 -o rke2.linux-${ARCH}.tar.gz https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2.linux-${ARCH}.tar.gz
+retryCmd curl -fsSL --max-time 120 -o rke2-images.linux-${ARCH}.tar.zst https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/rke2-images.linux-${ARCH}.tar.zst
+retryCmd curl -fsSL --max-time 120 -o sha256sum-${ARCH}.txt https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/sha256sum-${ARCH}.txt
 
 echo "Validating checksum for rke2.linux-${ARCH}.tar.gz"
 ZIP_NAME="rke2.linux-${ARCH}.tar.gz"
@@ -91,7 +91,7 @@ configs:
       username: "${REGISTRY_USERNAME}"
       password: "${REGISTRY_PASSWORD}"" | sudo tee /etc/rancher/rke2/registries.yaml > /dev/null
 
-retryCmd curl -fsSL --max-time 30 -o install.sh https://get.rke2.io
+retryCmd curl -fsSL --max-time 120 -o install.sh https://get.rke2.io
 chmod +x install.sh
 
 retryCmd sudo INSTALL_RKE2_ARTIFACT_PATH=/home/${USER} sh install.sh


### PR DESCRIPTION
This change increases the timeout used by `curl` commands in the Terraform scripts to reduce transient failures caused by slow network responses or temporary delays. It improves the reliability of Terraform automation runs without changing the intended workflow.