### PR TITLE
Uncomment conditional in Check Rancher Tag meant for troubleshooting

### DIFF
--- a/.github/workflows/check-rancher-tag.yml
+++ b/.github/workflows/check-rancher-tag.yml
@@ -32,7 +32,7 @@ jobs:
         uses: ./.github/actions/get-dispatch-workflow-list
 
   check-latest-rancher-tag:
-    # if: github.ref == 'refs/heads/main' || github.event_name == 'schedule'
+    if: github.ref == 'refs/heads/main' || github.event_name == 'schedule'
     needs: get-dispatch-workflow-list
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
## Summary
This change uncomments a conditional in the **Check Rancher Tag** logic that was intended for troubleshooting.
## What Changed
- Re-enabled a previously commented conditional used for troubleshooting in **Check Rancher Tag**
## Purpose
- Restore the intended troubleshooting behavior in the tag-checking flow