### PR TITLE
Update IMAGE_REPOSITORY variable in upgrade.sh scripts to use rancher/rancher

### DIFF
--- a/framework/set/resources/airgap/rancher/upgrade.sh
+++ b/framework/set/resources/airgap/rancher/upgrade.sh
@@ -17,7 +17,7 @@ else
     IMAGE_REGISTRY="${RANCHER_IMAGE%%/*}"
 
     if [[ -n "$RANCHER_AGENT_IMAGE" || "$RANCHER_IMAGE" == registry* ]]; then
-        IMAGE_REPOSITORY="rancher"
+        IMAGE_REPOSITORY="rancher/rancher"
     else
         IMAGE_REPOSITORY="${RANCHER_IMAGE#*/}"
     fi

--- a/framework/set/resources/proxy/rancher/upgrade.sh
+++ b/framework/set/resources/proxy/rancher/upgrade.sh
@@ -19,7 +19,7 @@ else
     IMAGE_REGISTRY="${RANCHER_IMAGE%%/*}"
 
     if [[ -n "$RANCHER_AGENT_IMAGE" || "$RANCHER_IMAGE" == registry* ]]; then
-        IMAGE_REPOSITORY="rancher"
+        IMAGE_REPOSITORY="rancher/rancher"
     else
         IMAGE_REPOSITORY="${RANCHER_IMAGE#*/}"
     fi

--- a/framework/set/resources/sanity/rancher/upgrade.sh
+++ b/framework/set/resources/sanity/rancher/upgrade.sh
@@ -17,7 +17,7 @@ else
     IMAGE_REGISTRY="${RANCHER_IMAGE%%/*}"
 
     if [[ -n "$RANCHER_AGENT_IMAGE" || "$RANCHER_IMAGE" == registry* ]]; then
-        IMAGE_REPOSITORY="rancher"
+        IMAGE_REPOSITORY="rancher/rancher"
     else
         IMAGE_REPOSITORY="${RANCHER_IMAGE#*/}"
     fi


### PR DESCRIPTION
## Summary
Updates the `IMAGE_REPOSITORY` variable in the `upgrade.sh` scripts to use `rancher/rancher`.
## Impact
Ensures the upgrade scripts reference the correct Rancher image repository consistently.