### PR TITLE
Add support for installing and upgrading Rancher setups with Rancher prime head builds

### DIFF
--- a/framework/set/resources/airgap/k3s/add-servers.sh
+++ b/framework/set/resources/airgap/k3s/add-servers.sh
@@ -13,6 +13,7 @@ REGISTRY_PASSWORD=${10}
 RANCHER_IMAGE=${11}
 RANCHER_TAG_VERSION=${12}
 RANCHER_AGENT_IMAGE=${13}
+RANCHER_TAG_FILE=/home/${USER}/rancher-tag-version.txt
 PEM_FILE=/home/$USER/airgap.pem
 MAX_SSH_RETRIES=20
 SSH_RETRY_INTERVAL_SECONDS=10
@@ -118,6 +119,11 @@ setupNetworkingFunction=$(declare -f setup_networking)
 run_ssh "${K3S_NEW_SERVER_IP}" "${setupNetworkingFunction}; setup_networking"
 
 if [ -n "$RANCHER_AGENT_IMAGE" ]; then
+  if [ -f "$RANCHER_TAG_FILE" ]; then
+    RANCHER_TAG_VERSION=$(tr -d '\r\n' < "$RANCHER_TAG_FILE")
+    RANCHER_TAG_VERSION="v${RANCHER_TAG_VERSION}"
+  fi
+
   run_ssh "${K3S_NEW_SERVER_IP}" "sudo docker pull ${REGISTRY}/${RANCHER_IMAGE}:${RANCHER_TAG_VERSION}"
   run_ssh "${K3S_NEW_SERVER_IP}" "sudo docker pull ${REGISTRY}/${RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}"
   run_ssh "${K3S_NEW_SERVER_IP}" "sudo systemctl restart k3s"

--- a/framework/set/resources/airgap/k3s/bastion.sh
+++ b/framework/set/resources/airgap/k3s/bastion.sh
@@ -6,6 +6,9 @@ K3S_SERVER_TWO_IP=$3
 K3S_SERVER_THREE_IP=$4
 USER=$5
 PEM_FILE=$6
+REPO=$7
+RANCHER_TAG_VERSION=$8
+RANCHER_CHART_REPO=$9
 
 set -e
 
@@ -20,6 +23,39 @@ curl -fsSL --max-time 30 -o k3s-airgap-images-arm64.tar.gz https://github.com/k3
 curl -fsSL --max-time 30 -o sha256sum-amd64.txt https://github.com/k3s-io/k3s/releases/download/${K8S_VERSION}/sha256sum-amd64.txt
 curl -fsSL --max-time 30 -o sha256sum-arm64.txt https://github.com/k3s-io/k3s/releases/download/${K8S_VERSION}/sha256sum-arm64.txt
 curl -fsSL --max-time 30 -o install.sh https://get.k3s.io
+
+if [[ $REPO == "prime-release" ]]; then
+    . /etc/os-release
+
+    [[ "${ID}" == "ubuntu" || "${ID}" == "debian" ]] && sudo apt update && sudo apt -y install yq
+    [[ "${ID}" == "rhel" || "${ID}" == "fedora" ]] && sudo yum install yq -y
+    [[ "${ID}" == "opensuse-leap" || "${ID}" == "sles" ]] && sudo zypper install  -y yq
+
+    HEAD_SERIES=""
+    if [[ $RANCHER_TAG_VERSION =~ ^v([0-9]+\.[0-9]+)-head$ ]]; then
+        HEAD_SERIES="${BASH_REMATCH[1]}"
+    fi
+
+    if [[ -z "$HEAD_SERIES" && $RANCHER_TAG_VERSION == "head" ]]; then
+      HEAD_SERIES="${RANCHER_HEAD_SERIES:-}"
+      if [[ -z "$HEAD_SERIES" ]]; then
+        HEAD_SERIES=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r '.entries.rancher[].version' | sed -nE 's/^([0-9]+\.[0-9]+)\.[0-9]+.*-head$/\1/p' | sort -Vu | tail -n 1)
+      fi
+    fi
+
+    if [[ $RANCHER_TAG_VERSION == "head" && -z "$HEAD_SERIES" ]]; then
+        LATEST_CHART_VERSION=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r '.entries.rancher | map(select(.version | test("^"))) | sort_by(.created) | .[-1].version')
+        RANCHER_TAG_VERSION="${LATEST_CHART_VERSION}"
+    fi
+
+    if [[ -n "$HEAD_SERIES" ]]; then
+        SERIES_FILTER="^${HEAD_SERIES//./\\\\.}"
+        LATEST_CHART_VERSION=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r ".entries.rancher | map(select(.version | test(\"${SERIES_FILTER}\"))) | sort_by(.created) | .[-1].version")
+        RANCHER_TAG_VERSION="${LATEST_CHART_VERSION}"
+    fi
+
+    printf '%s\n' "${RANCHER_TAG_VERSION}" > "/home/${USER}/rancher-tag-version.txt"
+fi
 
 chmod +x k3s
 chmod +x install.sh
@@ -74,6 +110,12 @@ sudo scp -i ${PEM} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null k
 sudo scp -i ${PEM} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null install.sh ${USER}@${K3S_SERVER_THREE_IP}:/home/${USER}/
 sudo scp -i ${PEM} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null sha256sum-amd64.txt ${USER}@${K3S_SERVER_THREE_IP}:/home/${USER}/
 sudo scp -i ${PEM} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null sha256sum-arm64.txt ${USER}@${K3S_SERVER_THREE_IP}:/home/${USER}/
+
+if [[ $REPO == "prime-release" ]]; then
+    sudo scp -i ${PEM} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "/home/${USER}/rancher-tag-version.txt" ${USER}@${K3S_SERVER_ONE_IP}:/home/${USER}/rancher-tag-version.txt
+    sudo scp -i ${PEM} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "/home/${USER}/rancher-tag-version.txt" ${USER}@${K3S_SERVER_TWO_IP}:/home/${USER}/rancher-tag-version.txt
+    sudo scp -i ${PEM} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "/home/${USER}/rancher-tag-version.txt" ${USER}@${K3S_SERVER_THREE_IP}:/home/${USER}/rancher-tag-version.txt
+fi
 
 mkdir -p ~/.kube
 sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl

--- a/framework/set/resources/airgap/k3s/createAirgapCluster.go
+++ b/framework/set/resources/airgap/k3s/createAirgapCluster.go
@@ -60,10 +60,12 @@ func CreateAirgapK3SCluster(file *os.File, newFile *hclwrite.File, rootBody *hcl
 	_, provisionerBlockBody := rke2.SSHNullResource(rootBody, terraformConfig, k3sBastionPublicDNS, k3sBastion)
 
 	command := "/tmp/bastion.sh " + terraformConfig.Standalone.K3SVersion + " " + k3sServerOnePrivateIP + " " +
-		k3sServerTwoPrivateIP + " " + k3sServerThreePrivateIP + " " + terraformConfig.Standalone.OSUser + " " + encodedPEMFile
+		k3sServerTwoPrivateIP + " " + k3sServerThreePrivateIP + " " + terraformConfig.Standalone.OSUser + " " + encodedPEMFile + " " +
+		terraformConfig.Standalone.Repo + " " + terraformConfig.Standalone.RancherTagVersion + " " +
+		terraformConfig.Standalone.RancherChartRepository
 
 	provisionerBlockBody.SetAttributeValue(general.Inline, cty.ListVal([]cty.Value{
-		cty.StringVal("echo '" + string(bastionScriptContent) + "' > /tmp/bastion.sh"),
+		cty.StringVal("cat <<'EOF' > /tmp/bastion.sh\n" + string(bastionScriptContent) + "\nEOF"),
 		cty.StringVal("chmod +x /tmp/bastion.sh"),
 		cty.StringVal(command),
 	}))

--- a/framework/set/resources/airgap/k3s/init-server.sh
+++ b/framework/set/resources/airgap/k3s/init-server.sh
@@ -12,6 +12,7 @@ REGISTRY_PASSWORD=$9
 RANCHER_IMAGE=${10}
 RANCHER_TAG_VERSION=${11}
 RANCHER_AGENT_IMAGE=${12}
+RANCHER_TAG_FILE=/home/${USER}/rancher-tag-version.txt
 PEM_FILE=/home/$USER/airgap.pem
 MAX_SSH_RETRIES=20
 SSH_RETRY_INTERVAL_SECONDS=10
@@ -118,6 +119,11 @@ setupNetworkingFunction=$(declare -f setup_networking)
 run_ssh "${K3S_SERVER_ONE_IP}" "${setupNetworkingFunction}; setup_networking"
 
 if [ -n "$RANCHER_AGENT_IMAGE" ]; then
+  if [ -f "$RANCHER_TAG_FILE" ]; then
+    RANCHER_TAG_VERSION=$(tr -d '\r\n' < "$RANCHER_TAG_FILE")
+    RANCHER_TAG_VERSION="v${RANCHER_TAG_VERSION}"
+  fi
+
   run_ssh "${K3S_SERVER_ONE_IP}" "sudo docker pull ${REGISTRY}/${RANCHER_IMAGE}:${RANCHER_TAG_VERSION}"
   run_ssh "${K3S_SERVER_ONE_IP}" "sudo docker pull ${REGISTRY}/${RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}"
   run_ssh "${K3S_SERVER_ONE_IP}" "sudo systemctl restart k3s"

--- a/framework/set/resources/airgap/rancher/setup.sh
+++ b/framework/set/resources/airgap/rancher/setup.sh
@@ -97,7 +97,11 @@ install_helm() {
 
 setup_helm_repo() {
   echo "Adding Helm chart repo"
-  helm repo add rancher-${REPO} ${RANCHER_CHART_REPO}${REPO}
+  if [ "$REPO" == "prime-release" ]; then
+    helm repo add rancher-${REPO} ${RANCHER_CHART_REPO}
+  else
+    helm repo add rancher-${REPO} ${RANCHER_CHART_REPO}${REPO}
+  fi
 }
 
 install_cert_manager() {
@@ -117,6 +121,22 @@ install_cert_manager() {
 
   echo "Waiting 1 minute for Rancher"
   sleep 60
+}
+
+install_prime_head_rancher() {
+    kubectl -n cattle-system create secret tls tls-rancher-ingress --cert=/home/$USER/tls.crt --key=/home/$USER/tls.key
+
+    echo "Installing Rancher"
+    helm upgrade --install rancher rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
+                                                                                         --set systemDefaultRegistry=${REGISTRY} \
+                                                                                         --set hostname=${HOSTNAME} \
+                                                                                         ${IMAGE} \
+                                                                                         ${VERSION} \
+                                                                                         --set agentTLSMode=system-store \
+                                                                                         --set bootstrapPassword=${BOOTSTRAP_PASSWORD} \
+                                                                                         --set useBundledSystemChart=true \
+                                                                                         --set ingress.tls.source=secret \
+                                                                                         --devel
 }
 
 install_rancher() {
@@ -238,14 +258,51 @@ check_cluster_status
 install_helm
 setup_helm_repo
 
+if [[ $REPO == "prime-release" ]]; then
+    . /etc/os-release
+
+    [[ "${ID}" == "ubuntu" || "${ID}" == "debian" ]] && sudo apt update && sudo apt -y install yq
+    [[ "${ID}" == "rhel" || "${ID}" == "fedora" ]] && sudo yum install yq -y
+    [[ "${ID}" == "opensuse-leap" || "${ID}" == "sles" ]] && sudo zypper install  -y yq
+
+    HEAD_SERIES=""
+    if [[ $RANCHER_TAG_VERSION =~ ^v([0-9]+\.[0-9]+)-head$ ]]; then
+        HEAD_SERIES="${BASH_REMATCH[1]}"
+    fi
+
+    if [[ -z "$HEAD_SERIES" && $RANCHER_TAG_VERSION == "head" ]]; then
+      HEAD_SERIES="${RANCHER_HEAD_SERIES:-}"
+      if [[ -z "$HEAD_SERIES" ]]; then
+        HEAD_SERIES=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r '.entries.rancher[].version' | sed -nE 's/^([0-9]+\.[0-9]+)\.[0-9]+.*-head$/\1/p' | sort -Vu | tail -n 1)
+      fi
+    fi
+
+    if [[ $RANCHER_TAG_VERSION == "head" && -z "$HEAD_SERIES" ]]; then
+        LATEST_CHART_VERSION=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r '.entries.rancher | map(select(.version | test("^"))) | sort_by(.created) | .[-1].version')
+        VERSION="--version ${LATEST_CHART_VERSION}"
+    fi
+
+    if [[ -n "$HEAD_SERIES" ]]; then
+        SERIES_FILTER="^${HEAD_SERIES//./\\\\.}"
+        LATEST_CHART_VERSION=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r ".entries.rancher | map(select(.version | test(\"${SERIES_FILTER}\"))) | sort_by(.created) | .[-1].version")
+        VERSION="--version ${LATEST_CHART_VERSION}"
+    fi
+fi
+
 # Needed to get the latest chart version if RANCHER_TAG_VERSION contains "head"
-if [[ $RANCHER_TAG_VERSION == *head* ]]; then
+if [[ $RANCHER_TAG_VERSION == *head* && $REPO != "prime-release" ]]; then
     LATEST_CHART_VERSION=$(helm search repo rancher-${REPO} --devel | tail -n +2 | head -n 1 | cut -f2)
     VERSION="--version ${LATEST_CHART_VERSION}"
 fi
 
 install_cert_manager
-install_rancher
+
+if [[ $REPO == "prime-release" ]]; then
+    install_prime_head_rancher
+else
+    install_rancher
+fi
+
 wait_for_rollout
 wait_for_rancher
 wait_for_ingress

--- a/framework/set/resources/airgap/rancher/upgrade.sh
+++ b/framework/set/resources/airgap/rancher/upgrade.sh
@@ -36,7 +36,23 @@ delete_ingress() {
 
 setup_helm_repo() {
   echo "Adding Helm chart repo"
-  helm repo add upgraded-rancher-${REPO} ${RANCHER_CHART_REPO}${REPO}
+  if [ "$REPO" == "prime-release" ]; then
+    helm repo add upgraded-rancher-${REPO} ${RANCHER_CHART_REPO}
+  else
+    helm repo add upgraded-rancher-${REPO} ${RANCHER_CHART_REPO}${REPO}
+  fi
+}
+
+upgrade_prime_head_rancher() {
+    echo "Upgrading Rancher"
+    helm upgrade --install rancher upgraded-rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
+                                                                                         --set hostname=${HOSTNAME} \
+                                                                                         ${IMAGE} \
+                                                                                         ${VERSION} \
+                                                                                         --set agentTLSMode=system-store \
+                                                                                         --set bootstrapPassword=${BOOTSTRAP_PASSWORD} \
+                                                                                         --set ingress.tls.source=secret \
+                                                                                         --devel
 }
 
 upgrade_default_rancher() {
@@ -128,13 +144,49 @@ wait_for_rancher() {
 delete_ingress
 setup_helm_repo
 
+if [[ $REPO == "prime-release" ]]; then
+    . /etc/os-release
+
+    [[ "${ID}" == "ubuntu" || "${ID}" == "debian" ]] && sudo apt update && sudo apt -y install yq
+    [[ "${ID}" == "rhel" || "${ID}" == "fedora" ]] && sudo yum install yq -y
+    [[ "${ID}" == "opensuse-leap" || "${ID}" == "sles" ]] && sudo zypper install  -y yq
+
+    HEAD_SERIES=""
+    if [[ $RANCHER_TAG_VERSION =~ ^v([0-9]+\.[0-9]+)-head$ ]]; then
+        HEAD_SERIES="${BASH_REMATCH[1]}"
+    fi
+
+    if [[ -z "$HEAD_SERIES" && $RANCHER_TAG_VERSION == "head" ]]; then
+      HEAD_SERIES="${RANCHER_HEAD_SERIES:-}"
+      if [[ -z "$HEAD_SERIES" ]]; then
+        HEAD_SERIES=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r '.entries.rancher[].version' | sed -nE 's/^([0-9]+\.[0-9]+)\.[0-9]+.*-head$/\1/p' | sort -Vu | tail -n 1)
+      fi
+    fi
+
+    if [[ $RANCHER_TAG_VERSION == "head" && -z "$HEAD_SERIES" ]]; then
+        LATEST_CHART_VERSION=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r '.entries.rancher | map(select(.version | test("^"))) | sort_by(.created) | .[-1].version')
+        VERSION="--version ${LATEST_CHART_VERSION}"
+    fi
+
+    if [[ -n "$HEAD_SERIES" ]]; then
+        SERIES_FILTER="^${HEAD_SERIES//./\\\\.}"
+        LATEST_CHART_VERSION=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r ".entries.rancher | map(select(.version | test(\"${SERIES_FILTER}\"))) | sort_by(.created) | .[-1].version")
+        VERSION="--version ${LATEST_CHART_VERSION}"
+    fi
+fi
+
 # Needed to get the latest chart version if RANCHER_TAG_VERSION contains "head"
-if [[ $RANCHER_TAG_VERSION == *head* ]]; then
+if [[ $RANCHER_TAG_VERSION == *head* && $REPO != "prime-release" ]]; then
     LATEST_CHART_VERSION=$(helm search repo upgraded-rancher-${REPO} --devel | tail -n +2 | head -n 1 | cut -f2)
     VERSION="--version ${LATEST_CHART_VERSION}"
 fi
 
-upgrade_default_rancher
+if [[ $REPO == "prime-release" ]]; then
+    upgrade_prime_head_rancher
+else
+    upgrade_default_rancher
+fi
+
 wait_for_rollout
 patch_rancher_fqdn
 wait_for_rancher

--- a/framework/set/resources/airgap/rancher/upgradeAirgapRancher.go
+++ b/framework/set/resources/airgap/rancher/upgradeAirgapRancher.go
@@ -46,7 +46,7 @@ func UpgradeAirgapRancher(file *os.File, newFile *hclwrite.File, rootBody *hclwr
 	command += "'"
 
 	provisionerBlockBody.SetAttributeValue(general.Inline, cty.ListVal([]cty.Value{
-		cty.StringVal("printf '" + string(scriptContent) + "' > /tmp/upgrade.sh"),
+		cty.StringVal("cat <<'EOF' > /tmp/upgrade.sh\n" + string(scriptContent) + "\nEOF"),
 		cty.StringVal("chmod +x /tmp/upgrade.sh"),
 		cty.StringVal(command),
 	}))

--- a/framework/set/resources/airgap/rke2/add-servers.sh
+++ b/framework/set/resources/airgap/rke2/add-servers.sh
@@ -12,6 +12,7 @@ REGISTRY_PASSWORD=$9
 RANCHER_IMAGE=${10}
 RANCHER_TAG_VERSION=${11}
 RANCHER_AGENT_IMAGE=${12}
+RANCHER_TAG_FILE=/home/${USER}/rancher-tag-version.txt
 PEM_FILE=/home/$USER/airgap.pem
 MAX_SSH_RETRIES=20
 SSH_RETRY_INTERVAL_SECONDS=10
@@ -118,6 +119,11 @@ setupNetworkingFunction=$(declare -f setup_networking)
 run_ssh "${RKE2_NEW_SERVER_IP}" "${setupNetworkingFunction}; setup_networking"
 
 if [ -n "$RANCHER_AGENT_IMAGE" ]; then
+  if [ -f "$RANCHER_TAG_FILE" ]; then
+    RANCHER_TAG_VERSION=$(tr -d '\r\n' < "$RANCHER_TAG_FILE")
+    RANCHER_TAG_VERSION="v${RANCHER_TAG_VERSION}"
+  fi
+
   run_ssh "${RKE2_NEW_SERVER_IP}" "sudo docker pull ${REGISTRY}/${RANCHER_IMAGE}:${RANCHER_TAG_VERSION}"
   run_ssh "${RKE2_NEW_SERVER_IP}" "sudo docker pull ${REGISTRY}/${RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}"
   run_ssh "${RKE2_NEW_SERVER_IP}" "sudo systemctl restart rke2-server"

--- a/framework/set/resources/airgap/rke2/bastion.sh
+++ b/framework/set/resources/airgap/rke2/bastion.sh
@@ -6,6 +6,9 @@ RKE2_SERVER_TWO_IP=$3
 RKE2_SERVER_THREE_IP=$4
 USER=$5
 PEM_FILE=$6
+REPO=$7
+RANCHER_TAG_VERSION=$8
+RANCHER_CHART_REPO=$9
 
 set -e
 
@@ -20,6 +23,39 @@ curl -fsSL --max-time 30 -o rke2-images.linux-arm64.tar.zst https://github.com/r
 curl -fsSL --max-time 30 -o sha256sum-amd64.txt https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/sha256sum-amd64.txt
 curl -fsSL --max-time 30 -o sha256sum-arm64.txt https://github.com/rancher/rke2/releases/download/${K8S_VERSION}+rke2r1/sha256sum-arm64.txt
 curl -fsSL --max-time 30 -o install.sh https://get.rke2.io
+
+if [[ $REPO == "prime-release" ]]; then
+    . /etc/os-release
+
+    [[ "${ID}" == "ubuntu" || "${ID}" == "debian" ]] && sudo apt update && sudo apt -y install yq
+    [[ "${ID}" == "rhel" || "${ID}" == "fedora" ]] && sudo yum install yq -y
+    [[ "${ID}" == "opensuse-leap" || "${ID}" == "sles" ]] && sudo zypper install  -y yq
+
+    HEAD_SERIES=""
+    if [[ $RANCHER_TAG_VERSION =~ ^v([0-9]+\.[0-9]+)-head$ ]]; then
+        HEAD_SERIES="${BASH_REMATCH[1]}"
+    fi
+
+    if [[ -z "$HEAD_SERIES" && $RANCHER_TAG_VERSION == "head" ]]; then
+      HEAD_SERIES="${RANCHER_HEAD_SERIES:-}"
+      if [[ -z "$HEAD_SERIES" ]]; then
+        HEAD_SERIES=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r '.entries.rancher[].version' | sed -nE 's/^([0-9]+\.[0-9]+)\.[0-9]+.*-head$/\1/p' | sort -Vu | tail -n 1)
+      fi
+    fi
+
+    if [[ $RANCHER_TAG_VERSION == "head" && -z "$HEAD_SERIES" ]]; then
+        LATEST_CHART_VERSION=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r '.entries.rancher | map(select(.version | test("^"))) | sort_by(.created) | .[-1].version')
+        RANCHER_TAG_VERSION="${LATEST_CHART_VERSION}"
+    fi
+
+    if [[ -n "$HEAD_SERIES" ]]; then
+        SERIES_FILTER="^${HEAD_SERIES//./\\\\.}"
+        LATEST_CHART_VERSION=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r ".entries.rancher | map(select(.version | test(\"${SERIES_FILTER}\"))) | sort_by(.created) | .[-1].version")
+        RANCHER_TAG_VERSION="${LATEST_CHART_VERSION}"
+    fi
+
+    printf '%s\n' "${RANCHER_TAG_VERSION}" > "/home/${USER}/rancher-tag-version.txt"
+fi
 
 chmod +x install.sh
 
@@ -76,6 +112,12 @@ sudo scp -i ${PEM} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null r
 sudo scp -i ${PEM} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null install.sh ${USER}@${RKE2_SERVER_THREE_IP}:/home/${USER}/
 sudo scp -i ${PEM} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null sha256sum-amd64.txt ${USER}@${RKE2_SERVER_THREE_IP}:/home/${USER}/
 sudo scp -i ${PEM} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null sha256sum-arm64.txt ${USER}@${RKE2_SERVER_THREE_IP}:/home/${USER}/
+
+if [[ $REPO == "prime-release" ]]; then
+    sudo scp -i ${PEM} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "/home/${USER}/rancher-tag-version.txt" ${USER}@${RKE2_SERVER_ONE_IP}:/home/${USER}/rancher-tag-version.txt
+    sudo scp -i ${PEM} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "/home/${USER}/rancher-tag-version.txt" ${USER}@${RKE2_SERVER_TWO_IP}:/home/${USER}/rancher-tag-version.txt
+    sudo scp -i ${PEM} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "/home/${USER}/rancher-tag-version.txt" ${USER}@${RKE2_SERVER_THREE_IP}:/home/${USER}/rancher-tag-version.txt
+fi
 
 mkdir -p ~/.kube
 sudo mv kubectl /usr/local/bin/

--- a/framework/set/resources/airgap/rke2/createAirgapCluster.go
+++ b/framework/set/resources/airgap/rke2/createAirgapCluster.go
@@ -60,10 +60,12 @@ func CreateAirgapRKE2Cluster(file *os.File, newFile *hclwrite.File, rootBody *hc
 	_, provisionerBlockBody := rke2.SSHNullResource(rootBody, terraformConfig, rke2BastionPublicDNS, rke2Bastion)
 
 	command := "/tmp/bastion.sh " + terraformConfig.Standalone.RKE2Version + " " + rke2ServerOnePrivateIP + " " +
-		rke2ServerTwoPrivateIP + " " + rke2ServerThreePrivateIP + " " + terraformConfig.Standalone.OSUser + " " + encodedPEMFile
+		rke2ServerTwoPrivateIP + " " + rke2ServerThreePrivateIP + " " + terraformConfig.Standalone.OSUser + " " + encodedPEMFile + " " +
+		terraformConfig.Standalone.Repo + " " + terraformConfig.Standalone.RancherTagVersion + " " +
+		terraformConfig.Standalone.RancherChartRepository
 
 	provisionerBlockBody.SetAttributeValue(general.Inline, cty.ListVal([]cty.Value{
-		cty.StringVal("echo '" + string(bastionScriptContent) + "' > /tmp/bastion.sh"),
+		cty.StringVal("cat <<'EOF' > /tmp/bastion.sh\n" + string(bastionScriptContent) + "\nEOF"),
 		cty.StringVal("chmod +x /tmp/bastion.sh"),
 		cty.StringVal(command),
 	}))

--- a/framework/set/resources/airgap/rke2/init-server.sh
+++ b/framework/set/resources/airgap/rke2/init-server.sh
@@ -11,6 +11,7 @@ REGISTRY_PASSWORD=$8
 RANCHER_IMAGE=$9
 RANCHER_TAG_VERSION=${10}
 RANCHER_AGENT_IMAGE=${11}
+RANCHER_TAG_FILE=/home/${USER}/rancher-tag-version.txt
 PEM_FILE=/home/$USER/airgap.pem
 MAX_SSH_RETRIES=20
 SSH_RETRY_INTERVAL_SECONDS=10
@@ -117,6 +118,11 @@ setupNetworkingFunction=$(declare -f setup_networking)
 run_ssh "${RKE2_SERVER_ONE_IP}" "${setupNetworkingFunction}; setup_networking"
 
 if [ -n "$RANCHER_AGENT_IMAGE" ]; then
+  if [ -f "$RANCHER_TAG_FILE" ]; then
+    RANCHER_TAG_VERSION=$(tr -d '\r\n' < "$RANCHER_TAG_FILE")
+    RANCHER_TAG_VERSION="v${RANCHER_TAG_VERSION}"
+  fi
+
   run_ssh "${RKE2_SERVER_ONE_IP}" "sudo docker pull ${REGISTRY}/${RANCHER_IMAGE}:${RANCHER_TAG_VERSION}"
   run_ssh "${RKE2_SERVER_ONE_IP}" "sudo docker pull ${REGISTRY}/${RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}"
   run_ssh "${RKE2_SERVER_ONE_IP}" "sudo systemctl restart rke2-server"

--- a/framework/set/resources/hosted/rancher/setup.sh
+++ b/framework/set/resources/hosted/rancher/setup.sh
@@ -106,7 +106,11 @@ install_helm() {
 
 setup_helm_repo() {
     echo "Adding Helm chart repo"
-    helm repo add rancher-${REPO} ${RANCHER_CHART_REPO}${REPO}
+    if [ "$REPO" == "prime-release" ]; then
+        helm repo add rancher-${REPO} ${RANCHER_CHART_REPO}
+    else
+        helm repo add rancher-${REPO} ${RANCHER_CHART_REPO}${REPO}
+    fi
 }
 
 install_cert_manager() {
@@ -241,6 +245,21 @@ install_gke_traefik() {
     done
 }
 
+install_prime_head_rancher() {
+    kubectl -n cattle-system create secret tls tls-rancher-ingress --cert=/home/$USER/tls.crt --key=/home/$USER/tls.key
+
+    echo "Installing Rancher"
+    helm upgrade --install rancher rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
+                                                                                         --set systemDefaultRegistry=${REGISTRY} \
+                                                                                         --set hostname=${HOSTNAME} \
+                                                                                         ${VERSION} \
+                                                                                         --set agentTLSMode=system-store \
+                                                                                         --set bootstrapPassword=${BOOTSTRAP_PASSWORD} \
+                                                                                         --set useBundledSystemChart=true \
+                                                                                         --set ingress.tls.source=secret \
+                                                                                         --devel
+}
+
 install_rancher() {
     echo "Installing Rancher"
     if [ -n "$RANCHER_AGENT_IMAGE" ]; then
@@ -332,8 +351,39 @@ check_cluster_status
 install_helm
 setup_helm_repo
 
+if [[ $REPO == "prime-release" ]]; then
+    . /etc/os-release
+
+    [[ "${ID}" == "ubuntu" || "${ID}" == "debian" ]] && sudo apt update && sudo apt -y install yq
+    [[ "${ID}" == "rhel" || "${ID}" == "fedora" ]] && sudo yum install yq -y
+    [[ "${ID}" == "opensuse-leap" || "${ID}" == "sles" ]] && sudo zypper install  -y yq
+
+    HEAD_SERIES=""
+    if [[ $RANCHER_TAG_VERSION =~ ^v([0-9]+\.[0-9]+)-head$ ]]; then
+        HEAD_SERIES="${BASH_REMATCH[1]}"
+    fi
+
+    if [[ -z "$HEAD_SERIES" && $RANCHER_TAG_VERSION == "head" ]]; then
+      HEAD_SERIES="${RANCHER_HEAD_SERIES:-}"
+      if [[ -z "$HEAD_SERIES" ]]; then
+        HEAD_SERIES=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r '.entries.rancher[].version' | sed -nE 's/^([0-9]+\.[0-9]+)\.[0-9]+.*-head$/\1/p' | sort -Vu | tail -n 1)
+      fi
+    fi
+
+    if [[ $RANCHER_TAG_VERSION == "head" && -z "$HEAD_SERIES" ]]; then
+        LATEST_CHART_VERSION=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r '.entries.rancher | map(select(.version | test("^"))) | sort_by(.created) | .[-1].version')
+        VERSION="--version ${LATEST_CHART_VERSION}"
+    fi
+
+    if [[ -n "$HEAD_SERIES" ]]; then
+        SERIES_FILTER="^${HEAD_SERIES//./\\\\.}"
+        LATEST_CHART_VERSION=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r ".entries.rancher | map(select(.version | test(\"${SERIES_FILTER}\"))) | sort_by(.created) | .[-1].version")
+        VERSION="--version ${LATEST_CHART_VERSION}"
+    fi
+fi
+
 # Needed to get the latest chart version if RANCHER_TAG_VERSION contains "head"
-if [[ $RANCHER_TAG_VERSION == *head* ]]; then
+if [[ $RANCHER_TAG_VERSION == *head* && $REPO != "prime-release" ]]; then
     LATEST_CHART_VERSION=$(helm search repo rancher-${REPO} --devel | tail -n +2 | head -n 1 | cut -f2)
     VERSION="--version ${LATEST_CHART_VERSION}"
 fi
@@ -348,7 +398,12 @@ elif [[ $PROVIDER == "gke" ]]; then
     install_gke_traefik
 fi
 
-install_rancher
+if [[ $REPO == "prime-release" ]]; then
+    install_prime_head_rancher
+else
+    install_rancher
+fi
+
 wait_for_rollout
 wait_for_rancher
 

--- a/framework/set/resources/proxy/rancher/setup.sh
+++ b/framework/set/resources/proxy/rancher/setup.sh
@@ -117,7 +117,11 @@ install_helm() {
 
 setup_helm_repo() {
     echo "Adding Helm chart repo"
-    helm repo add rancher-${REPO} ${RANCHER_CHART_REPO}${REPO}
+    if [ "$REPO" == "prime-release" ]; then
+        helm repo add rancher-${REPO} ${RANCHER_CHART_REPO}
+    else
+        helm repo add rancher-${REPO} ${RANCHER_CHART_REPO}${REPO}
+    fi
 }
 
 install_cert_manager() {
@@ -136,6 +140,19 @@ install_cert_manager() {
 
     echo "Waiting 1 minute for Rancher"
     sleep 60
+}
+
+install_prime_head_rancher() {
+    kubectl -n cattle-system create secret tls tls-rancher-ingress --cert=/home/$USER/tls.crt --key=/home/$USER/tls.key
+
+    echo "Installing Rancher"
+    helm upgrade --install rancher rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
+                                                                                         --set hostname=${HOSTNAME} \
+                                                                                         ${VERSION} \
+                                                                                         --set agentTLSMode=system-store \
+                                                                                         --set bootstrapPassword=${BOOTSTRAP_PASSWORD} \
+                                                                                         --set ingress.tls.source=secret \
+                                                                                         --devel
 }
 
 install_rancher() {
@@ -192,13 +209,50 @@ check_cluster_status
 install_helm
 setup_helm_repo
 
+if [[ $REPO == "prime-release" ]]; then
+    . /etc/os-release
+
+    [[ "${ID}" == "ubuntu" || "${ID}" == "debian" ]] && sudo apt update && sudo apt -y install yq
+    [[ "${ID}" == "rhel" || "${ID}" == "fedora" ]] && sudo yum install yq -y
+    [[ "${ID}" == "opensuse-leap" || "${ID}" == "sles" ]] && sudo zypper install  -y yq
+
+    HEAD_SERIES=""
+    if [[ $RANCHER_TAG_VERSION =~ ^v([0-9]+\.[0-9]+)-head$ ]]; then
+        HEAD_SERIES="${BASH_REMATCH[1]}"
+    fi
+
+    if [[ -z "$HEAD_SERIES" && $RANCHER_TAG_VERSION == "head" ]]; then
+      HEAD_SERIES="${RANCHER_HEAD_SERIES:-}"
+      if [[ -z "$HEAD_SERIES" ]]; then
+        HEAD_SERIES=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r '.entries.rancher[].version' | sed -nE 's/^([0-9]+\.[0-9]+)\.[0-9]+.*-head$/\1/p' | sort -Vu | tail -n 1)
+      fi
+    fi
+
+    if [[ $RANCHER_TAG_VERSION == "head" && -z "$HEAD_SERIES" ]]; then
+        LATEST_CHART_VERSION=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r '.entries.rancher | map(select(.version | test("^"))) | sort_by(.created) | .[-1].version')
+        VERSION="--version ${LATEST_CHART_VERSION}"
+    fi
+
+    if [[ -n "$HEAD_SERIES" ]]; then
+        SERIES_FILTER="^${HEAD_SERIES//./\\\\.}"
+        LATEST_CHART_VERSION=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r ".entries.rancher | map(select(.version | test(\"${SERIES_FILTER}\"))) | sort_by(.created) | .[-1].version")
+        VERSION="--version ${LATEST_CHART_VERSION}"
+    fi
+fi
+
 # Needed to get the latest chart version if RANCHER_TAG_VERSION contains "head"
-if [[ $RANCHER_TAG_VERSION == *head* ]]; then
+if [[ $RANCHER_TAG_VERSION == *head* && $REPO != "prime-release" ]]; then
     LATEST_CHART_VERSION=$(helm search repo rancher-${REPO} --devel | tail -n +2 | head -n 1 | cut -f2)
     VERSION="--version ${LATEST_CHART_VERSION}"
 fi
 
 install_cert_manager
-install_rancher
+
+if [[ $REPO == "prime-release" ]]; then
+    install_prime_head_rancher
+else
+    install_rancher
+fi
+
 wait_for_rollout
 wait_for_rancher

--- a/framework/set/resources/proxy/rancher/upgrade.sh
+++ b/framework/set/resources/proxy/rancher/upgrade.sh
@@ -33,7 +33,22 @@ set -ex
 
 setup_helm_repo() {
     echo "Adding Helm chart repo"
-    helm repo add upgraded-rancher-${REPO} ${RANCHER_CHART_REPO}${REPO}
+    if [ "$REPO" == "prime-release" ]; then
+        helm repo add upgraded-rancher-${REPO} ${RANCHER_CHART_REPO}
+    else
+        helm repo add upgraded-rancher-${REPO} ${RANCHER_CHART_REPO}${REPO}
+    fi
+}
+
+upgrade_prime_head_rancher() {
+    echo "Upgrading Rancher"
+    helm upgrade --install rancher upgraded-rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
+                                                                                         --set hostname=${HOSTNAME} \
+                                                                                         ${VERSION} \
+                                                                                         --set agentTLSMode=system-store \
+                                                                                         --set bootstrapPassword=${BOOTSTRAP_PASSWORD} \
+                                                                                         --set ingress.tls.source=secret \
+                                                                                         --devel
 }
 
 upgrade_rancher() {
@@ -83,12 +98,48 @@ wait_for_rancher() {
 
 setup_helm_repo
 
+if [[ $REPO == "prime-release" ]]; then
+    . /etc/os-release
+
+    [[ "${ID}" == "ubuntu" || "${ID}" == "debian" ]] && sudo apt update && sudo apt -y install yq
+    [[ "${ID}" == "rhel" || "${ID}" == "fedora" ]] && sudo yum install yq -y
+    [[ "${ID}" == "opensuse-leap" || "${ID}" == "sles" ]] && sudo zypper install  -y yq
+
+    HEAD_SERIES=""
+    if [[ $RANCHER_TAG_VERSION =~ ^v([0-9]+\.[0-9]+)-head$ ]]; then
+        HEAD_SERIES="${BASH_REMATCH[1]}"
+    fi
+
+    if [[ -z "$HEAD_SERIES" && $RANCHER_TAG_VERSION == "head" ]]; then
+      HEAD_SERIES="${RANCHER_HEAD_SERIES:-}"
+      if [[ -z "$HEAD_SERIES" ]]; then
+        HEAD_SERIES=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r '.entries.rancher[].version' | sed -nE 's/^([0-9]+\.[0-9]+)\.[0-9]+.*-head$/\1/p' | sort -Vu | tail -n 1)
+      fi
+    fi
+
+    if [[ $RANCHER_TAG_VERSION == "head" && -z "$HEAD_SERIES" ]]; then
+        LATEST_CHART_VERSION=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r '.entries.rancher | map(select(.version | test("^"))) | sort_by(.created) | .[-1].version')
+        VERSION="--version ${LATEST_CHART_VERSION}"
+    fi
+
+    if [[ -n "$HEAD_SERIES" ]]; then
+        SERIES_FILTER="^${HEAD_SERIES//./\\\\.}"
+        LATEST_CHART_VERSION=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r ".entries.rancher | map(select(.version | test(\"${SERIES_FILTER}\"))) | sort_by(.created) | .[-1].version")
+        VERSION="--version ${LATEST_CHART_VERSION}"
+    fi
+fi
+
 # Needed to get the latest chart version if RANCHER_TAG_VERSION contains "head"
-if [[ $RANCHER_TAG_VERSION == *head* ]]; then
+if [[ $RANCHER_TAG_VERSION == *head* && $REPO != "prime-release" ]]; then
     LATEST_CHART_VERSION=$(helm search repo upgraded-rancher-${REPO} --devel | tail -n +2 | head -n 1 | cut -f2)
     VERSION="--version ${LATEST_CHART_VERSION}"
 fi
 
-upgrade_rancher
+if [[ $REPO == "prime-release" ]]; then
+    upgrade_prime_head_rancher
+else
+    upgrade_rancher
+fi
+
 wait_for_rollout
 wait_for_rancher

--- a/framework/set/resources/proxy/rancher/upgradeRancher.go
+++ b/framework/set/resources/proxy/rancher/upgradeRancher.go
@@ -44,7 +44,7 @@ func UpgradeProxiedRancher(file *os.File, newFile *hclwrite.File, rootBody *hclw
 	command += "'"
 
 	provisionerBlockBody.SetAttributeValue(general.Inline, cty.ListVal([]cty.Value{
-		cty.StringVal("printf '" + string(scriptContent) + "' > /tmp/upgrade.sh"),
+		cty.StringVal("cat <<'EOF' > /tmp/upgrade.sh\n" + string(scriptContent) + "\nEOF"),
 		cty.StringVal("chmod +x /tmp/upgrade.sh"),
 		cty.StringVal(command),
 	}))

--- a/framework/set/resources/registries/createRegistry/auth-registry.sh
+++ b/framework/set/resources/registries/createRegistry/auth-registry.sh
@@ -13,8 +13,10 @@ USER=${10}
 RANCHER_IMAGE=${11}
 FULL_CHAIN_FILE=${12}
 CERT_KEY_FILE=${13}
-ROUTE53_FQDN=${14}
-RANCHER_AGENT_IMAGE=${15}
+REPO=${14}
+RANCHER_CHART_REPO=${15}
+ROUTE53_FQDN=${16}
+RANCHER_AGENT_IMAGE=${17}
 
 set -e
 
@@ -101,9 +103,43 @@ create_registry() {
 
 fetch_images() {
     echo "Fetching Rancher image lists..."
-    curl -fsSL --max-time 30 -o /home/${USER}/rancher-images.txt ${ASSET_DIR}${RANCHER_VERSION}/rancher-images.txt
-    curl -fsSL --max-time 30 -o /home/${USER}/rancher-windows-images.txt ${ASSET_DIR}${RANCHER_VERSION}/rancher-windows-images.txt
-    curl -fsSL --max-time 30 -o /home/${USER}/sha256sum.txt ${ASSET_DIR}${RANCHER_VERSION}/sha256sum.txt
+
+    if [[ $REPO == "prime-release" ]]; then
+        . /etc/os-release
+
+        [[ "${ID}" == "ubuntu" || "${ID}" == "debian" ]] && sudo apt update && sudo apt -y install yq
+        [[ "${ID}" == "rhel" || "${ID}" == "fedora" ]] && sudo yum install yq -y
+        [[ "${ID}" == "opensuse-leap" || "${ID}" == "sles" ]] && sudo zypper install  -y yq
+
+        HEAD_SERIES=""
+        if [[ $RANCHER_VERSION =~ ^v([0-9]+\.[0-9]+)-head$ ]]; then
+            HEAD_SERIES="${BASH_REMATCH[1]}"
+        fi
+
+        if [[ -z "$HEAD_SERIES" && $RANCHER_VERSION == "head" ]]; then
+            HEAD_SERIES="${RANCHER_HEAD_SERIES:-}"
+            if [[ -z "$HEAD_SERIES" ]]; then
+                HEAD_SERIES=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r '.entries.rancher[].version' | sed -nE 's/^([0-9]+\.[0-9]+)\.[0-9]+.*-head$/\1/p' | sort -Vu | tail -n 1)
+            fi
+        fi
+
+        if [[ $RANCHER_VERSION == "head" && -z "$HEAD_SERIES" ]]; then
+            LATEST_CHART_VERSION=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r '.entries.rancher | map(select(.version | test("^"))) | sort_by(.created) | .[-1].version')
+        fi
+
+        if [[ -n "$HEAD_SERIES" ]]; then
+            SERIES_FILTER="^${HEAD_SERIES//./\\\\.}"
+            LATEST_CHART_VERSION=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r ".entries.rancher | map(select(.version | test(\"${SERIES_FILTER}\"))) | sort_by(.created) | .[-1].version")
+        fi
+
+        curl -fsSL --max-time 30 -o /home/${USER}/rancher-images.txt ${ASSET_DIR}v${LATEST_CHART_VERSION}/rancher-images.txt
+        curl -fsSL --max-time 30 -o /home/${USER}/rancher-windows-images.txt ${ASSET_DIR}v${LATEST_CHART_VERSION}/rancher-windows-images.txt
+        curl -fsSL --max-time 30 -o /home/${USER}/sha256sum.txt ${ASSET_DIR}v${LATEST_CHART_VERSION}/sha256sum.txt
+    else
+        curl -fsSL --max-time 30 -o /home/${USER}/rancher-images.txt ${ASSET_DIR}${RANCHER_VERSION}/rancher-images.txt
+        curl -fsSL --max-time 30 -o /home/${USER}/rancher-windows-images.txt ${ASSET_DIR}${RANCHER_VERSION}/rancher-windows-images.txt
+        curl -fsSL --max-time 30 -o /home/${USER}/sha256sum.txt ${ASSET_DIR}${RANCHER_VERSION}/sha256sum.txt
+    fi
 
     echo "Validating checksums for Rancher image lists..."
     CHECKSUM_LINE=$(grep "rancher-images.txt" /home/${USER}/sha256sum.txt)

--- a/framework/set/resources/registries/createRegistry/createRegistry.go
+++ b/framework/set/resources/registries/createRegistry/createRegistry.go
@@ -53,7 +53,8 @@ func CreateAuthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootBody
 	command := "/tmp/auth-registry.sh " + terraformConfig.Standalone.CertManagerVersion + " " + terraformConfig.StandaloneRegistry.RegistryName + " " + terraformConfig.StandaloneRegistry.RegistryUsername + " " +
 		terraformConfig.StandaloneRegistry.RegistryPassword + " " + terraformConfig.Standalone.RegistryUsername + " " + terraformConfig.Standalone.RegistryPassword + " " +
 		rke2AuthRegistryPublicDNS + " " + terraformConfig.Standalone.RancherTagVersion + " " + terraformConfig.StandaloneRegistry.AssetsPath + " " +
-		terraformConfig.Standalone.OSUser + " " + terraformConfig.Standalone.RancherImage + " " + encodedFullChain + " " + encodedCertKey
+		terraformConfig.Standalone.OSUser + " " + terraformConfig.Standalone.RancherImage + " " + encodedFullChain + " " + encodedCertKey + " " +
+		terraformConfig.Standalone.Repo + " " + terraformConfig.Standalone.RancherChartRepository
 
 	if useSecureFQDN {
 		command += " " + rke2AuthRegistryRoute53FQDN
@@ -68,7 +69,7 @@ func CreateAuthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootBody
 	}
 
 	provisionerBlockBody.SetAttributeValue(general.Inline, cty.ListVal([]cty.Value{
-		cty.StringVal("echo '" + string(registryScriptContent) + "' > /tmp/auth-registry.sh"),
+		cty.StringVal("cat <<'EOF' > /tmp/auth-registry.sh\n" + string(registryScriptContent) + "\nEOF"),
 		cty.StringVal("chmod +x /tmp/auth-registry.sh"),
 		cty.StringVal(command),
 	}))
@@ -116,7 +117,8 @@ func CreateUnauthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootBo
 		command = "/tmp/unauth-registry.sh " + terraformConfig.StandaloneRegistry.RegistryName + " " + terraformConfig.Standalone.CertManagerVersion + " " +
 			terraformConfig.Standalone.RegistryUsername + " " + terraformConfig.Standalone.RegistryPassword + " " + rke2UnauthRegistryPublicDNS + " " +
 			terraformConfig.Standalone.UpgradedRancherTagVersion + " " + terraformConfig.StandaloneRegistry.UpgradedAssetsPath + " " +
-			terraformConfig.Standalone.OSUser + " " + terraformConfig.Standalone.UpgradedRancherImage + " " + encodedFullChain + " " + encodedCertKey
+			terraformConfig.Standalone.OSUser + " " + terraformConfig.Standalone.UpgradedRancherImage + " " + encodedFullChain + " " + encodedCertKey + " " +
+			terraformConfig.Standalone.UpgradedRancherRepo + " " + terraformConfig.Standalone.UpgradedRancherChartRepository
 
 		if useSecureFQDN {
 			command += " " + rke2UnauthRegistryRoute53FQDN
@@ -133,7 +135,8 @@ func CreateUnauthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootBo
 		command = "/tmp/unauth-registry.sh " + terraformConfig.StandaloneRegistry.RegistryName + " " + terraformConfig.Standalone.CertManagerVersion + " " +
 			terraformConfig.Standalone.RegistryUsername + " " + terraformConfig.Standalone.RegistryPassword + " " + rke2UnauthRegistryPublicDNS + " " +
 			terraformConfig.Standalone.RancherTagVersion + " " + terraformConfig.StandaloneRegistry.AssetsPath + " " + terraformConfig.Standalone.OSUser + " " +
-			terraformConfig.Standalone.RancherImage + " " + encodedFullChain + " " + encodedCertKey
+			terraformConfig.Standalone.RancherImage + " " + encodedFullChain + " " + encodedCertKey + " " + terraformConfig.Standalone.Repo + " " +
+			terraformConfig.Standalone.RancherChartRepository
 
 		if useSecureFQDN {
 			command += " " + rke2UnauthRegistryRoute53FQDN
@@ -149,7 +152,7 @@ func CreateUnauthenticatedRegistry(file *os.File, newFile *hclwrite.File, rootBo
 	}
 
 	provisionerBlockBody.SetAttributeValue(general.Inline, cty.ListVal([]cty.Value{
-		cty.StringVal("echo '" + string(registryScriptContent) + "' > /tmp/unauth-registry.sh"),
+		cty.StringVal("cat <<'EOF' > /tmp/unauth-registry.sh\n" + string(registryScriptContent) + "\nEOF"),
 		cty.StringVal("chmod +x /tmp/unauth-registry.sh"),
 		cty.StringVal(command),
 	}))
@@ -180,7 +183,8 @@ func CreateECRRegistry(file *os.File, newFile *hclwrite.File, rootBody *hclwrite
 	command := "/tmp/ecr-registry.sh " + terraformConfig.StandaloneRegistry.ECRURI + " " + terraformConfig.Standalone.RegistryUsername + " " +
 		terraformConfig.Standalone.RegistryPassword + " " + terraformConfig.Standalone.RancherTagVersion + " " + terraformConfig.Standalone.RancherImage + " " +
 		terraformConfig.Standalone.OSUser + " " + terraformConfig.StandaloneRegistry.AssetsPath + " " + terraformConfig.AWSCredentials.AWSAccessKey + " " +
-		terraformConfig.AWSCredentials.AWSSecretKey + " " + terraformConfig.AWSConfig.Region
+		terraformConfig.AWSCredentials.AWSSecretKey + " " + terraformConfig.AWSConfig.Region + " " + terraformConfig.Standalone.Repo + " " +
+		terraformConfig.Standalone.RancherChartRepository
 
 	if terraformConfig.Standalone.RancherAgentImage != "" {
 		command += " " + terraformConfig.Standalone.RancherAgentImage
@@ -189,7 +193,7 @@ func CreateECRRegistry(file *os.File, newFile *hclwrite.File, rootBody *hclwrite
 	}
 
 	provisionerBlockBody.SetAttributeValue(general.Inline, cty.ListVal([]cty.Value{
-		cty.StringVal("echo '" + string(registryScriptContent) + "' > /tmp/ecr-registry.sh"),
+		cty.StringVal("cat <<'EOF' > /tmp/ecr-registry.sh\n" + string(registryScriptContent) + "\nEOF"),
 		cty.StringVal("chmod +x /tmp/ecr-registry.sh"),
 		cty.StringVal(command),
 	}))

--- a/framework/set/resources/registries/createRegistry/ecr-registry.sh
+++ b/framework/set/resources/registries/createRegistry/ecr-registry.sh
@@ -10,7 +10,9 @@ ASSET_DIR=$7
 AWS_ACCESS_KEY_ID=$8
 AWS_SECRET_ACCESS_KEY=$9
 AWS_REGION=${10}
-RANCHER_AGENT_IMAGE=${11}
+REPO=${11}
+RANCHER_CHART_REPO=${12}
+RANCHER_AGENT_IMAGE=${13}
 
 set -e
 
@@ -45,8 +47,41 @@ copy_certs() {
 
 fetch_images() {
     echo "Downloading ${RANCHER_VERSION} image list and scripts..."
-    curl -fsSL --max-time 30 -o /home/${USER}/rancher-images.txt ${ASSET_DIR}${RANCHER_VERSION}/rancher-images.txt
-    curl -fsSL --max-time 30 -o /home/${USER}/sha256sum.txt ${ASSET_DIR}${RANCHER_VERSION}/sha256sum.txt
+    if [[ $REPO == "prime-release" ]]; then
+        . /etc/os-release
+
+        [[ "${ID}" == "ubuntu" || "${ID}" == "debian" ]] && sudo apt update && sudo apt -y install yq
+        [[ "${ID}" == "rhel" || "${ID}" == "fedora" ]] && sudo yum install yq -y
+        [[ "${ID}" == "opensuse-leap" || "${ID}" == "sles" ]] && sudo zypper install  -y yq
+
+        HEAD_SERIES=""
+        if [[ $RANCHER_VERSION =~ ^v([0-9]+\.[0-9]+)-head$ ]]; then
+            HEAD_SERIES="${BASH_REMATCH[1]}"
+        fi
+
+        if [[ -z "$HEAD_SERIES" && $RANCHER_VERSION == "head" ]]; then
+            HEAD_SERIES="${RANCHER_HEAD_SERIES:-}"
+            if [[ -z "$HEAD_SERIES" ]]; then
+                HEAD_SERIES=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r '.entries.rancher[].version' | sed -nE 's/^([0-9]+\.[0-9]+)\.[0-9]+.*-head$/\1/p' | sort -Vu | tail -n 1)
+            fi
+        fi
+
+        if [[ $RANCHER_VERSION == "head" && -z "$HEAD_SERIES" ]]; then
+            LATEST_CHART_VERSION=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r '.entries.rancher | map(select(.version | test("^"))) | sort_by(.created) | .[-1].version')
+        fi
+
+        if [[ -n "$HEAD_SERIES" ]]; then
+            SERIES_FILTER="^${HEAD_SERIES//./\\\\.}"
+            LATEST_CHART_VERSION=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r ".entries.rancher | map(select(.version | test(\"${SERIES_FILTER}\"))) | sort_by(.created) | .[-1].version")
+        fi
+
+        curl -fsSL --max-time 30 -o /home/${USER}/rancher-images.txt ${ASSET_DIR}v${LATEST_CHART_VERSION}/rancher-images.txt
+        curl -fsSL --max-time 30 -o /home/${USER}/rancher-windows-images.txt ${ASSET_DIR}v${LATEST_CHART_VERSION}/rancher-windows-images.txt
+        curl -fsSL --max-time 30 -o /home/${USER}/sha256sum.txt ${ASSET_DIR}v${LATEST_CHART_VERSION}/sha256sum.txt
+    else
+        curl -fsSL --max-time 30 -o /home/${USER}/rancher-images.txt ${ASSET_DIR}${RANCHER_VERSION}/rancher-images.txt
+        curl -fsSL --max-time 30 -o /home/${USER}/sha256sum.txt ${ASSET_DIR}${RANCHER_VERSION}/sha256sum.txt
+    fi
 
     echo "Validating checksums for Rancher image lists..."
     CHECKSUM_LINE=$(grep "rancher-images.txt" /home/${USER}/sha256sum.txt)

--- a/framework/set/resources/registries/createRegistry/unauth-registry.sh
+++ b/framework/set/resources/registries/createRegistry/unauth-registry.sh
@@ -11,8 +11,10 @@ USER=$8
 RANCHER_IMAGE=$9
 FULL_CHAIN_FILE=${10}
 CERT_KEY_FILE=${11}
-ROUTE53_FQDN=${12}
-RANCHER_AGENT_IMAGE=${13}
+REPO=${12}
+RANCHER_CHART_REPO=${13}
+ROUTE53_FQDN=${14}
+RANCHER_AGENT_IMAGE=${15}
 
 set -e
 
@@ -94,9 +96,42 @@ fetch_images() {
         sudo rm -f /home/${USER}/rancher-*
     fi
 
-    curl -fsSL --max-time 30 -o /home/${USER}/rancher-images.txt ${ASSET_DIR}${RANCHER_VERSION}/rancher-images.txt
-    curl -fsSL --max-time 30 -o /home/${USER}/rancher-windows-images.txt ${ASSET_DIR}${RANCHER_VERSION}/rancher-windows-images.txt
-    curl -fsSL --max-time 30 -o /home/${USER}/sha256sum.txt ${ASSET_DIR}${RANCHER_VERSION}/sha256sum.txt
+    if [[ $REPO == "prime-release" ]]; then
+        . /etc/os-release
+
+        [[ "${ID}" == "ubuntu" || "${ID}" == "debian" ]] && sudo apt update && sudo apt -y install yq
+        [[ "${ID}" == "rhel" || "${ID}" == "fedora" ]] && sudo yum install yq -y
+        [[ "${ID}" == "opensuse-leap" || "${ID}" == "sles" ]] && sudo zypper install  -y yq
+
+        HEAD_SERIES=""
+        if [[ $RANCHER_VERSION =~ ^v([0-9]+\.[0-9]+)-head$ ]]; then
+            HEAD_SERIES="${BASH_REMATCH[1]}"
+        fi
+
+        if [[ -z "$HEAD_SERIES" && $RANCHER_VERSION == "head" ]]; then
+            HEAD_SERIES="${RANCHER_HEAD_SERIES:-}"
+            if [[ -z "$HEAD_SERIES" ]]; then
+                HEAD_SERIES=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r '.entries.rancher[].version' | sed -nE 's/^([0-9]+\.[0-9]+)\.[0-9]+.*-head$/\1/p' | sort -Vu | tail -n 1)
+            fi
+        fi
+
+        if [[ $RANCHER_VERSION == "head" && -z "$HEAD_SERIES" ]]; then
+            LATEST_CHART_VERSION=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r '.entries.rancher | map(select(.version | test("^"))) | sort_by(.created) | .[-1].version')
+        fi
+
+        if [[ -n "$HEAD_SERIES" ]]; then
+            SERIES_FILTER="^${HEAD_SERIES//./\\\\.}"
+            LATEST_CHART_VERSION=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r ".entries.rancher | map(select(.version | test(\"${SERIES_FILTER}\"))) | sort_by(.created) | .[-1].version")
+        fi
+
+        curl -fsSL --max-time 30 -o /home/${USER}/rancher-images.txt ${ASSET_DIR}v${LATEST_CHART_VERSION}/rancher-images.txt
+        curl -fsSL --max-time 30 -o /home/${USER}/rancher-windows-images.txt ${ASSET_DIR}v${LATEST_CHART_VERSION}/rancher-windows-images.txt
+        curl -fsSL --max-time 30 -o /home/${USER}/sha256sum.txt ${ASSET_DIR}v${LATEST_CHART_VERSION}/sha256sum.txt
+    else
+        curl -fsSL --max-time 30 -o /home/${USER}/rancher-images.txt ${ASSET_DIR}${RANCHER_VERSION}/rancher-images.txt
+        curl -fsSL --max-time 30 -o /home/${USER}/rancher-windows-images.txt ${ASSET_DIR}${RANCHER_VERSION}/rancher-windows-images.txt
+        curl -fsSL --max-time 30 -o /home/${USER}/sha256sum.txt ${ASSET_DIR}${RANCHER_VERSION}/sha256sum.txt
+    fi
 
     echo "Validating checksums for Rancher image lists..."
     CHECKSUM_LINE=$(grep "rancher-images.txt" /home/${USER}/sha256sum.txt)

--- a/framework/set/resources/registries/rancher/setup.sh
+++ b/framework/set/resources/registries/rancher/setup.sh
@@ -106,7 +106,11 @@ install_helm() {
 
 setup_helm_repo() {
     echo "Adding Helm chart repo"
-    helm repo add rancher-${REPO} ${RANCHER_CHART_REPO}${REPO}
+    if [ "$REPO" == "prime-release" ]; then
+        helm repo add rancher-${REPO} ${RANCHER_CHART_REPO}
+    else
+        helm repo add rancher-${REPO} ${RANCHER_CHART_REPO}${REPO}
+    fi
 }
 
 docker_login() {
@@ -137,6 +141,19 @@ install_cert_manager() {
 
     echo "Waiting 1 minute for Rancher"
     sleep 60
+}
+
+install_prime_head_rancher() {
+    kubectl -n cattle-system create secret tls tls-rancher-ingress --cert=/home/$USER/tls.crt --key=/home/$USER/tls.key
+
+    echo "Installing Rancher"
+    helm upgrade --install rancher rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
+                                                                                         --set hostname=${HOSTNAME} \
+                                                                                         ${VERSION} \
+                                                                                         --set agentTLSMode=system-store \
+                                                                                         --set bootstrapPassword=${BOOTSTRAP_PASSWORD} \
+                                                                                         --set ingress.tls.source=secret \
+                                                                                         --devel
 }
 
 install_rancher() {
@@ -193,8 +210,39 @@ check_cluster_status
 install_helm
 setup_helm_repo
 
+if [[ $REPO == "prime-release" ]]; then
+    . /etc/os-release
+
+    [[ "${ID}" == "ubuntu" || "${ID}" == "debian" ]] && sudo apt update && sudo apt -y install yq
+    [[ "${ID}" == "rhel" || "${ID}" == "fedora" ]] && sudo yum install yq -y
+    [[ "${ID}" == "opensuse-leap" || "${ID}" == "sles" ]] && sudo zypper install  -y yq
+
+    HEAD_SERIES=""
+    if [[ $RANCHER_TAG_VERSION =~ ^v([0-9]+\.[0-9]+)-head$ ]]; then
+        HEAD_SERIES="${BASH_REMATCH[1]}"
+    fi
+
+    if [[ -z "$HEAD_SERIES" && $RANCHER_TAG_VERSION == "head" ]]; then
+      HEAD_SERIES="${RANCHER_HEAD_SERIES:-}"
+      if [[ -z "$HEAD_SERIES" ]]; then
+        HEAD_SERIES=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r '.entries.rancher[].version' | sed -nE 's/^([0-9]+\.[0-9]+)\.[0-9]+.*-head$/\1/p' | sort -Vu | tail -n 1)
+      fi
+    fi
+
+    if [[ $RANCHER_TAG_VERSION == "head" && -z "$HEAD_SERIES" ]]; then
+        LATEST_CHART_VERSION=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r '.entries.rancher | map(select(.version | test("^"))) | sort_by(.created) | .[-1].version')
+        VERSION="--version ${LATEST_CHART_VERSION}"
+    fi
+
+    if [[ -n "$HEAD_SERIES" ]]; then
+        SERIES_FILTER="^${HEAD_SERIES//./\\\\.}"
+        LATEST_CHART_VERSION=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r ".entries.rancher | map(select(.version | test(\"${SERIES_FILTER}\"))) | sort_by(.created) | .[-1].version")
+        VERSION="--version ${LATEST_CHART_VERSION}"
+    fi
+fi
+
 # Needed to get the latest chart version if RANCHER_TAG_VERSION contains "head"
-if [[ $RANCHER_TAG_VERSION == *head* ]]; then
+if [[ $RANCHER_TAG_VERSION == *head* && $REPO != "prime-release" ]]; then
     LATEST_CHART_VERSION=$(helm search repo rancher-${REPO} --devel | tail -n +2 | head -n 1 | cut -f2)
     VERSION="--version ${LATEST_CHART_VERSION}"
 fi
@@ -209,6 +257,12 @@ else
 fi
 
 install_cert_manager
-install_rancher
+
+if [[ $REPO == "prime-release" ]]; then
+    install_prime_head_rancher
+else
+    install_rancher
+fi
+
 wait_for_rollout
 wait_for_rancher

--- a/framework/set/resources/registries/rke2/add-servers.sh
+++ b/framework/set/resources/registries/rke2/add-servers.sh
@@ -8,13 +8,45 @@ RKE2_TOKEN=$5
 RANCHER_IMAGE=$6
 RANCHER_TAG_VERSION=$7
 REGISTRY=$8
-REGISTRY_USERNAME=${9}
-REGISTRY_PASSWORD=${10}
-DOCKERHUB_USER=${11}
-DOCKERHUB_PASS=${12}
-RANCHER_AGENT_IMAGE=${13}
+REPO=$9
+RANCHER_TAG_VERSION=${10}
+RANCHER_CHART_REPO=${11}
+REGISTRY_USERNAME=${12}
+REGISTRY_PASSWORD=${13}
+DOCKERHUB_USER=${14}
+DOCKERHUB_PASS=${15}
+RANCHER_AGENT_IMAGE=${16}
 
 set -e
+
+if [[ $REPO == "prime-release" ]]; then
+  . /etc/os-release
+
+  [[ "${ID}" == "ubuntu" || "${ID}" == "debian" ]] && sudo apt update && sudo apt -y install yq
+  [[ "${ID}" == "rhel" || "${ID}" == "fedora" ]] && sudo yum install yq -y
+  [[ "${ID}" == "opensuse-leap" || "${ID}" == "sles" ]] && sudo zypper install  -y yq
+
+  HEAD_SERIES=""
+  if [[ $RANCHER_TAG_VERSION =~ ^v([0-9]+\.[0-9]+)-head$ ]]; then
+      HEAD_SERIES="${BASH_REMATCH[1]}"
+  fi
+
+  if [[ -z "$HEAD_SERIES" && $RANCHER_TAG_VERSION == "head" ]]; then
+    HEAD_SERIES="${RANCHER_HEAD_SERIES:-}"
+    if [[ -z "$HEAD_SERIES" ]]; then
+      HEAD_SERIES=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r '.entries.rancher[].version' | sed -nE 's/^([0-9]+\.[0-9]+)\.[0-9]+.*-head$/\1/p' | sort -Vu | tail -n 1)
+    fi
+  fi
+
+  if [[ $RANCHER_TAG_VERSION == "head" && -z "$HEAD_SERIES" ]]; then
+      LATEST_CHART_VERSION=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r '.entries.rancher | map(select(.version | test("^"))) | sort_by(.created) | .[-1].version')
+  fi
+
+  if [[ -n "$HEAD_SERIES" ]]; then
+      SERIES_FILTER="^${HEAD_SERIES//./\\\\.}"
+      LATEST_CHART_VERSION=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r ".entries.rancher | map(select(.version | test(\"${SERIES_FILTER}\"))) | sort_by(.created) | .[-1].version")
+  fi
+fi
 
 sudo mkdir -p /etc/rancher/rke2
 sudo touch /etc/rancher/rke2/config.yaml
@@ -97,6 +129,10 @@ if [ -n "${REGISTRY_USERNAME}" ] && [ -n "${REGISTRY_PASSWORD}" ]; then
 fi
 
 if [ -n "$RANCHER_AGENT_IMAGE" ]; then
+  if [ "$REPO" == "prime-release" ]; then
+    RANCHER_TAG_VERSION=${LATEST_CHART_VERSION}
+  fi
+
   sudo docker pull ${REGISTRY}/${RANCHER_IMAGE}:${RANCHER_TAG_VERSION}
   sudo docker pull ${REGISTRY}/${RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}
   sudo systemctl restart rke2-server

--- a/framework/set/resources/registries/rke2/createCluster.go
+++ b/framework/set/resources/registries/rke2/createCluster.go
@@ -73,7 +73,9 @@ func createRKE2Server(rootBody *hclwrite.Body, terraformConfig *config.Terraform
 
 	command := "/tmp/init-server.sh " + terraformConfig.Standalone.OSUser + " " + terraformConfig.Standalone.OSGroup + " " +
 		terraformConfig.Standalone.RKE2Version + " " + rke2ServerOnePrivateIP + " " + rke2Token + " " +
-		terraformConfig.Standalone.RancherImage + " " + terraformConfig.Standalone.RancherTagVersion + " " + registryPublicDNS
+		terraformConfig.Standalone.RancherImage + " " + terraformConfig.Standalone.RancherTagVersion + " " + registryPublicDNS + " " +
+		terraformConfig.Standalone.Repo + " " + terraformConfig.Standalone.RancherTagVersion + " " +
+		terraformConfig.Standalone.RancherChartRepository
 
 	if terraformConfig.StandaloneRegistry.UseAuthGlobalRegistry {
 		command += " " + terraformConfig.StandaloneRegistry.RegistryUsername + " " + terraformConfig.StandaloneRegistry.RegistryPassword + " " +
@@ -107,7 +109,9 @@ func addRKE2ServerNodes(rootBody *hclwrite.Body, terraformConfig *config.Terrafo
 
 		command := "/tmp/add-servers.sh " + terraformConfig.Standalone.OSUser + " " + terraformConfig.Standalone.OSGroup + " " +
 			terraformConfig.Standalone.RKE2Version + " " + rke2ServerOnePrivateIP + " " + rke2Token + " " +
-			terraformConfig.Standalone.RancherImage + " " + terraformConfig.Standalone.RancherTagVersion + " " + registryPublicDNS
+			terraformConfig.Standalone.RancherImage + " " + terraformConfig.Standalone.RancherTagVersion + " " + registryPublicDNS + " " +
+			terraformConfig.Standalone.Repo + " " + terraformConfig.Standalone.RancherTagVersion + " " +
+			terraformConfig.Standalone.RancherChartRepository
 
 		if terraformConfig.StandaloneRegistry.UseAuthGlobalRegistry {
 			command += " " + terraformConfig.StandaloneRegistry.RegistryUsername + " " + terraformConfig.StandaloneRegistry.RegistryPassword + " " +

--- a/framework/set/resources/registries/rke2/init-server.sh
+++ b/framework/set/resources/registries/rke2/init-server.sh
@@ -8,13 +8,45 @@ RKE2_TOKEN=$5
 RANCHER_IMAGE=$6
 RANCHER_TAG_VERSION=$7
 REGISTRY=$8
-REGISTRY_USERNAME=${9}
-REGISTRY_PASSWORD=${10}
-DOCKERHUB_USER=${11}
-DOCKERHUB_PASS=${12}
-RANCHER_AGENT_IMAGE=${13}
+REPO=$9
+RANCHER_TAG_VERSION=${10}
+RANCHER_CHART_REPO=${11}
+REGISTRY_USERNAME=${12}
+REGISTRY_PASSWORD=${13}
+DOCKERHUB_USER=${14}
+DOCKERHUB_PASS=${15}
+RANCHER_AGENT_IMAGE=${16}
 
 set -e
+
+if [[ $REPO == "prime-release" ]]; then
+  . /etc/os-release
+
+  [[ "${ID}" == "ubuntu" || "${ID}" == "debian" ]] && sudo apt update && sudo apt -y install yq
+  [[ "${ID}" == "rhel" || "${ID}" == "fedora" ]] && sudo yum install yq -y
+  [[ "${ID}" == "opensuse-leap" || "${ID}" == "sles" ]] && sudo zypper install  -y yq
+
+  HEAD_SERIES=""
+  if [[ $RANCHER_TAG_VERSION =~ ^v([0-9]+\.[0-9]+)-head$ ]]; then
+      HEAD_SERIES="${BASH_REMATCH[1]}"
+  fi
+
+  if [[ -z "$HEAD_SERIES" && $RANCHER_TAG_VERSION == "head" ]]; then
+    HEAD_SERIES="${RANCHER_HEAD_SERIES:-}"
+    if [[ -z "$HEAD_SERIES" ]]; then
+      HEAD_SERIES=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r '.entries.rancher[].version' | sed -nE 's/^([0-9]+\.[0-9]+)\.[0-9]+.*-head$/\1/p' | sort -Vu | tail -n 1)
+    fi
+  fi
+
+  if [[ $RANCHER_TAG_VERSION == "head" && -z "$HEAD_SERIES" ]]; then
+      LATEST_CHART_VERSION=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r '.entries.rancher | map(select(.version | test("^"))) | sort_by(.created) | .[-1].version')
+  fi
+
+  if [[ -n "$HEAD_SERIES" ]]; then
+      SERIES_FILTER="^${HEAD_SERIES//./\\\\.}"
+      LATEST_CHART_VERSION=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r ".entries.rancher | map(select(.version | test(\"${SERIES_FILTER}\"))) | sort_by(.created) | .[-1].version")
+  fi
+fi
 
 sudo mkdir -p /etc/rancher/rke2
 sudo touch /etc/rancher/rke2/config.yaml
@@ -97,6 +129,10 @@ if [ -n "${REGISTRY_USERNAME}" ] && [ -n "${REGISTRY_PASSWORD}" ]; then
 fi
 
 if [ -n "$RANCHER_AGENT_IMAGE" ]; then
+  if [ "$REPO" == "prime-release" ]; then
+    RANCHER_TAG_VERSION=${LATEST_CHART_VERSION}
+  fi
+
   sudo docker pull ${REGISTRY}/${RANCHER_IMAGE}:${RANCHER_TAG_VERSION}
   sudo docker pull ${REGISTRY}/${RANCHER_AGENT_IMAGE}:${RANCHER_TAG_VERSION}
   sudo systemctl restart rke2-server

--- a/framework/set/resources/sanity/rancher/setup.sh
+++ b/framework/set/resources/sanity/rancher/setup.sh
@@ -119,7 +119,9 @@ install_helm() {
 setup_helm_repo() {
     echo "Adding Helm chart repo"
     if [ "$REPO" == "rc" ]; then
-        helm repo add rancher-partner-${REPO} ${RANCHER_CHART_REPO}${REPO}
+        helm repo add rancher-partner-${REPO} ${RANCHER_CHART_REPO}
+    elif [ "$REPO" == "prime-release" ]; then
+        helm repo add rancher-${REPO} ${RANCHER_CHART_REPO}
     else
         helm repo add rancher-${REPO} ${RANCHER_CHART_REPO}${REPO}
     fi
@@ -210,6 +212,19 @@ install_mcm_off() {
                                                                                          --set ingress.tls.source=secret \
                                                                                          --devel
     fi
+}
+
+install_prime_head_rancher() {
+    kubectl -n cattle-system create secret tls tls-rancher-ingress --cert=/home/$USER/tls.crt --key=/home/$USER/tls.key
+
+    echo "Installing Rancher"
+    helm upgrade --install rancher rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
+                                                                                         --set hostname=${HOSTNAME} \
+                                                                                         ${VERSION} \
+                                                                                         --set agentTLSMode=system-store \
+                                                                                         --set bootstrapPassword=${BOOTSTRAP_PASSWORD} \
+                                                                                         --set ingress.tls.source=secret \
+                                                                                         --devel
 }
 
 install_default_rancher() {
@@ -304,8 +319,39 @@ check_cluster_status
 install_helm
 setup_helm_repo
 
+if [[ $REPO == "prime-release" ]]; then
+    . /etc/os-release
+
+    [[ "${ID}" == "ubuntu" || "${ID}" == "debian" ]] && sudo apt update && sudo apt -y install yq
+    [[ "${ID}" == "rhel" || "${ID}" == "fedora" ]] && sudo yum install yq -y
+    [[ "${ID}" == "opensuse-leap" || "${ID}" == "sles" ]] && sudo zypper install  -y yq
+
+    HEAD_SERIES=""
+    if [[ $RANCHER_TAG_VERSION =~ ^v([0-9]+\.[0-9]+)-head$ ]]; then
+        HEAD_SERIES="${BASH_REMATCH[1]}"
+    fi
+
+    if [[ -z "$HEAD_SERIES" && $RANCHER_TAG_VERSION == "head" ]]; then
+      HEAD_SERIES="${RANCHER_HEAD_SERIES:-}"
+      if [[ -z "$HEAD_SERIES" ]]; then
+        HEAD_SERIES=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r '.entries.rancher[].version' | sed -nE 's/^([0-9]+\.[0-9]+)\.[0-9]+.*-head$/\1/p' | sort -Vu | tail -n 1)
+      fi
+    fi
+
+    if [[ $RANCHER_TAG_VERSION == "head" && -z "$HEAD_SERIES" ]]; then
+        LATEST_CHART_VERSION=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r '.entries.rancher | map(select(.version | test("^"))) | sort_by(.created) | .[-1].version')
+        VERSION="--version ${LATEST_CHART_VERSION}"
+    fi
+
+    if [[ -n "$HEAD_SERIES" ]]; then
+        SERIES_FILTER="^${HEAD_SERIES//./\\\\.}"
+        LATEST_CHART_VERSION=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r ".entries.rancher | map(select(.version | test(\"${SERIES_FILTER}\"))) | sort_by(.created) | .[-1].version")
+        VERSION="--version ${LATEST_CHART_VERSION}"
+    fi
+fi
+
 # Needed to get the latest chart version if RANCHER_TAG_VERSION contains "head"
-if [[ $RANCHER_TAG_VERSION == *head* ]]; then
+if [[ $RANCHER_TAG_VERSION == *head* && $REPO != "prime-release" ]]; then
     LATEST_CHART_VERSION=$(helm search repo rancher-${REPO} --devel | tail -n +2 | head -n 1 | cut -f2)
     VERSION="--version ${LATEST_CHART_VERSION}"
 fi
@@ -332,6 +378,8 @@ elif [ -n "$MCM" ]; then
     esac
 elif [ -n "$PARTNER_RC" ]; then
     install_partner_rc_rancher
+elif [[ $REPO == "prime-release" ]]; then
+    install_prime_head_rancher
 else
     install_default_rancher
 fi

--- a/framework/set/resources/sanity/rancher/upgrade.sh
+++ b/framework/set/resources/sanity/rancher/upgrade.sh
@@ -31,7 +31,11 @@ set -ex
 
 setup_helm_repo() {
     echo "Adding Helm chart repo"
-    helm repo add upgraded-rancher-${REPO} ${RANCHER_CHART_REPO}${REPO}
+    if [ "$REPO" == "prime-release" ]; then
+        helm repo add upgraded-rancher-${REPO} ${RANCHER_CHART_REPO}
+    else
+        helm repo add upgraded-rancher-${REPO} ${RANCHER_CHART_REPO}${REPO}
+    fi
 }
 
 upgrade_mcm_off() {
@@ -66,6 +70,17 @@ upgrade_mcm_off() {
                                                                                         --set ingress.tls.source=secret \
                                                                                         --devel
     fi
+}
+
+upgrade_prime_head_rancher() {
+    echo "Upgrading Rancher"
+    helm upgrade --install rancher upgraded-rancher-${REPO}/rancher --namespace cattle-system --set global.cattle.psp.enabled=false \
+                                                                                         --set hostname=${HOSTNAME} \
+                                                                                         ${VERSION} \
+                                                                                         --set agentTLSMode=system-store \
+                                                                                         --set bootstrapPassword=${BOOTSTRAP_PASSWORD} \
+                                                                                         --set ingress.tls.source=secret \
+                                                                                         --devel
 }
 
 upgrade_default_rancher() {
@@ -113,8 +128,39 @@ wait_for_rancher() {
 
 setup_helm_repo
 
+if [[ $REPO == "prime-release" ]]; then
+    . /etc/os-release
+
+    [[ "${ID}" == "ubuntu" || "${ID}" == "debian" ]] && sudo apt update && sudo apt -y install yq
+    [[ "${ID}" == "rhel" || "${ID}" == "fedora" ]] && sudo yum install yq -y
+    [[ "${ID}" == "opensuse-leap" || "${ID}" == "sles" ]] && sudo zypper install  -y yq
+
+    HEAD_SERIES=""
+    if [[ $RANCHER_TAG_VERSION =~ ^v([0-9]+\.[0-9]+)-head$ ]]; then
+        HEAD_SERIES="${BASH_REMATCH[1]}"
+    fi
+
+    if [[ -z "$HEAD_SERIES" && $RANCHER_TAG_VERSION == "head" ]]; then
+      HEAD_SERIES="${RANCHER_HEAD_SERIES:-}"
+      if [[ -z "$HEAD_SERIES" ]]; then
+        HEAD_SERIES=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r '.entries.rancher[].version' | sed -nE 's/^([0-9]+\.[0-9]+)\.[0-9]+.*-head$/\1/p' | sort -Vu | tail -n 1)
+      fi
+    fi
+
+    if [[ $RANCHER_TAG_VERSION == "head" && -z "$HEAD_SERIES" ]]; then
+        LATEST_CHART_VERSION=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r '.entries.rancher | map(select(.version | test("^"))) | sort_by(.created) | .[-1].version')
+        VERSION="--version ${LATEST_CHART_VERSION}"
+    fi
+
+    if [[ -n "$HEAD_SERIES" ]]; then
+        SERIES_FILTER="^${HEAD_SERIES//./\\\\.}"
+        LATEST_CHART_VERSION=$(curl -fsSL ${RANCHER_CHART_REPO}/index.yaml | yq -r ".entries.rancher | map(select(.version | test(\"${SERIES_FILTER}\"))) | sort_by(.created) | .[-1].version")
+        VERSION="--version ${LATEST_CHART_VERSION}"
+    fi
+fi
+
 # Needed to get the latest chart version if RANCHER_TAG_VERSION contains "head"
-if [[ $RANCHER_TAG_VERSION == *head* ]]; then
+if [[ $RANCHER_TAG_VERSION == *head* && $REPO != "prime-release" ]]; then
     LATEST_CHART_VERSION=$(helm search repo upgraded-rancher-${REPO} --devel | tail -n +2 | head -n 1 | cut -f2)
     VERSION="--version ${LATEST_CHART_VERSION}"
 fi
@@ -128,6 +174,8 @@ if [ -n "$UPGRADED_MCM" ]; then
             upgrade_default_rancher
             ;;
     esac
+elif [[ $REPO == "prime-release" ]]; then
+    upgrade_prime_head_rancher
 else
     upgrade_default_rancher
 fi

--- a/framework/set/resources/sanity/rancher/upgradeRancher.go
+++ b/framework/set/resources/sanity/rancher/upgradeRancher.go
@@ -50,7 +50,7 @@ func UpgradeRancher(file *os.File, newFile *hclwrite.File, rootBody *hclwrite.Bo
 	}
 
 	provisionerBlockBody.SetAttributeValue(general.Inline, cty.ListVal([]cty.Value{
-		cty.StringVal("printf '" + string(scriptContent) + "' > /tmp/upgrade.sh"),
+		cty.StringVal("cat <<'EOF' > /tmp/upgrade.sh\n" + string(scriptContent) + "\nEOF"),
 		cty.StringVal("chmod +x /tmp/upgrade.sh"),
 		cty.StringVal(command),
 	}))

--- a/tests/extensions/provisioning/verify.go
+++ b/tests/extensions/provisioning/verify.go
@@ -1,6 +1,8 @@
 package provisioning
 
 import (
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
@@ -21,11 +23,22 @@ func VerifyRegistry(t *testing.T, client *rancher.Client, clusterID string, terr
 }
 
 // VerifyRancherVersion validates that the expected rancher version matches the version of the rancher server.
-func VerifyRancherVersion(t *testing.T, hostURL, expectedVersion, keyPath string, terraformOptions *terraform.Options) {
+func VerifyRancherVersion(t *testing.T, hostURL, expectedVersion, keyPath string, terraformConfig *config.TerraformConfig,
+	terraformOptions *terraform.Options) {
 	resp, err := RequestRancherVersion(hostURL)
 	require.NoError(t, err)
 
 	logrus.Infof("Rancher version: %s | Rancher commit: %s", resp.RancherVersion, resp.GitCommit)
+
+	if strings.Contains(terraformConfig.Standalone.Repo, "prime-release") || strings.Contains(terraformConfig.Standalone.UpgradedRancherRepo, "prime-release") {
+		expectedVersionPrefix := strings.TrimSuffix(expectedVersion, "-head")
+		expectedVersionPrefix = strings.TrimSuffix(expectedVersionPrefix, ".x")
+		versionPattern := "^" + regexp.QuoteMeta(expectedVersionPrefix) + `\.[0-9]+-head$`
+
+		if matched, regexErr := regexp.MatchString(versionPattern, resp.RancherVersion); regexErr == nil && matched {
+			expectedVersion = resp.RancherVersion
+		}
+	}
 
 	if resp.RancherVersion != expectedVersion {
 		logrus.Infof("Expected version: %s | Actual version: %s", expectedVersion, resp.RancherVersion)

--- a/tests/infrastructure/ranchers/setup/airgap/rancher.go
+++ b/tests/infrastructure/ranchers/setup/airgap/rancher.go
@@ -47,30 +47,44 @@ func CreateAirgapRancher(t *testing.T, provider string, cattleConfig map[string]
 	}
 
 	_, err = operations.ReplaceValue([]string{"terraform", "airgapBastion"}, terraformConfig.AirgapBastion, cattleConfig)
-	require.NoError(t, err)
+	if err != nil {
+		return err
+	}
 
 	_, err = operations.ReplaceValue([]string{"terraform", "privateRegistries", "systemDefaultRegistry"}, terraformConfig.PrivateRegistries.SystemDefaultRegistry, cattleConfig)
-	require.NoError(t, err)
+	if err != nil {
+		return err
+	}
 
 	_, err = operations.ReplaceValue([]string{"terraform", "privateRegistries", "url"}, terraformConfig.PrivateRegistries.URL, cattleConfig)
-	require.NoError(t, err)
+	if err != nil {
+		return err
+	}
 
-	rancherConfig, terraformConfig, terratestConfig, _ = config.LoadTFPConfigs(cattleConfig)
+	rancherConfig, terraformConfig, terratestConfig, standaloneConfig = config.LoadTFPConfigs(cattleConfig)
 	infraConfig.WriteConfigToFile(os.Getenv(rancherinternal.ConfigEnvironmentKey), cattleConfig)
 
 	sshKey, err := os.ReadFile(terraformConfig.PrivateKeyPath)
-	require.NoError(t, err)
+	if err != nil {
+		return err
+	}
 
-	_, err = ssh.StartBastionSSHTunnel(bastion, terraformConfig.Standalone.OSUser, sshKey, "8443", standaloneConfig.RancherHostname, "443")
-	require.NoError(t, err)
+	_, err = ssh.StartBastionSSHTunnel(bastion, standaloneConfig.OSUser, sshKey, "8443", standaloneConfig.RancherHostname, "443")
+	if err != nil {
+		return err
+	}
 
 	testSession := session.NewSession()
 
-	client, err := ranchersetup.PostRancherSetup(t, terraformOptions, rancherConfig, testSession, terraformConfig.Standalone.RancherHostname, keyPath, false)
-	require.NoError(t, err)
+	client, err := ranchersetup.PostRancherSetup(t, terraformOptions, rancherConfig, testSession, standaloneConfig.RancherHostname, keyPath, false)
+	if err != nil {
+		return err
+	}
 
 	_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, client.RancherConfig.AdminToken, cattleConfig)
-	require.NoError(t, err)
+	if err != nil {
+		return err
+	}
 
 	rancherConfig, terraformConfig, terratestConfig, _ = config.LoadTFPConfigs(cattleConfig)
 	infraConfig.WriteConfigToFile(os.Getenv(rancherinternal.ConfigEnvironmentKey), cattleConfig)
@@ -104,7 +118,7 @@ func SetupAirgapRancher(t *testing.T, session *session.Session, moduleKeyPath st
 	tunnel, err := ssh.StartBastionSSHTunnel(bastion, terraformConfig.Standalone.OSUser, sshKey, "8443", standaloneConfig.RancherHostname, "443")
 	require.NoError(t, err)
 
-	client, err := ranchersetup.PostRancherSetup(t, standaloneTerraformOptions, rancherConfig, session, terraformConfig.Standalone.RancherHostname, keyPath, false)
+	client, err := ranchersetup.PostRancherSetup(t, standaloneTerraformOptions, rancherConfig, session, standaloneConfig.RancherHostname, keyPath, false)
 	require.NoError(t, err)
 
 	_, keyPath = rancher2.SetKeyPath(keypath.RancherKeyPath, terratestConfig.PathToRepo, "")

--- a/tests/infrastructure/ranchers/setup/dualstack/rancher.go
+++ b/tests/infrastructure/ranchers/setup/dualstack/rancher.go
@@ -68,7 +68,7 @@ func SetupDualStackRancher(t *testing.T, session *session.Session, moduleKeyPath
 	require.NoError(t, err)
 
 	if standaloneConfig.RancherTagVersion != rancherinternal.Head {
-		provisioning.VerifyRancherVersion(t, rancherConfig.Host, standaloneConfig.RancherTagVersion, keyPath, standaloneTerraformOptions)
+		provisioning.VerifyRancherVersion(t, rancherConfig.Host, standaloneConfig.RancherTagVersion, keyPath, terraformConfig, standaloneTerraformOptions)
 	}
 
 	_, keyPath = rancher2.SetKeyPath(keypath.RancherKeyPath, terratestConfig.PathToRepo, "")

--- a/tests/infrastructure/ranchers/setup/ipv6/rancher.go
+++ b/tests/infrastructure/ranchers/setup/ipv6/rancher.go
@@ -68,7 +68,7 @@ func SetupIPv6Rancher(t *testing.T, session *session.Session, moduleKeyPath stri
 	require.NoError(t, err)
 
 	if standaloneConfig.RancherTagVersion != rancherinternal.Head {
-		provisioning.VerifyRancherVersion(t, rancherConfig.Host, standaloneConfig.RancherTagVersion, keyPath, standaloneTerraformOptions)
+		provisioning.VerifyRancherVersion(t, rancherConfig.Host, standaloneConfig.RancherTagVersion, keyPath, terraformConfig, standaloneTerraformOptions)
 	}
 
 	_, keyPath = rancher2.SetKeyPath(keypath.RancherKeyPath, terratestConfig.PathToRepo, "")

--- a/tests/infrastructure/ranchers/setup/proxy/rancher.go
+++ b/tests/infrastructure/ranchers/setup/proxy/rancher.go
@@ -80,7 +80,7 @@ func SetupProxyRancher(t *testing.T, session *session.Session, moduleKeyPath str
 	require.NoError(t, err)
 
 	if standaloneConfig.RancherTagVersion != rancherinternal.Head {
-		provisioning.VerifyRancherVersion(t, rancherConfig.Host, standaloneConfig.RancherTagVersion, keyPath, standaloneTerraformOptions)
+		provisioning.VerifyRancherVersion(t, rancherConfig.Host, standaloneConfig.RancherTagVersion, keyPath, terraformConfig, standaloneTerraformOptions)
 	}
 
 	_, keyPath = rancher2.SetKeyPath(keypath.RancherKeyPath, terratestConfig.PathToRepo, "")

--- a/tests/infrastructure/ranchers/setup/registry/rancher.go
+++ b/tests/infrastructure/ranchers/setup/registry/rancher.go
@@ -80,7 +80,7 @@ func SetupRegistryRancher(t *testing.T, session *session.Session, moduleKeyPath 
 	require.NoError(t, err)
 
 	if standaloneConfig.RancherTagVersion != rancherinternal.Head {
-		provisioning.VerifyRancherVersion(t, rancherConfig.Host, standaloneConfig.RancherTagVersion, keyPath, standaloneTerraformOptions)
+		provisioning.VerifyRancherVersion(t, rancherConfig.Host, standaloneConfig.RancherTagVersion, keyPath, terraformConfig, standaloneTerraformOptions)
 	}
 
 	_, keyPath = rancher2.SetKeyPath(keypath.RancherKeyPath, terratestConfig.PathToRepo, "")

--- a/tests/infrastructure/ranchers/setup/standard/rancher.go
+++ b/tests/infrastructure/ranchers/setup/standard/rancher.go
@@ -110,7 +110,7 @@ func SetupRancher(t *testing.T, session *session.Session, moduleKeyPath string, 
 	require.NoError(t, err)
 
 	if standaloneConfig.RancherTagVersion != rancherinternal.Head {
-		provisioning.VerifyRancherVersion(t, rancherConfig.Host, standaloneConfig.RancherTagVersion, keyPath, standaloneTerraformOptions)
+		provisioning.VerifyRancherVersion(t, rancherConfig.Host, standaloneConfig.RancherTagVersion, keyPath, terraformConfig, standaloneTerraformOptions)
 	}
 
 	if standaloneConfig.FeatureFlags != nil && standaloneConfig.FeatureFlags.Turtles != "" {

--- a/tests/infrastructure/ranchers/upgrade/airgap/rancher.go
+++ b/tests/infrastructure/ranchers/upgrade/airgap/rancher.go
@@ -95,11 +95,11 @@ func UpgradeAirgapRancher(t *testing.T, client *rancher.Client, bastion, registr
 	sshKey, err := os.ReadFile(terraformConfig.PrivateKeyPath)
 	require.NoError(t, err)
 
-	tunnel, err = ssh.StartBastionSSHTunnel(bastion, terraformConfig.Standalone.OSUser, sshKey, "8443", standaloneConfig.RancherHostname, "443")
+	tunnel, err = ssh.StartBastionSSHTunnel(bastion, standaloneConfig.OSUser, sshKey, "8443", standaloneConfig.RancherHostname, "443")
 	require.NoError(t, err)
 
 	standaloneTerraformOptions := framework.Setup(t, terraformConfig, terratestConfig, keypath.AirgapKeyPath)
-	client, err = ranchersetup.PostRancherSetup(t, standaloneTerraformOptions, rancherConfig, session, terraformConfig.Standalone.RancherHostname, keyPath, true)
+	client, err = ranchersetup.PostRancherSetup(t, standaloneTerraformOptions, rancherConfig, session, standaloneConfig.RancherHostname, keyPath, true)
 	require.NoError(t, err)
 
 	updatedCattleConfig, err := ranchersetup.UpdateRancherConfigMap(cattleConfig, client)
@@ -109,7 +109,7 @@ func UpgradeAirgapRancher(t *testing.T, client *rancher.Client, bastion, registr
 		_, airgapKeyPath := rancher2.SetKeyPath(keypath.AirgapKeyPath, terratestConfig.PathToRepo, terraformConfig.Provider)
 		terraformOptions := framework.Setup(t, terraformConfig, terratestConfig, airgapKeyPath)
 
-		provisioning.VerifyRancherVersion(t, rancherConfig.Host, standaloneConfig.UpgradedRancherTagVersion, airgapKeyPath, terraformOptions)
+		provisioning.VerifyRancherVersion(t, rancherConfig.Host, standaloneConfig.UpgradedRancherTagVersion, airgapKeyPath, terraformConfig, terraformOptions)
 	}
 
 	_, keyPath = rancher2.SetKeyPath(keypath.RancherKeyPath, terratestConfig.PathToRepo, "")

--- a/tests/infrastructure/ranchers/upgrade/dualstack/rancher.go
+++ b/tests/infrastructure/ranchers/upgrade/dualstack/rancher.go
@@ -86,7 +86,7 @@ func UpgradeDualStackRancher(t *testing.T, client *rancher.Client, serverNodeOne
 		_, dualStackKeyPath := rancher2.SetKeyPath(keypath.DualStackKeyPath, terratestConfig.PathToRepo, terraformConfig.Provider)
 		terraformOptions := framework.Setup(t, terraformConfig, terratestConfig, dualStackKeyPath)
 
-		provisioning.VerifyRancherVersion(t, rancherConfig.Host, standaloneConfig.UpgradedRancherTagVersion, dualStackKeyPath, terraformOptions)
+		provisioning.VerifyRancherVersion(t, rancherConfig.Host, standaloneConfig.UpgradedRancherTagVersion, dualStackKeyPath, terraformConfig, terraformOptions)
 	}
 
 	_, keyPath = rancher2.SetKeyPath(keypath.RancherKeyPath, terratestConfig.PathToRepo, "")

--- a/tests/infrastructure/ranchers/upgrade/ipv6/rancher.go
+++ b/tests/infrastructure/ranchers/upgrade/ipv6/rancher.go
@@ -86,7 +86,7 @@ func UpgradeIPv6Rancher(t *testing.T, client *rancher.Client, serverNodeOne stri
 		_, ipv6KeyPath := rancher2.SetKeyPath(keypath.IPv6KeyPath, terratestConfig.PathToRepo, terraformConfig.Provider)
 		terraformOptions := framework.Setup(t, terraformConfig, terratestConfig, ipv6KeyPath)
 
-		provisioning.VerifyRancherVersion(t, rancherConfig.Host, standaloneConfig.UpgradedRancherTagVersion, ipv6KeyPath, terraformOptions)
+		provisioning.VerifyRancherVersion(t, rancherConfig.Host, standaloneConfig.UpgradedRancherTagVersion, ipv6KeyPath, terraformConfig, terraformOptions)
 	}
 
 	_, keyPath = rancher2.SetKeyPath(keypath.RancherKeyPath, terratestConfig.PathToRepo, "")

--- a/tests/infrastructure/ranchers/upgrade/proxy/rancher.go
+++ b/tests/infrastructure/ranchers/upgrade/proxy/rancher.go
@@ -87,7 +87,7 @@ func UpgradeProxyRancher(t *testing.T, client *rancher.Client, proxyPrivateIP, p
 		_, proxyKeyPath := rancher2.SetKeyPath(keypath.ProxyKeyPath, terratestConfig.PathToRepo, terraformConfig.Provider)
 		terraformOptions := framework.Setup(t, terraformConfig, terratestConfig, proxyKeyPath)
 
-		provisioning.VerifyRancherVersion(t, rancherConfig.Host, standaloneConfig.UpgradedRancherTagVersion, proxyKeyPath, terraformOptions)
+		provisioning.VerifyRancherVersion(t, rancherConfig.Host, standaloneConfig.UpgradedRancherTagVersion, proxyKeyPath, terraformConfig, terraformOptions)
 	}
 
 	_, keyPath = rancher2.SetKeyPath(keypath.RancherKeyPath, terratestConfig.PathToRepo, "")

--- a/tests/infrastructure/ranchers/upgrade/standard/rancher.go
+++ b/tests/infrastructure/ranchers/upgrade/standard/rancher.go
@@ -101,7 +101,7 @@ func UpgradeRancher(t *testing.T, client *rancher.Client, serverNodeOne string, 
 		_, sanityKeyPath := rancher2.SetKeyPath(keypath.SanityKeyPath, terratestConfig.PathToRepo, terraformConfig.Provider)
 		terraformOptions := framework.Setup(t, terraformConfig, terratestConfig, sanityKeyPath)
 
-		provisioning.VerifyRancherVersion(t, rancherConfig.Host, standaloneConfig.UpgradedRancherTagVersion, sanityKeyPath, terraformOptions)
+		provisioning.VerifyRancherVersion(t, rancherConfig.Host, standaloneConfig.UpgradedRancherTagVersion, sanityKeyPath, terraformConfig, terraformOptions)
 	}
 
 	_, keyPath = rancher2.SetKeyPath(keypath.RancherKeyPath, terratestConfig.PathToRepo, "")


### PR DESCRIPTION
Adds support for using Rancher Prime HEAD builds when installing new Rancher environments and upgrading existing Rancher setups. This ensures both fresh install and upgrade workflows can work with Rancher Prime head build artifacts.