### PR TITLE
Update v2.15 and v2.16 GitHub Action jobs to use prime-head and add new check-prime-head-results.yml workflow

### DIFF
--- a/.github/actions/check-prime-head-results/action.yaml
+++ b/.github/actions/check-prime-head-results/action.yaml
@@ -1,0 +1,68 @@
+---
+name: Check Prime Head Results
+description: "Checks if all dispatch workflows have successful prime head job completions for specified release lines"
+
+inputs:
+  dispatch-workflow-list:
+    description: "Comma-separated list of dispatch workflow names to check"
+    required: true
+
+outputs:
+  complete_v215:
+    description: "Whether v2.15 prime head release testing is complete"
+    value: ${{ steps.check-releases.outputs.complete_v215 }}
+  failed_workflows_v215:
+    description: "Comma-separated list of workflows that need v2.15 re-run"
+    value: ${{ steps.check-releases.outputs.failed_workflows_v215 }}
+
+runs:
+  using: composite
+  steps:
+    - id: check-releases
+      env:
+        SANITIZED_RELEASES: "v215"
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        WORKFLOWS="${{ inputs.dispatch-workflow-list }}"
+        
+        for release in $SANITIZED_RELEASES; do
+          ALL_PASSED=true
+          FAILED_WORKFLOWS=""
+          JOB_NAME="v${release:1:1}.${release:2}"
+          
+          echo "Checking $release jobs..."
+          for workflow in ${WORKFLOWS//,/ }; do
+            RESPONSE=$(gh api repos/${{ github.repository }}/actions/workflows/${workflow}/runs \
+              --jq '[.workflow_runs[] | select(.head_branch=="main" and .event=="schedule")] | .[0]')
+            
+            if [[ -z "$RESPONSE" ]] || [[ "$RESPONSE" == "null" ]]; then
+              echo "  $workflow: No recent runs found"
+              ALL_PASSED=false
+              FAILED_WORKFLOWS="${FAILED_WORKFLOWS}${workflow},"
+              continue
+            fi
+
+            RUN_ID=$(echo "$RESPONSE" | jq -r '.id')
+            
+            JOB_SUCCESS=$(gh api repos/${{ github.repository }}/actions/runs/${RUN_ID}/jobs \
+              --jq ".jobs[] | select(.name==\"${JOB_NAME}\" and .conclusion==\"success\") | .name" 2>/dev/null)
+
+            if [[ -z "$JOB_SUCCESS" ]]; then
+              echo "  - $workflow did not pass, needs to re-run..."
+              ALL_PASSED=false
+              FAILED_WORKFLOWS="${FAILED_WORKFLOWS}${workflow},"
+            else
+              echo "  - $workflow has a successful run!"
+            fi
+          done
+
+          if [[ "$ALL_PASSED" == "true" ]]; then
+            echo "complete_${release}=true" >> $GITHUB_OUTPUT
+          else
+            echo "complete_${release}=false" >> $GITHUB_OUTPUT
+          fi
+          
+          FAILED_WORKFLOWS="${FAILED_WORKFLOWS%,}"
+          echo "failed_workflows_${release}=${FAILED_WORKFLOWS}" >> $GITHUB_OUTPUT
+        done
+      shell: bash

--- a/.github/actions/report-prime-head-results/action.yaml
+++ b/.github/actions/report-prime-head-results/action.yaml
@@ -1,0 +1,68 @@
+---
+name: Report Prime Head Results
+description: "Reports prime head release testing results and sends Slack notifications for completed release lines"
+
+inputs:
+  complete_v215:
+    description: "Whether v2.15 prime head release testing is complete"
+    required: true
+  failed_workflows_v215:
+    description: "Comma-separated list of workflows that need v2.15 re-run"
+    required: true
+  slack-webhook-url:
+    description: "Slack webhook URL for notifications"
+    required: true
+  rancher-tag-bucket:
+    description: "S3 bucket for storing notification markers"
+    required: true
+  rancher-version-v215:
+    description: "Rancher version for v2.15 (e.g., v2.15-head)"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Report prime head results
+      run: |       
+        if [[ "${{ inputs.complete_v215 }}" != "true" ]]; then
+          echo "v2.15 workflows needing re-run:"
+          echo "${{ inputs.failed_workflows_v215 }}"
+        fi
+      shell: bash
+
+    - name: Check if Slack notification already sent
+      if: ${{ inputs.complete_v215 == 'true' }}
+      id: check_marker
+      run: |
+        TAG="${{ inputs.rancher-version-v215 }}"
+        BASE_TAG=$(echo "$TAG" | grep -oE '^v[0-9]+\.[0-9]+')
+        MARKER_FILE="slack_notified_${BASE_TAG}.txt"
+        
+        echo "BASE_TAG=$BASE_TAG" >> $GITHUB_ENV
+        echo "MARKER_FILE=$MARKER_FILE" >> $GITHUB_ENV
+        
+        if aws s3 ls "s3://${{ inputs.rancher-tag-bucket }}/${MARKER_FILE}" > /dev/null 2>&1; then
+          echo "Notification already sent for $BASE_TAG. Skipping."
+          echo "skip_slack=true" >> $GITHUB_OUTPUT
+        else
+          echo "skip_slack=false" >> $GITHUB_OUTPUT
+        fi
+      shell: bash
+
+    - name: Send v2-15 release testing completion notification
+      if: ${{ inputs.complete_v215 == 'true' && steps.check_marker.outputs.skip_slack == 'false' }}
+      uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4
+      with:
+        webhook: ${{ inputs.slack-webhook-url }}
+        webhook-type: incoming-webhook
+        payload: |
+          {
+            "text": "*[rancher/tfp-automation]* :alert:\n`${{ env.BASE_TAG }}` Release Testing Completed :white_check_mark:"
+          }
+
+    - name: Write notification marker to S3
+      if: ${{ inputs.complete_v215 == 'true' && steps.check_marker.outputs.skip_slack == 'false' }}
+      run: |
+        echo "notified" > marker.txt
+        aws s3 cp marker.txt "s3://${{ inputs.rancher-tag-bucket }}/${MARKER_FILE}"
+      shell: bash

--- a/.github/config/dispatch-workflows.txt
+++ b/.github/config/dispatch-workflows.txt
@@ -1,1 +1,1 @@
-day2-ops-rancher2.yaml
+day2-ops-rancher2.yml

--- a/.github/workflows/aks-provisioning.yml
+++ b/.github/workflows/aks-provisioning.yml
@@ -50,7 +50,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'head'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
-    environment: head
+    environment: prime-head
     env:
       CLOUD_PROVIDER: "azure"
       DOWNSTREAM_CLUSTER_PROVIDER: "azure"
@@ -141,14 +141,6 @@ jobs:
               (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_15)
             }}
 
-      - name: Set Rancher repo
-        uses: ./.github/actions/set-rancher-repo
-        with:
-          rancher-version: ${{ env.RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.RANCHER_REPO }}
-          is-prime: false
-          release-community-version: "2.16"
-
       - name: Get Qase ID
         id: get-qase-id
         uses: ./.github/actions/get-qase-id
@@ -156,15 +148,6 @@ jobs:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_16 }}"
           qase_recurring_id: "${{ vars.QASE_RECURRING_TEST_RUN_ID_2_16 }}"
-
-      - name: Set Rancher chart url
-        uses: ./.github/actions/set-rancher-chart-url
-        with:
-          rancher-repo: ${{ env.RANCHER_REPO }}
-          is-prime: false
-          community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
-          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
-          fallback-chart-url: ${{ secrets.RANCHER_HELM_CHART_URL }}
 
       - name: Create config.yaml
         run: |
@@ -231,13 +214,13 @@ jobs:
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               osUser: "${{ secrets.AZURE_SSH_USER }}"
               osGroup: "${{ secrets.AZURE_SSH_USER }}"
-              rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
+              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ vars.AZURE_LOCATION }}.cloudapp.azure.com"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
               registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
-              repo: "${{ env.RANCHER_REPO }}"
+              repo: "${{ secrets.RANCHER_REPO }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
@@ -327,7 +310,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.15-head'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
-    environment: head
+    environment: prime-head
     env:
       CLOUD_PROVIDER: "azure"
       DOWNSTREAM_CLUSTER_PROVIDER: "azure"
@@ -418,14 +401,6 @@ jobs:
               (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_15)
             }}
 
-      - name: Set Rancher repo
-        uses: ./.github/actions/set-rancher-repo
-        with:
-          rancher-version: ${{ env.RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.RANCHER_REPO }}
-          is-prime: false
-          release-community-version: "2.15"
-
       - name: Get Qase ID
         id: get-qase-id
         uses: ./.github/actions/get-qase-id
@@ -433,15 +408,6 @@ jobs:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_15 }}"
           qase_recurring_id: "${{ vars.QASE_RECURRING_TEST_RUN_ID_2_15 }}"
-
-      - name: Set Rancher chart url
-        uses: ./.github/actions/set-rancher-chart-url
-        with:
-          rancher-repo: ${{ env.RANCHER_REPO }}
-          is-prime: false
-          community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
-          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
-          fallback-chart-url: ${{ secrets.RANCHER_HELM_CHART_URL }}
 
       - name: Create config.yaml
         run: |
@@ -508,13 +474,13 @@ jobs:
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               osUser: "${{ secrets.AZURE_SSH_USER }}"
               osGroup: "${{ secrets.AZURE_SSH_USER }}"
-              rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
+              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ vars.AZURE_LOCATION }}.cloudapp.azure.com"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
               registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
-              repo: "${{ env.RANCHER_REPO }}"
+              repo: "${{ secrets.RANCHER_REPO }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
@@ -604,7 +570,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
-    environment: staging-latest
+    environment: prime-head
     env:
       CLOUD_PROVIDER: "azure"
       DOWNSTREAM_CLUSTER_PROVIDER: "azure"
@@ -695,14 +661,6 @@ jobs:
               (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_14)
             }}
 
-      - name: Set Rancher repo
-        uses: ./.github/actions/set-rancher-repo
-        with:
-          rancher-version: ${{ env.RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.RANCHER_REPO }}
-          is-prime: true
-          release-prime-version: "2.14"
-
       - name: Get Qase ID
         id: get-qase-id
         uses: ./.github/actions/get-qase-id
@@ -710,15 +668,6 @@ jobs:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_14 }}"
           qase_recurring_id: "${{ vars.QASE_RECURRING_TEST_RUN_ID_2_14 }}"
-
-      - name: Set Rancher chart url
-        uses: ./.github/actions/set-rancher-chart-url
-        with:
-          rancher-repo: ${{ env.RANCHER_REPO }}
-          is-prime: true
-          community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
-          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
-          fallback-chart-url: ${{ secrets.RANCHER_HELM_CHART_URL }}
 
       - name: Create config.yaml
         run: |
@@ -787,13 +736,13 @@ jobs:
               osUser: "${{ secrets.AZURE_SSH_USER }}"
               osGroup: "${{ secrets.AZURE_SSH_USER }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
-              rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
+              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ vars.AZURE_LOCATION }}.cloudapp.azure.com"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
               registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
-              repo: "${{ env.RANCHER_REPO }}"
+              repo: "${{ secrets.RANCHER_REPO }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}

--- a/.github/workflows/check-prime-head-results.yml
+++ b/.github/workflows/check-prime-head-results.yml
@@ -1,0 +1,92 @@
+---
+name: Check Prime Head Results
+
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+  actions: write
+
+jobs:
+  get-dispatch-workflow-list:
+    runs-on: ubuntu-latest
+    outputs:
+      workflow_list: ${{ steps.get-list.outputs.workflow_list }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Get workflow list from dispatch-workflows.yml
+        id: get-list
+        uses: ./.github/actions/get-dispatch-workflow-list
+
+  set-prime-head-chart-version:
+    needs: get-dispatch-workflow-list
+    runs-on: ubuntu-latest
+    env:
+      PRIME_HEAD_RELEASE_LINES: "v2.15"
+    outputs:
+      chart_version_v215: ${{ steps.set-chart-version.outputs.chart_version_v215 }}
+    steps:
+      - name: Set chart versions
+        id: set-chart-version
+        run: |
+          ALL_TAGS=$(curl -s https://api.github.com/repos/rancher/rancher/releases | jq -r '.[].tag_name')
+          for release in $PRIME_HEAD_RELEASE_LINES; do
+            SANITIZED="${release//./}"
+            LATEST=$(echo "$ALL_TAGS" \
+              | grep -E "^${release}\.[0-9]+$" \
+              | sort -V -r \
+              | head -n 1)
+            echo "chart_version_${SANITIZED}=${LATEST#v}" >> $GITHUB_OUTPUT
+          done
+
+  check-prime-head-results:
+    needs: [get-dispatch-workflow-list, set-prime-head-chart-version]
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    env:
+      RANCHER_VERSION_V215: "v2.15-head"
+    outputs:
+      complete_v215: ${{ steps.check-results.outputs.complete_v215 }}
+      failed_workflows_v215: ${{ steps.check-results.outputs.failed_workflows_v215 }}
+      rancher_version_v215: ${{ steps.set-versions.outputs.rancher_version_v215 }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
+        with:
+          role-to-assume: ${{ secrets.TFP_IAM_ROLE }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Set version outputs
+        id: set-versions
+        run: echo "rancher_version_v215=${RANCHER_VERSION_V215}" >> $GITHUB_OUTPUT
+
+      - name: Check prime head release testing results
+        id: check-results
+        uses: ./.github/actions/check-prime-head-results
+        with:
+          dispatch-workflow-list: ${{ needs.get-dispatch-workflow-list.outputs.workflow_list }}
+
+      - name: Report and notify prime head results
+        uses: ./.github/actions/report-prime-head-results
+        with:
+          complete_v215: ${{ steps.check-results.outputs.complete_v215 }}
+          failed_workflows_v215: ${{ steps.check-results.outputs.failed_workflows_v215 }}
+          slack-webhook-url: ${{ secrets.TEAM_SLACK_WEBHOOK_URL }}
+          rancher-tag-bucket: ${{ secrets.RANCHER_TAG_BUCKET }}
+          rancher-version-v215: ${{ env.RANCHER_VERSION_V215 }}
+
+  trigger-failed-prime-head-tests-v215:
+    needs: [check-prime-head-results, set-prime-head-chart-version]
+    if: ${{ needs.check-prime-head-results.outputs.failed_workflows_v215 != '' }}
+    uses: ./.github/workflows/dispatch-workflows.yml
+    with:
+      rancher_version: ${{ needs.check-prime-head-results.outputs.rancher_version_v215 }}
+      rancher_chart_version: ${{ needs.set-prime-head-chart-version.outputs.chart_version_v215 }}
+      workflow_list: ${{ needs.check-prime-head-results.outputs.failed_workflows_v215 }}

--- a/.github/workflows/day2-ops-rancher2.yml
+++ b/.github/workflows/day2-ops-rancher2.yml
@@ -62,7 +62,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'head'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
-    environment: head
+    environment: prime-head
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_16 }}"
       HOSTNAME_PREFIX: "tfp-rec-216"
@@ -155,14 +155,6 @@ jobs:
               (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_15)
             }}
 
-      - name: Set Rancher repo
-        uses: ./.github/actions/set-rancher-repo
-        with:
-          rancher-version: ${{ env.RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.RANCHER_REPO }}
-          is-prime: false
-          release-community-version: "2.16"
-
       - name: Get Qase ID
         id: get-qase-id
         uses: ./.github/actions/get-qase-id
@@ -170,15 +162,6 @@ jobs:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_16 }}"
           qase_recurring_id: "${{ vars.QASE_RECURRING_TEST_RUN_ID_2_16 }}"
-
-      - name: Set Rancher chart url
-        uses: ./.github/actions/set-rancher-chart-url
-        with:
-          rancher-repo: ${{ env.RANCHER_REPO }}
-          is-prime: false
-          community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
-          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
-          fallback-chart-url: ${{ secrets.RANCHER_HELM_CHART_URL }}
 
       - name: Create config.yaml
         run: |
@@ -245,13 +228,13 @@ jobs:
               k3sVersion: "${{ vars.K3S_VERSION_2_16 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ vars.OS_USER }}"
               osGroup: "${{ vars.OS_GROUP }}"
-              rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
+              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
               registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
-              repo: "${{ env.RANCHER_REPO }}"
+              repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_16 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
@@ -365,11 +348,11 @@ jobs:
     if: |
       github.event_name == 'schedule' ||
       github.event.inputs.run_all_versions == 'true' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.15')) && (contains(github.event.inputs.rancher_version, '-alpha') || contains(github.event.inputs.rancher_version, '-rc')) ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.15')) && (contains(inputs.rancher_version, '-alpha') || contains(inputs.rancher_version, '-rc'))
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.15-head')) ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.15-head'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
-    environment: head
+    environment: prime-head
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_15 }}"
       HOSTNAME_PREFIX: "tfp-rec-215"
@@ -462,14 +445,6 @@ jobs:
               (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_15)
             }}
 
-      - name: Set Rancher repo
-        uses: ./.github/actions/set-rancher-repo
-        with:
-          rancher-version: ${{ env.RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.RANCHER_REPO }}
-          is-prime: false
-          release-community-version: "2.15"
-
       - name: Get Qase ID
         id: get-qase-id
         uses: ./.github/actions/get-qase-id
@@ -477,15 +452,6 @@ jobs:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_15 }}"
           qase_recurring_id: "${{ vars.QASE_RECURRING_TEST_RUN_ID_2_15 }}"
-
-      - name: Set Rancher chart url
-        uses: ./.github/actions/set-rancher-chart-url
-        with:
-          rancher-repo: ${{ env.RANCHER_REPO }}
-          is-prime: false
-          community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
-          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
-          fallback-chart-url: ${{ secrets.RANCHER_HELM_CHART_URL }}
 
       - name: Create config.yaml
         run: |
@@ -552,13 +518,13 @@ jobs:
               k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ vars.OS_USER }}"
               osGroup: "${{ vars.OS_GROUP }}"
-              rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
+              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
               registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
-              repo: "${{ env.RANCHER_REPO }}"
+              repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"

--- a/.github/workflows/eks-provisioning.yml
+++ b/.github/workflows/eks-provisioning.yml
@@ -50,7 +50,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'head'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
-    environment: head
+    environment: prime-head
     env:
       CLOUD_PROVIDER: "eks"
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_16 }}"
@@ -155,14 +155,6 @@ jobs:
               (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_15)
             }}
 
-      - name: Set Rancher repo
-        uses: ./.github/actions/set-rancher-repo
-        with:
-          rancher-version: ${{ env.RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.RANCHER_REPO }}
-          is-prime: false
-          release-community-version: "2.16"
-
       - name: Get Qase ID
         id: get-qase-id
         uses: ./.github/actions/get-qase-id
@@ -170,15 +162,6 @@ jobs:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_16 }}"
           qase_recurring_id: "${{ vars.QASE_RECURRING_TEST_RUN_ID_2_16 }}"
-
-      - name: Set Rancher chart url
-        uses: ./.github/actions/set-rancher-chart-url
-        with:
-          rancher-repo: ${{ env.RANCHER_REPO }}
-          is-prime: false
-          community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
-          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
-          fallback-chart-url: ${{ secrets.RANCHER_HELM_CHART_URL }}
 
       - name: Create config.yaml
         run: |
@@ -230,13 +213,13 @@ jobs:
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
-              rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
+              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
               registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
-              repo: "${{ env.RANCHER_REPO }}"
+              repo: "${{ secrets.RANCHER_REPO }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
@@ -333,7 +316,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.15-head'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
-    environment: head
+    environment: prime-head
     env:
       CLOUD_PROVIDER: "eks"
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_15 }}"
@@ -438,14 +421,6 @@ jobs:
               (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_15)
             }}
 
-      - name: Set Rancher repo
-        uses: ./.github/actions/set-rancher-repo
-        with:
-          rancher-version: ${{ env.RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.RANCHER_REPO }}
-          is-prime: false
-          release-community-version: "2.15"
-
       - name: Get Qase ID
         id: get-qase-id
         uses: ./.github/actions/get-qase-id
@@ -453,15 +428,6 @@ jobs:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_15 }}"
           qase_recurring_id: "${{ vars.QASE_RECURRING_TEST_RUN_ID_2_15 }}"
-
-      - name: Set Rancher chart url
-        uses: ./.github/actions/set-rancher-chart-url
-        with:
-          rancher-repo: ${{ env.RANCHER_REPO }}
-          is-prime: false
-          community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
-          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
-          fallback-chart-url: ${{ secrets.RANCHER_HELM_CHART_URL }}
 
       - name: Create config.yaml
         run: |
@@ -513,13 +479,13 @@ jobs:
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
-              rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
+              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
               registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
-              repo: "${{ env.RANCHER_REPO }}"
+              repo: "${{ secrets.RANCHER_REPO }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
@@ -616,7 +582,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14-head'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
-    environment: staging-latest
+    environment: prime-head
     env:
       CLOUD_PROVIDER: "eks"
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_14 }}"
@@ -721,14 +687,6 @@ jobs:
               (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_14)
             }}
 
-      - name: Set Rancher repo
-        uses: ./.github/actions/set-rancher-repo
-        with:
-          rancher-version: ${{ env.RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.RANCHER_REPO }}
-          is-prime: true
-          release-prime-version: "2.14"
-
       - name: Get Qase ID
         id: get-qase-id
         uses: ./.github/actions/get-qase-id
@@ -736,15 +694,6 @@ jobs:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_14 }}"
           qase_recurring_id: "${{ vars.QASE_RECURRING_TEST_RUN_ID_2_14 }}"
-
-      - name: Set Rancher chart url
-        uses: ./.github/actions/set-rancher-chart-url
-        with:
-          rancher-repo: ${{ env.RANCHER_REPO }}
-          is-prime: true
-          community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
-          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
-          fallback-chart-url: ${{ secrets.RANCHER_HELM_CHART_URL }}
 
       - name: Create config.yaml
         run: |
@@ -797,13 +746,13 @@ jobs:
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
-              rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
+              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
               registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
-              repo: "${{ env.RANCHER_REPO }}"
+              repo: "${{ secrets.RANCHER_REPO }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}

--- a/.github/workflows/gke-provisioning.yml
+++ b/.github/workflows/gke-provisioning.yml
@@ -50,7 +50,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'head'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
-    environment: head
+    environment: prime-head
     env:
       CLOUD_PROVIDER: "gke"
       DOWNSTREAM_CLUSTER_PROVIDER: "google"
@@ -143,14 +143,6 @@ jobs:
               (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_15)
             }}
 
-      - name: Set Rancher repo
-        uses: ./.github/actions/set-rancher-repo
-        with:
-          rancher-version: ${{ env.RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.RANCHER_REPO }}
-          is-prime: false
-          release-community-version: "2.16"
-
       - name: Get Qase ID
         id: get-qase-id
         uses: ./.github/actions/get-qase-id
@@ -158,15 +150,6 @@ jobs:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_16 }}"
           qase_recurring_id: "${{ vars.QASE_RECURRING_TEST_RUN_ID_2_16 }}"
-
-      - name: Set Rancher chart url
-        uses: ./.github/actions/set-rancher-chart-url
-        with:
-          rancher-repo: ${{ env.RANCHER_REPO }}
-          is-prime: false
-          community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
-          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
-          fallback-chart-url: ${{ secrets.RANCHER_HELM_CHART_URL }}
 
       - name: Create config.yaml
         run: |
@@ -219,13 +202,13 @@ jobs:
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               osUser: "${{ vars.OS_USER }}"
               osGroup: "${{ vars.OS_GROUP }}"
-              rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
+              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.sslip.io"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
               registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
-              repo: "${{ env.RANCHER_REPO }}"
+              repo: "${{ secrets.RANCHER_REPO }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
@@ -315,7 +298,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.15-head'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
-    environment: head
+    environment: prime-head
     env:
       CLOUD_PROVIDER: "gke"
       DOWNSTREAM_CLUSTER_PROVIDER: "google"
@@ -408,14 +391,6 @@ jobs:
               (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_15)
             }}
 
-      - name: Set Rancher repo
-        uses: ./.github/actions/set-rancher-repo
-        with:
-          rancher-version: ${{ env.RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.RANCHER_REPO }}
-          is-prime: false
-          release-community-version: "2.15"
-
       - name: Get Qase ID
         id: get-qase-id
         uses: ./.github/actions/get-qase-id
@@ -423,15 +398,6 @@ jobs:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_15 }}"
           qase_recurring_id: "${{ vars.QASE_RECURRING_TEST_RUN_ID_2_15 }}"
-
-      - name: Set Rancher chart url
-        uses: ./.github/actions/set-rancher-chart-url
-        with:
-          rancher-repo: ${{ env.RANCHER_REPO }}
-          is-prime: false
-          community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
-          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
-          fallback-chart-url: ${{ secrets.RANCHER_HELM_CHART_URL }}
 
       - name: Create config.yaml
         run: |
@@ -484,13 +450,13 @@ jobs:
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               osUser: "${{ vars.OS_USER }}"
               osGroup: "${{ vars.OS_GROUP }}"
-              rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
+              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.sslip.io"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
               registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
-              repo: "${{ env.RANCHER_REPO }}"
+              repo: "${{ secrets.RANCHER_REPO }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}
@@ -580,7 +546,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14-head'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
-    environment: staging-latest
+    environment: prime-head
     env:
       CLOUD_PROVIDER: "gke"
       DOWNSTREAM_CLUSTER_PROVIDER: "google"
@@ -673,14 +639,6 @@ jobs:
               (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_14)
             }}
 
-      - name: Set Rancher repo
-        uses: ./.github/actions/set-rancher-repo
-        with:
-          rancher-version: ${{ env.RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.RANCHER_REPO }}
-          is-prime: true
-          release-prime-version: "2.14"
-
       - name: Get Qase ID
         id: get-qase-id
         uses: ./.github/actions/get-qase-id
@@ -688,15 +646,6 @@ jobs:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: "${{ vars.QASE_RELEASE_TEST_RUN_ID_2_14 }}"
           qase_recurring_id: "${{ vars.QASE_RECURRING_TEST_RUN_ID_2_14 }}"
-
-      - name: Set Rancher chart url
-        uses: ./.github/actions/set-rancher-chart-url
-        with:
-          rancher-repo: ${{ env.RANCHER_REPO }}
-          is-prime: true
-          community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
-          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
-          fallback-chart-url: ${{ secrets.RANCHER_HELM_CHART_URL }}
 
       - name: Create config.yaml
         run: |
@@ -750,13 +699,13 @@ jobs:
               osUser: "${{ vars.OS_USER }}"
               osGroup: "${{ vars.OS_GROUP }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
-              rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
+              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.sslip.io"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
               registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
-              repo: "${{ env.RANCHER_REPO }}"
+              repo: "${{ secrets.RANCHER_REPO }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             standaloneLogging: ${{ vars.TERRAFORM_STANDALONE_LOGGING }}

--- a/.github/workflows/ipv6-eks-provisioning.yml
+++ b/.github/workflows/ipv6-eks-provisioning.yml
@@ -63,7 +63,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'head'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
-    environment: head
+    environment: prime-head
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_16 }}"
       HOSTNAME_PREFIX: "ipv6-eks-216"
@@ -156,14 +156,6 @@ jobs:
               (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_15)
             }}
 
-      - name: Set Rancher repo
-        uses: ./.github/actions/set-rancher-repo
-        with:
-          rancher-version: ${{ env.RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.RANCHER_REPO }}
-          is-prime: false
-          release-community-version: "2.16"
-
       - name: Get Qase ID
         if: env.REPORTING_ENABLED == 'true'
         id: get-qase-id
@@ -172,15 +164,6 @@ jobs:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: ${{ vars.QASE_RELEASE_TEST_RUN_ID_2_16 }}
           qase_recurring_id: ${{ vars.QASE_RECURRING_TEST_RUN_ID_2_16 }}
-
-      - name: Set Rancher chart url
-        uses: ./.github/actions/set-rancher-chart-url
-        with:
-          rancher-repo: ${{ env.RANCHER_REPO }}
-          is-prime: false
-          community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
-          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
-          fallback-chart-url: ${{ secrets.RANCHER_HELM_CHART_URL }}
 
       - name: Create config.yaml
         run: |
@@ -250,13 +233,13 @@ jobs:
               k3sVersion: "${{ vars.K3S_VERSION_2_16 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ vars.IPV6_OS_USER }}"
               osGroup: "${{ vars.IPV6_OS_GROUP }}"
-              rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
+              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
               registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
-              repo: "${{ env.RANCHER_REPO }}"
+              repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_16 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
@@ -359,7 +342,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.15-head'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
-    environment: head
+    environment: prime-head
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_15 }}"
       HOSTNAME_PREFIX: "ipv6-eks-215"
@@ -452,14 +435,6 @@ jobs:
               (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_15)
             }}
 
-      - name: Set Rancher repo
-        uses: ./.github/actions/set-rancher-repo
-        with:
-          rancher-version: ${{ env.RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.RANCHER_REPO }}
-          is-prime: false
-          release-community-version: "2.15"
-
       - name: Get Qase ID
         if: env.REPORTING_ENABLED == 'true'
         id: get-qase-id
@@ -468,15 +443,6 @@ jobs:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: ${{ vars.QASE_RELEASE_TEST_RUN_ID_2_15 }}
           qase_recurring_id: ${{ vars.QASE_RECURRING_TEST_RUN_ID_2_15 }}
-
-      - name: Set Rancher chart url
-        uses: ./.github/actions/set-rancher-chart-url
-        with:
-          rancher-repo: ${{ env.RANCHER_REPO }}
-          is-prime: false
-          community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
-          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
-          fallback-chart-url: ${{ secrets.RANCHER_HELM_CHART_URL }}
 
       - name: Create config.yaml
         run: |
@@ -546,13 +512,13 @@ jobs:
               k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ vars.IPV6_OS_USER }}"
               osGroup: "${{ vars.IPV6_OS_GROUP }}"
-              rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
+              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
               registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
-              repo: "${{ env.RANCHER_REPO }}"
+              repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
@@ -654,7 +620,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14-head'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
-    environment: staging-latest
+    environment: prime-head
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_14 }}"
       HOSTNAME_PREFIX: "ipv6-eks-214"
@@ -747,14 +713,6 @@ jobs:
               (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_14)
             }}
 
-      - name: Set Rancher repo
-        uses: ./.github/actions/set-rancher-repo
-        with:
-          rancher-version: ${{ env.RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.RANCHER_REPO }}
-          is-prime: true
-          release-prime-version: "2.14"
-
       - name: Get Qase ID
         if: env.REPORTING_ENABLED == 'true'
         id: get-qase-id
@@ -763,15 +721,6 @@ jobs:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
           qase_release_id: ${{ vars.QASE_RELEASE_TEST_RUN_ID_2_14 }}
           qase_recurring_id: ${{ vars.QASE_RECURRING_TEST_RUN_ID_2_14 }}
-
-      - name: Set Rancher chart url
-        uses: ./.github/actions/set-rancher-chart-url
-        with:
-          rancher-repo: ${{ env.RANCHER_REPO }}
-          is-prime: false
-          community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
-          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
-          fallback-chart-url: ${{ secrets.RANCHER_HELM_CHART_URL }}
 
       - name: Create config.yaml
         run: |
@@ -842,13 +791,13 @@ jobs:
               osUser: "${{ vars.IPV6_OS_USER }}"
               osGroup: "${{ vars.IPV6_OS_GROUP }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
-              rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
+              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
               registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
-              repo: "${{ env.RANCHER_REPO }}"
+              repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_14 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"


### PR DESCRIPTION
## Summary
Updates the GitHub Actions jobs for v2.15 and v2.16 to use `prime-head` and adds a new `check-prime-head-results.yml` workflow to validate the resulting checks.
## Changes
- switch the v2.15 and v2.16 GitHub Actions jobs to use `prime-head`
- add the `check-prime-head-results.yml` workflow to verify `prime-head` results