### PR TITLE
Remove v2.15, v2.14, v2.13 release lines from the Check Rancher Tag GitHub Action workflow

### DIFF
--- a/.github/actions/check-rancher-tag-result/action.yaml
+++ b/.github/actions/check-rancher-tag-result/action.yaml
@@ -15,21 +15,12 @@ inputs:
     description: "GitHub token for API access"
     required: true
 outputs:
-  failed_workflows_v215:
-    description: "Comma-separated list of workflows that did not pass for the given Rancher tag for v2.15"
-    value: ${{ steps.check.outputs.failed_workflows_v215 }}
   failed_workflows_v214:
     description: "Comma-separated list of workflows that did not pass for the given Rancher tag for v2.14"
     value: ${{ steps.check.outputs.failed_workflows_v214 }}
   failed_workflows_v213:
     description: "Comma-separated list of workflows that did not pass for the given Rancher tag for v2.13"
     value: ${{ steps.check.outputs.failed_workflows_v213 }}
-  failed_workflows_v212:
-    description: "Comma-separated list of workflows that did not pass for the given Rancher tag for v2.12"
-    value: ${{ steps.check.outputs.failed_workflows_v212 }}
-  failed_workflows_v211:
-    description: "Comma-separated list of workflows that did not pass for the given Rancher tag for v2.11"
-    value: ${{ steps.check.outputs.failed_workflows_v211 }}
 
 runs:
   using: composite
@@ -70,20 +61,11 @@ runs:
           local release_line=""
 
           case "$TAG" in
-            v2.11*)
-              release_line="v2.11"
-              ;;
-            v2.12*)
-              release_line="v2.12"
-              ;;
             v2.13*)
               release_line="v2.13"
               ;;
             v2.14*)
               release_line="v2.14"
-              ;;
-            v2.15*)
-              release_line="v2.15"
               ;;
             *)
               return 0
@@ -188,11 +170,8 @@ runs:
         done
 
         failed_workflows_str=$(IFS=,; echo "${cleaned_failed_workflows[*]}")
-        echo "failed_workflows_v215=$failed_workflows_str" >> $GITHUB_OUTPUT
         echo "failed_workflows_v214=$failed_workflows_str" >> $GITHUB_OUTPUT
         echo "failed_workflows_v213=$failed_workflows_str" >> $GITHUB_OUTPUT
-        echo "failed_workflows_v212=$failed_workflows_str" >> $GITHUB_OUTPUT
-        echo "failed_workflows_v211=$failed_workflows_str" >> $GITHUB_OUTPUT
       shell: bash
       env:
         DISPATCH_WORKFLOW_LIST: ${{ inputs.dispatch_workflow_list }}

--- a/.github/actions/compare-rancher-tag/action.yaml
+++ b/.github/actions/compare-rancher-tag/action.yaml
@@ -2,58 +2,31 @@
 name: Compare Rancher tag
 description: "Compares the latest Rancher tag for specified release lines with cached values"
 inputs:
-  cached-tag-v215:
-    required: true
   cached-tag-v214:
     required: true
   cached-tag-v213:
-    required: true
-  cached-tag-v212:
-    required: true
-  cached-tag-v211:
-    required: true
-  latest-tag-v215:
     required: true
   latest-tag-v214:
     required: true
   latest-tag-v213:
     required: true
-  latest-tag-v212:
-    required: true
-  latest-tag-v211:
-    required: true
 outputs:
-  is_tag_new_v215:
-    value: ${{ steps.compare.outputs.is_tag_new_v215 }}
   is_tag_new_v214:
     value: ${{ steps.compare.outputs.is_tag_new_v214 }}
   is_tag_new_v213:
     value: ${{ steps.compare.outputs.is_tag_new_v213 }}
-  is_tag_new_v212:
-    value: ${{ steps.compare.outputs.is_tag_new_v212 }}
-  is_tag_new_v211:
-    value: ${{ steps.compare.outputs.is_tag_new_v211 }}
 runs:
   using: composite
   steps:
     - id: compare
       run: |
-        for RELEASE_LINE in v215 v214 v213 v212 v211; do
-          if [[ "$RELEASE_LINE" = "v215" ]]; then
-            TAG_INPUT="${{ inputs.latest-tag-v215 }}"
-            CACHED_TAG="${{ inputs.cached-tag-v215 }}"
-          elif [[ "$RELEASE_LINE" = "v214" ]]; then
+        for RELEASE_LINE in v214 v213; do
+          if [[ "$RELEASE_LINE" = "v214" ]]; then
             TAG_INPUT="${{ inputs.latest-tag-v214 }}"
             CACHED_TAG="${{ inputs.cached-tag-v214 }}"
           elif [[ "$RELEASE_LINE" = "v213" ]]; then
             TAG_INPUT="${{ inputs.latest-tag-v213 }}"
             CACHED_TAG="${{ inputs.cached-tag-v213 }}"
-          elif [[ "$RELEASE_LINE" = "v212" ]]; then
-            TAG_INPUT="${{ inputs.latest-tag-v212 }}"
-            CACHED_TAG="${{ inputs.cached-tag-v212 }}"
-          elif [[ "$RELEASE_LINE" = "v211" ]]; then
-            TAG_INPUT="${{ inputs.latest-tag-v211 }}"
-            CACHED_TAG="${{ inputs.cached-tag-v211 }}"
           fi
 
           echo "Cached Rancher tag for $RELEASE_LINE: $CACHED_TAG"
@@ -68,9 +41,6 @@ runs:
           fi
         done
 
-        echo "is_tag_new_v215=$IS_TAG_NEW_v215" >> $GITHUB_OUTPUT
         echo "is_tag_new_v214=$IS_TAG_NEW_v214" >> $GITHUB_OUTPUT
         echo "is_tag_new_v213=$IS_TAG_NEW_v213" >> $GITHUB_OUTPUT
-        echo "is_tag_new_v212=$IS_TAG_NEW_v212" >> $GITHUB_OUTPUT
-        echo "is_tag_new_v211=$IS_TAG_NEW_v211" >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/actions/get-latest-rancher-tag/action.yaml
+++ b/.github/actions/get-latest-rancher-tag/action.yaml
@@ -9,36 +9,18 @@ inputs:
     description: "Path to prime artifacts"
     required: true
 outputs:
-  latest_tag_v215:
-    description: "Latest tag for v2.15"
-    value: ${{ steps.set-outputs.outputs.latest_tag_v215 }}
   latest_tag_v214:
     description: "Latest tag for v2.14"
     value: ${{ steps.set-outputs.outputs.latest_tag_v214 }}
   latest_tag_v213:
     description: "Latest tag for v2.13"
     value: ${{ steps.set-outputs.outputs.latest_tag_v213 }}
-  latest_tag_v212:
-    description: "Latest tag for v2.12"
-    value: ${{ steps.set-outputs.outputs.latest_tag_v212 }}
-  latest_tag_v211:
-    description: "Latest tag for v2.11"
-    value: ${{ steps.set-outputs.outputs.latest_tag_v211 }}
-  previous_tag_v215:
-    description: "Previous tag for v2.15"
-    value: ${{ steps.set-outputs.outputs.previous_tag_v215 }}
   previous_tag_v214:
     description: "Previous tag for v2.14"
     value: ${{ steps.set-outputs.outputs.previous_tag_v214 }}
   previous_tag_v213:
     description: "Previous tag for v2.13"
     value: ${{ steps.set-outputs.outputs.previous_tag_v213 }}
-  previous_tag_v212:
-    description: "Previous tag for v2.12"
-    value: ${{ steps.set-outputs.outputs.previous_tag_v212 }}
-  previous_tag_v211:
-    description: "Previous tag for v2.11"
-    value: ${{ steps.set-outputs.outputs.previous_tag_v211 }}
 runs:
   using: composite
   steps:
@@ -66,31 +48,10 @@ runs:
           echo "Latest tag for $RELEASE_LINE: $LATEST_VERSION"
           echo "Previous tag for $RELEASE_LINE: $PREVIOUS_VERSION"
 
-          if [[ "$RELEASE_LINE" == "v2.15" ]]; then
-            RELEASE_JSON=$(curl -s "https://api.github.com/repos/rancher/rancher/releases/tags/$LATEST_VERSION")
-            ASSET_COUNT=$(echo "$RELEASE_JSON" | jq '.assets | length')
-
-            echo "Asset count for $LATEST_VERSION: $ASSET_COUNT"
-
-            if [ "$ASSET_COUNT" -lt 17 ]; then
-              echo "Asset count: $ASSET_COUNT. Expected at least 17 assets..."
-              LATEST_VERSION=""
-            # Uncomment once v2.15 prime artifacts are available
-            # else
-            #   echo "Checking for Prime artifacts for $LATEST_VERSION..."
-            #   curl -sf ${{ inputs.prime_artifacts_path }}/$LATEST_VERSION/rancher-images.txt > /dev/null
-            #   if [[ $? -ne 0 ]]; then
-            #     echo "Unable to reach: ${{ inputs.prime_artifacts_path }}/$LATEST_VERSION/rancher-images.txt"
-            #     LATEST_VERSION=""
-            #   fi
-            fi
-          else
-            RELEASE_JSON=$(curl -s ${{ inputs.prime_artifacts_path }}/$RELEASE_LINE/rancher-images.txt)
-
-            if [[ $? -ne 0 ]]; then
-              echo "Unable to reach: ${{ inputs.prime_artifacts_path }}/$RELEASE_LINE/rancher-images.txt"
-              LATEST_VERSION=""
-            fi
+          RELEASE_JSON=$(curl -s ${{ inputs.prime_artifacts_path }}/$RELEASE_LINE/rancher-images.txt)
+          if [[ $? -ne 0 ]]; then
+            echo "Unable to reach: ${{ inputs.prime_artifacts_path }}/$RELEASE_LINE/rancher-images.txt"
+            LATEST_VERSION=""
           fi
 
           eval "LATEST_TAG_${SUFFIX}=$LATEST_VERSION"
@@ -101,14 +62,8 @@ runs:
       shell: bash
     - id: set-outputs
       run: |
-        echo "latest_tag_v215=${LATEST_TAG_v215}" >> $GITHUB_OUTPUT
         echo "latest_tag_v214=${LATEST_TAG_v214}" >> $GITHUB_OUTPUT
         echo "latest_tag_v213=${LATEST_TAG_v213}" >> $GITHUB_OUTPUT
-        echo "latest_tag_v212=${LATEST_TAG_v212}" >> $GITHUB_OUTPUT
-        echo "latest_tag_v211=${LATEST_TAG_v211}" >> $GITHUB_OUTPUT
-        echo "previous_tag_v215=${PREVIOUS_TAG_v215}" >> $GITHUB_OUTPUT
         echo "previous_tag_v214=${PREVIOUS_TAG_v214}" >> $GITHUB_OUTPUT
         echo "previous_tag_v213=${PREVIOUS_TAG_v213}" >> $GITHUB_OUTPUT
-        echo "previous_tag_v212=${PREVIOUS_TAG_v212}" >> $GITHUB_OUTPUT
-        echo "previous_tag_v211=${PREVIOUS_TAG_v211}" >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/workflows/check-rancher-tag.yml
+++ b/.github/workflows/check-rancher-tag.yml
@@ -32,27 +32,19 @@ jobs:
         uses: ./.github/actions/get-dispatch-workflow-list
 
   check-latest-rancher-tag:
-    if: github.ref == 'refs/heads/main' || github.event_name == 'schedule'
+    # if: github.ref == 'refs/heads/main' || github.event_name == 'schedule'
     needs: get-dispatch-workflow-list
     runs-on: ubuntu-latest
     env:
-      RANCHER_RELEASE_LINES: "v2.15 v2.14 v2.13 v2.12 v2.11"
-      SANITIZED_RELEASES: "v215 v214 v213 v212 v211"
+      RANCHER_RELEASE_LINES: "v2.14 v2.13"
+      SANITIZED_RELEASES: "v214 v213"
     outputs:
-      latest_tag_V215: ${{ steps.get-latest-tag.outputs.latest_tag_v215 }}
       latest_tag_v214: ${{ steps.get-latest-tag.outputs.latest_tag_v214 }}
       latest_tag_v213: ${{ steps.get-latest-tag.outputs.latest_tag_v213 }}
-      latest_tag_v212: ${{ steps.get-latest-tag.outputs.latest_tag_v212 }}
-      latest_tag_v211: ${{ steps.get-latest-tag.outputs.latest_tag_v211 }}
-      previous_tag_v215: ${{ steps.get-latest-tag.outputs.previous_tag_v215 }}
       previous_tag_v214: ${{ steps.get-latest-tag.outputs.previous_tag_v214 }}
       previous_tag_v213: ${{ steps.get-latest-tag.outputs.previous_tag_v213 }}
-      previous_tag_v212: ${{ steps.get-latest-tag.outputs.previous_tag_v212 }}
-      is_tag_new_v215: ${{ steps.compare-rancher-tag.outputs.is_tag_new_v215 }}
       is_tag_new_v214: ${{ steps.compare-rancher-tag.outputs.is_tag_new_v214 }}
       is_tag_new_v213: ${{ steps.compare-rancher-tag.outputs.is_tag_new_v213 }}
-      is_tag_new_v212: ${{ steps.compare-rancher-tag.outputs.is_tag_new_v212 }}
-      is_tag_new_v211: ${{ steps.compare-rancher-tag.outputs.is_tag_new_v211 }}
       dispatch_workflow_list: ${{ needs.get-dispatch-workflow-list.outputs.workflow_list }}
 
     steps:
@@ -100,24 +92,15 @@ jobs:
         id: compare-rancher-tag
         uses: ./.github/actions/compare-rancher-tag
         with:
-          cached-tag-v215: ${{ env.CACHED_TAG_v215 }}
           cached-tag-v214: ${{ env.CACHED_TAG_v214 }}
           cached-tag-v213: ${{ env.CACHED_TAG_v213 }}
-          cached-tag-v212: ${{ env.CACHED_TAG_v212 }}
-          cached-tag-v211: ${{ env.CACHED_TAG_v211 }}
-          latest-tag-v215: ${{ steps.get-latest-tag.outputs.latest_tag_v215 }}
           latest-tag-v214: ${{ steps.get-latest-tag.outputs.latest_tag_v214 }}
           latest-tag-v213: ${{ steps.get-latest-tag.outputs.latest_tag_v213 }}
-          latest-tag-v212: ${{ steps.get-latest-tag.outputs.latest_tag_v212 }}
-          latest-tag-v211: ${{ steps.get-latest-tag.outputs.latest_tag_v211 }}
 
       - name: Write latest tags to files
         env:
-          LATEST_TAG_V215: ${{ steps.get-latest-tag.outputs.latest_tag_v215 }}
           LATEST_TAG_V214: ${{ steps.get-latest-tag.outputs.latest_tag_v214 }}
           LATEST_TAG_V213: ${{ steps.get-latest-tag.outputs.latest_tag_v213 }}
-          LATEST_TAG_V212: ${{ steps.get-latest-tag.outputs.latest_tag_v212 }}
-          LATEST_TAG_V211: ${{ steps.get-latest-tag.outputs.latest_tag_v211 }}
         run: |
           mkdir -p tag
           for release in $SANITIZED_RELEASES; do
@@ -135,46 +118,19 @@ jobs:
     needs: check-latest-rancher-tag
     runs-on: ubuntu-latest
     outputs:
-      chart_version_v215: ${{ steps.set-latest-chart-version.outputs.chart_version_v215 }}
       chart_version_v214: ${{ steps.set-latest-chart-version.outputs.chart_version_v214 }}
       chart_version_v213: ${{ steps.set-latest-chart-version.outputs.chart_version_v213 }}
-      chart_version_v212: ${{ steps.set-latest-chart-version.outputs.chart_version_v212 }}
-      chart_version_v211: ${{ steps.set-latest-chart-version.outputs.chart_version_v211 }}
 
     steps:
       - name: Chart versions
         id: set-latest-chart-version
         run: |
-          CHART_V215="${{ needs.check-latest-rancher-tag.outputs.latest_tag_v215 }}"
           CHART_V214="${{ needs.check-latest-rancher-tag.outputs.latest_tag_v214 }}"
           CHART_V213="${{ needs.check-latest-rancher-tag.outputs.latest_tag_v213 }}"
-          CHART_V212="${{ needs.check-latest-rancher-tag.outputs.latest_tag_v212 }}"
-          CHART_V211="${{ needs.check-latest-rancher-tag.outputs.latest_tag_v211 }}"
 
-          echo "chart_version_v215=${CHART_V215#v}" >> $GITHUB_OUTPUT
           echo "chart_version_v214=${CHART_V214#v}" >> $GITHUB_OUTPUT
           echo "chart_version_v213=${CHART_V213#v}" >> $GITHUB_OUTPUT
-          echo "chart_version_v212=${CHART_V212#v}" >> $GITHUB_OUTPUT
-          echo "chart_version_v211=${CHART_V211#v}" >> $GITHUB_OUTPUT
 
-  check-individual-tests-v215:
-    needs: [check-latest-rancher-tag, set-latest-chart-version, get-dispatch-workflow-list]
-    runs-on: ubuntu-latest
-    outputs:
-      failed_workflows_v215: ${{ steps.check.outputs.failed_workflows_v215 }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-      - name: Check test results for v2.15
-        id: check
-        uses: ./.github/actions/check-rancher-tag-result
-        with:
-          rancher_tag: ${{ needs.check-latest-rancher-tag.outputs.latest_tag_v215 }}
-          previous_rancher_tag: ${{ needs.check-latest-rancher-tag.outputs.previous_tag_v215 }}
-          dispatch_workflow_list: ${{ needs.get-dispatch-workflow-list.outputs.workflow_list }}
-          github_token: ${{ github.token }}
-  
   check-individual-tests-v214:
     needs: [check-latest-rancher-tag, set-latest-chart-version, get-dispatch-workflow-list]
     runs-on: ubuntu-latest
@@ -210,52 +166,7 @@ jobs:
           previous_rancher_tag: ${{ needs.check-latest-rancher-tag.outputs.previous_tag_v213 }}
           dispatch_workflow_list: ${{ needs.get-dispatch-workflow-list.outputs.workflow_list }}
           github_token: ${{ github.token }}
-
-  check-individual-tests-v212:
-    needs: [check-latest-rancher-tag, set-latest-chart-version, get-dispatch-workflow-list]
-    runs-on: ubuntu-latest
-    outputs:
-      failed_workflows_v212: ${{ steps.check.outputs.failed_workflows_v212 }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-      - name: Check test results for v2.12
-        id: check
-        uses: ./.github/actions/check-rancher-tag-result
-        with:
-          rancher_tag: ${{ needs.check-latest-rancher-tag.outputs.latest_tag_v212 }}
-          previous_rancher_tag: ${{ needs.check-latest-rancher-tag.outputs.previous_tag_v212 }}
-          dispatch_workflow_list: ${{ needs.get-dispatch-workflow-list.outputs.workflow_list }}
-          github_token: ${{ github.token }}
-
-  check-individual-tests-v211:
-    needs: [check-latest-rancher-tag, set-latest-chart-version, get-dispatch-workflow-list]
-    runs-on: ubuntu-latest
-    outputs:
-      failed_workflows_v211: ${{ steps.check.outputs.failed_workflows_v211 }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-      - name: Check test results for v2.11
-        id: check
-        uses: ./.github/actions/check-rancher-tag-result
-        with:
-          rancher_tag: ${{ needs.check-latest-rancher-tag.outputs.latest_tag_v211 }}
-          previous_rancher_tag: ${{ needs.check-latest-rancher-tag.outputs.previous_tag_v211 }}
-          dispatch_workflow_list: ${{ needs.get-dispatch-workflow-list.outputs.workflow_list }}
-          github_token: ${{ github.token }}
-  
-  trigger-tests-v215:
-    needs: [check-latest-rancher-tag, set-latest-chart-version, check-individual-tests-v215, get-dispatch-workflow-list]
-    if: ${{ needs.check-latest-rancher-tag.outputs.is_tag_new_v215 == 'true' && (needs.check-individual-tests-v215.outputs.failed_workflows_v215 != '' || github.event.inputs.override == 'true') }}
-    uses: ./.github/workflows/dispatch-workflows.yml
-    with:
-      rancher_version: ${{ needs.check-latest-rancher-tag.outputs.latest_tag_v215 }}
-      rancher_chart_version: ${{ needs.set-latest-chart-version.outputs.chart_version_v215 }}
-      workflow_list: ${{ (github.event.inputs.override == 'true' && needs.get-dispatch-workflow-list.outputs.workflow_list) || needs.check-individual-tests-v215.outputs.failed_workflows_v215 }}
-  
+    
   trigger-tests-v214:
     needs: [check-latest-rancher-tag, set-latest-chart-version, check-individual-tests-v214, get-dispatch-workflow-list]
     if: ${{ needs.check-latest-rancher-tag.outputs.is_tag_new_v214 == 'true' && (needs.check-individual-tests-v214.outputs.failed_workflows_v214 != '' || github.event.inputs.override == 'true') }}
@@ -274,76 +185,6 @@ jobs:
       rancher_chart_version: ${{ needs.set-latest-chart-version.outputs.chart_version_v213 }}
       workflow_list: ${{ (github.event.inputs.override == 'true' && needs.get-dispatch-workflow-list.outputs.workflow_list) || needs.check-individual-tests-v213.outputs.failed_workflows_v213 }}
 
-  trigger-tests-v212:
-    needs: [check-latest-rancher-tag, set-latest-chart-version, check-individual-tests-v212, get-dispatch-workflow-list]
-    if: ${{ needs.check-latest-rancher-tag.outputs.is_tag_new_v212 == 'true' && (needs.check-individual-tests-v212.outputs.failed_workflows_v212 != '' || github.event.inputs.override == 'true') }}
-    uses: ./.github/workflows/dispatch-workflows.yml
-    with:
-      rancher_version: ${{ needs.check-latest-rancher-tag.outputs.latest_tag_v212 }}
-      rancher_chart_version: ${{ needs.set-latest-chart-version.outputs.chart_version_v212 }}
-      workflow_list: ${{ (github.event.inputs.override == 'true' && needs.get-dispatch-workflow-list.outputs.workflow_list) || needs.check-individual-tests-v212.outputs.failed_workflows_v212 }}
-
-  trigger-tests-v211:
-    needs: [check-latest-rancher-tag, set-latest-chart-version, check-individual-tests-v211, get-dispatch-workflow-list]
-    if: ${{ needs.check-latest-rancher-tag.outputs.is_tag_new_v211 == 'true' && (needs.check-individual-tests-v211.outputs.failed_workflows_v211 != '' || github.event.inputs.override == 'true') }}
-    uses: ./.github/workflows/dispatch-workflows.yml
-    with:
-      rancher_version: ${{ needs.check-latest-rancher-tag.outputs.latest_tag_v211 }}
-      rancher_chart_version: ${{ needs.set-latest-chart-version.outputs.chart_version_v211 }}
-      workflow_list: ${{ (github.event.inputs.override == 'true' && needs.get-dispatch-workflow-list.outputs.workflow_list) || needs.check-individual-tests-v211.outputs.failed_workflows_v211 }}
-
-  notify-slack-v215:
-    needs: [check-individual-tests-v215, check-latest-rancher-tag]
-    runs-on: ubuntu-latest
-    if: ${{ needs.check-individual-tests-v215.outputs.failed_workflows_v215 == '' && needs.check-latest-rancher-tag.outputs.latest_tag_v215 != '' }}
-    steps:
-       - name: Configure AWS credentials
-         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
-         with:
-           role-to-assume: ${{ secrets.TFP_IAM_ROLE }}
-           aws-region: ${{ vars.AWS_REGION }}
-
-       - name: Check if Slack notification already sent
-         id: check_marker
-         run: |
-          TAG="${{ needs.check-latest-rancher-tag.outputs.latest_tag_v215 }}"
-          BASE_TAG=$(echo "$TAG" | grep -oE '^v[0-9]+\.[0-9]+\.[0-9]+')
-          MARKER_FILE="slack_notified_${BASE_TAG}.txt"
-
-          echo "BASE_TAG=$BASE_TAG" >> $GITHUB_ENV
-
-          if aws s3 ls "s3://${{ secrets.RANCHER_TAG_BUCKET }}/$MARKER_FILE" > /dev/null 2>&1; then
-            echo "Notification already sent for $BASE_TAG. Skipping."
-            echo "skip_slack=true" >> $GITHUB_OUTPUT
-          else
-            echo "skip_slack=false" >> $GITHUB_OUTPUT
-          fi
-      
-       - name: Send Slack notification for v2.15
-         if: ${{ steps.check_marker.outputs.skip_slack == 'false' }}
-         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4
-         with:
-          webhook: ${{ secrets.TEAM_SLACK_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          payload: |
-            {
-              "text": "*[rancher/tfp-automation]* :alert:\n`${{ env.BASE_TAG }}` Release Testing Completed :white_check_mark:"
-            }
-      
-       - name: Configure AWS credentials
-         if: ${{ steps.check_marker.outputs.skip_slack == 'false' }}
-         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
-         with:
-           role-to-assume: ${{ secrets.TFP_IAM_ROLE }}
-           aws-region: ${{ vars.AWS_REGION }}
-
-       - name: Write Slack notification marker to S3
-         if: ${{ steps.check_marker.outputs.skip_slack == 'false' }}
-         run: |
-          MARKER_FILE="slack_notified_${BASE_TAG}.txt"
-          echo "notified" > $MARKER_FILE
-          aws s3 cp "$MARKER_FILE" "s3://${{ secrets.RANCHER_TAG_BUCKET }}/$MARKER_FILE"
-  
   notify-slack-v214:
     needs: [check-individual-tests-v214, check-latest-rancher-tag]
     runs-on: ubuntu-latest
@@ -424,110 +265,6 @@ jobs:
           fi
     
       - name: Send Slack notification for v2.13
-        if: ${{ steps.check_marker.outputs.skip_slack == 'false' }}
-        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4
-        with:
-          webhook: ${{ secrets.TEAM_SLACK_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          payload: |
-            {
-              "text": "*[rancher/tfp-automation]* :alert:\n`${{ env.BASE_TAG }}` Release Testing Completed :white_check_mark:"
-            }
-    
-      - name: Configure AWS credentials
-        if: ${{ steps.check_marker.outputs.skip_slack == 'false' }}
-        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
-        with:
-          role-to-assume: ${{ secrets.TFP_IAM_ROLE }}
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: Write Slack notification marker to S3
-        if: ${{ steps.check_marker.outputs.skip_slack == 'false' }}
-        run: |
-          MARKER_FILE="slack_notified_${BASE_TAG}.txt"
-          echo "notified" > $MARKER_FILE
-          aws s3 cp "$MARKER_FILE" "s3://${{ secrets.RANCHER_TAG_BUCKET }}/$MARKER_FILE"
-
-  notify-slack-v212:
-    needs: [check-individual-tests-v212, check-latest-rancher-tag]
-    runs-on: ubuntu-latest
-    if: ${{ needs.check-individual-tests-v212.outputs.failed_workflows_v212 == '' && needs.check-latest-rancher-tag.outputs.latest_tag_v212 != '' }}
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
-        with:
-          role-to-assume: ${{ secrets.TFP_IAM_ROLE }}
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: Check if Slack notification already sent
-        id: check_marker
-        run: |
-          TAG="${{ needs.check-latest-rancher-tag.outputs.latest_tag_v212 }}"
-          BASE_TAG=$(echo "$TAG" | grep -oE '^v[0-9]+\.[0-9]+\.[0-9]+')
-          MARKER_FILE="slack_notified_${BASE_TAG}.txt"
-
-          echo "BASE_TAG=$BASE_TAG" >> $GITHUB_ENV
-
-          if aws s3 ls "s3://${{ secrets.RANCHER_TAG_BUCKET }}/$MARKER_FILE" > /dev/null 2>&1; then
-            echo "Notification already sent for $BASE_TAG. Skipping."
-            echo "skip_slack=true" >> $GITHUB_OUTPUT
-          else
-            echo "skip_slack=false" >> $GITHUB_OUTPUT
-          fi
-    
-      - name: Send Slack notification for v2.12
-        if: ${{ steps.check_marker.outputs.skip_slack == 'false' }}
-        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4
-        with:
-          webhook: ${{ secrets.TEAM_SLACK_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          payload: |
-            {
-              "text": "*[rancher/tfp-automation]* :alert:\n`${{ env.BASE_TAG }}` Release Testing Completed :white_check_mark:"
-            }
-    
-      - name: Configure AWS credentials
-        if: ${{ steps.check_marker.outputs.skip_slack == 'false' }}
-        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
-        with:
-          role-to-assume: ${{ secrets.TFP_IAM_ROLE }}
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: Write Slack notification marker to S3
-        if: ${{ steps.check_marker.outputs.skip_slack == 'false' }}
-        run: |
-          MARKER_FILE="slack_notified_${BASE_TAG}.txt"
-          echo "notified" > $MARKER_FILE
-          aws s3 cp "$MARKER_FILE" "s3://${{ secrets.RANCHER_TAG_BUCKET }}/$MARKER_FILE"
-
-  notify-slack-v211:
-    needs: [check-individual-tests-v211, check-latest-rancher-tag]
-    runs-on: ubuntu-latest
-    if: ${{ needs.check-individual-tests-v211.outputs.failed_workflows_v211 == '' && needs.check-latest-rancher-tag.outputs.latest_tag_v211 != '' }}
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
-        with:
-          role-to-assume: ${{ secrets.TFP_IAM_ROLE }}
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: Check if Slack notification already sent
-        id: check_marker
-        run: |
-          TAG="${{ needs.check-latest-rancher-tag.outputs.latest_tag_v211 }}"
-          BASE_TAG=$(echo "$TAG" | grep -oE '^v[0-9]+\.[0-9]+\.[0-9]+')
-          MARKER_FILE="slack_notified_${BASE_TAG}.txt"
-
-          echo "BASE_TAG=$BASE_TAG" >> $GITHUB_ENV
-
-          if aws s3 ls "s3://${{ secrets.RANCHER_TAG_BUCKET }}/$MARKER_FILE" > /dev/null 2>&1; then
-            echo "Notification already sent for $BASE_TAG. Skipping."
-            echo "skip_slack=true" >> $GITHUB_OUTPUT
-          else
-            echo "skip_slack=false" >> $GITHUB_OUTPUT
-          fi
-    
-      - name: Send Slack notification for v2.11
         if: ${{ steps.check_marker.outputs.skip_slack == 'false' }}
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4
         with:


### PR DESCRIPTION
## Summary
Removes the v2.15, v2.14, and v2.13 release lines from the Check Rancher Tag GitHub Action workflow.
## Details
This updates the workflow configuration to stop referencing those older Rancher release lines and keep the action aligned with the currently supported versions.